### PR TITLE
Bound cached token authorization and identity lookups by their real expiry

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -407,8 +407,10 @@ func TestRetrieveTimeout(t *testing.T) {
 
 	assert.Equal(t, server_structs.RespPollTimeout, brokerResp.Status)
 
-	ctx, cancelFunc := context.WithTimeout(ctx, 50*time.Millisecond)
+	// Use a separate variable: reassigning ctx here would race with the
+	// goroutines above that are reading it.
+	timeoutCtx, cancelFunc := context.WithTimeout(ctx, 50*time.Millisecond)
 	defer cancelFunc()
-	_, err = doRetrieveRequest(t, ctx, 10*time.Second)
+	_, err = doRetrieveRequest(t, timeoutCtx, 10*time.Second)
 	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 }

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -178,7 +178,7 @@ func Setup(t *testing.T, ctx context.Context, egrp *errgroup.Group) {
 	})
 	require.NoError(t, err)
 
-	namespaceKeys = nil
+	setNamespaceKeys(nil)
 	LaunchNamespaceKeyMaintenance(ctx, egrp)
 }
 

--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -20,12 +20,11 @@ package broker
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -40,42 +39,26 @@ import (
 )
 
 var (
-	// A thread-safe cache for the namespace public keys
-	namespaceKeys *ttlcache.Cache[string, *jwk.Cache]
+	// namespaceKeys caches the registry's public keys for each namespace,
+	// keyed by namespace prefix.  Guarded by namespaceKeysMu: it is installed
+	// at startup and cleared at shutdown while requests may be reading it.
+	namespaceKeys   *token.JwksCache
+	namespaceKeysMu sync.RWMutex
 )
 
-const (
-	// namespaceKeyTTL bounds how long a namespace's key fetcher is retained
-	// after it stops being used.  Entries in active use are kept alive
-	// indefinitely (see the touch-on-hit note in LaunchNamespaceKeyMaintenance).
-	namespaceKeyTTL = 15 * time.Minute
+// namespaceKeyCapacity bounds how many namespaces are tracked at once.  The
+// prefix is taken from the request before the caller's token has been verified,
+// so without a bound a stream of made-up prefixes would grow the cache without
+// limit.  Least recently used entries go first, which keeps the namespaces
+// actually in use.
+const namespaceKeyCapacity = 4096
 
-	// jwksMinRefreshInterval is the floor on how often the background
-	// refresher re-fetches a namespace's JWKS from the registry.  Key
-	// rotations are normally picked up within this interval.
-	jwksMinRefreshInterval = 15 * time.Minute
-
-	// jwksFetchTimeout bounds a single synchronous JWKS fetch.
-	jwksFetchTimeout = 10 * time.Second
-)
-
-// jwksForcedRefreshInterval rate-limits the out-of-band refresh triggered by a
-// token naming a key we do not hold, so that a stream of bogus key IDs cannot
-// become a stream of registry fetches.  A variable so tests can drive the
-// rotation path without waiting it out.
-var jwksForcedRefreshInterval = 30 * time.Second
-
-// jwksErrSink reports background JWKS refresh failures, which the jwk cache
-// otherwise discards silently.  Without it, a namespace whose refreshes have
-// been failing keeps serving its last known good keys with nothing in the log
-// to explain why a rotated key never took effect.
-type jwksErrSink struct {
-	iss string
-}
-
-func (s jwksErrSink) Error(err error) {
-	log.Warningf("Background JWKS refresh failed for issuer %s (serving last known good keys): %v", s.iss, err)
-}
+// namespaceKeyRetryInterval is the minimum spacing between fetches of one
+// namespace's keys, so that neither a down registry nor a run of tokens naming
+// unknown key IDs turns into a run of registry requests.  A variable so tests
+// can exercise the refresh paths without waiting it out; it is read when the
+// cache is built.
+var namespaceKeyRetryInterval = 30 * time.Second
 
 // Launches a background goroutine that periodically expires
 // the namespace key cache
@@ -83,56 +66,44 @@ func LaunchNamespaceKeyMaintenance(ctx context.Context, egrp *errgroup.Group) {
 	// This is launched by both the director and the cache; if we are in a unit test
 	// where both are running in the same process, we only want to
 	// launch the goroutine once.
-	if namespaceKeys != nil {
+	if getNamespaceKeys() != nil {
 		return
 	}
 
-	loader := ttlcache.LoaderFunc[string, *jwk.Cache](
-		func(cache *ttlcache.Cache[string, *jwk.Cache], prefix string) *ttlcache.Item[string, *jwk.Cache] {
-			iss, err := getRegistryIssValue(prefix)
-			if err != nil {
-				return nil
-			}
-			// The actual location of the JWKS at the registry
-			jwksUrl := iss + "/.well-known/issuer.jwks"
+	setNamespaceKeys(token.NewJwksCache(ctx, egrp,
+		token.WithJwksCapacity(namespaceKeyCapacity),
+		token.WithJwksRetryInterval(namespaceKeyRetryInterval),
+	))
 
-			ar := jwk.NewCache(ctx, jwk.WithErrSink(jwksErrSink{iss: iss}))
-			client := &http.Client{Transport: config.GetBasicTransport()}
-			if err = ar.Register(jwksUrl, jwk.WithMinRefreshInterval(jwksMinRefreshInterval), jwk.WithHTTPClient(client)); err != nil {
-				log.Errorln("Failed to fetch issuer information for", iss, "from JWKS URL", jwksUrl, ":", err)
-				return nil
-			}
-			// Register does not fetch; the first fetch happens in
-			// getRegistryIssuerInfo, which can report a failure to the caller
-			// and retry on the next request.
-			log.Debugln("Setting public key cache for issuer", iss)
-			item := cache.Set(prefix, ar, ttlcache.DefaultTTL)
-			return item
-		},
-	)
-	// Touch-on-hit is deliberately left enabled here, unlike the token
-	// authorization caches fixed for #3696.  Entries hold self-refreshing
-	// jwk.Cache fetchers rather than authorization decisions, and the keyset
-	// lives inside the fetcher: a namespace's registered keys do churn, but
-	// those changes arrive through the fetcher's own refresh loop no matter
-	// how old the entry is, so extending an entry never prolongs a stale key.
-	// Dropping a fetcher, by contrast, discards the last known good keyset
-	// with it.  Keeping busy prefixes pinned therefore means a registry
-	// outage cannot break token verification for the namespaces that are
-	// actually in use, while the TTL still reclaims fetchers for idle ones.
-	namespaceKeys = ttlcache.New(
-		ttlcache.WithTTL[string, *jwk.Cache](namespaceKeyTTL),
-		ttlcache.WithLoader(ttlcache.NewSuppressedLoader(loader, nil)),
-	)
-
-	go namespaceKeys.Start()
 	egrp.Go(func() error {
 		<-ctx.Done()
-		namespaceKeys.Stop()
-		namespaceKeys.DeleteAll()
-		namespaceKeys = nil
+		setNamespaceKeys(nil)
 		return nil
 	})
+}
+
+func getNamespaceKeys() *token.JwksCache {
+	namespaceKeysMu.RLock()
+	defer namespaceKeysMu.RUnlock()
+	return namespaceKeys
+}
+
+func setNamespaceKeys(cache *token.JwksCache) {
+	namespaceKeysMu.Lock()
+	defer namespaceKeysMu.Unlock()
+	namespaceKeys = cache
+}
+
+// registryJwksResolver returns the location of the registry's JWKS for the
+// given namespace prefix.
+func registryJwksResolver(prefix string) token.JwksUrlResolver {
+	return func(context.Context) (string, error) {
+		iss, err := getRegistryIssValue(prefix)
+		if err != nil {
+			return "", err
+		}
+		return iss + "/.well-known/issuer.jwks", nil
+	}
 }
 
 // Given a namespace prefix, return the value that should be used
@@ -166,85 +137,30 @@ func getRegistryIssuerInfo(ctx context.Context, prefix string) (iss string, keys
 		return
 	}
 
-	// The actual location of the JWKS at the registry
-	jwksUrl := iss + "/.well-known/issuer.jwks"
-
-	if namespaceKeys == nil {
+	cache := getNamespaceKeys()
+	if cache == nil {
 		err = errors.New("namespace key cache not initialized; call LaunchNamespaceKeyMaintenance first")
 		return
 	}
 
-	item := namespaceKeys.Get(prefix)
-	if item == nil || item.Value() == nil {
-		err = errors.Errorf("failed to load issuer information for namespace %s: namespace may not be registered in the registry or registry endpoint is unreachable", prefix)
-		return
-	}
-	fetcher := item.Value()
-	keyset, err = fetcher.Get(ctx, jwksUrl)
-	if err == nil && keyset != nil && keyset.Len() > 0 {
-		return
-	}
-
-	// We have no usable keys for this namespace.  The fetcher may simply be
-	// new, or it may be one whose earlier fetch failed: the jwk cache stamps
-	// an entry as fetched before the attempt, so a fetcher that has never
-	// succeeded is never retried by Get and keeps returning nothing.  Force
-	// one attempt so the namespace recovers as soon as the registry does.
-	// A fetcher already holding keys never reaches this path, which is what
-	// keeps a registry outage from disturbing namespaces that are in use.
-	refreshCtx, cancel := context.WithTimeout(ctx, jwksFetchTimeout)
-	defer cancel()
-	keyset, err = fetcher.Refresh(refreshCtx, jwksUrl)
+	keyset, err = cache.Keys(ctx, prefix, registryJwksResolver(prefix))
 	if err != nil {
-		err = errors.Wrapf(err, "failed to retrieve keyset from JWKS URL %s for namespace %s", jwksUrl, prefix)
+		err = errors.Wrapf(err, "failed to retrieve the registry's public keys for namespace %s", prefix)
 		return
 	}
 	return
 }
 
-// refreshNamespaceKeys forces an out-of-band JWKS fetch for the namespace,
-// rate-limited to one attempt per jwksForcedRefreshInterval.  It returns the
-// refreshed keyset, or nil when the rate limit suppressed the fetch.  A failed
-// fetch leaves the fetcher's last known good keyset untouched.
+// refreshNamespaceKeys re-reads a namespace's keys from the registry ahead of
+// their normal revalidation, subject to the cache's throttle.  It returns nil,
+// and no error, when the throttle suppressed the fetch, and leaves the cached
+// keys in place when the fetch fails.
 func refreshNamespaceKeys(ctx context.Context, prefix string) (jwk.Set, error) {
-	if namespaceKeys == nil {
+	cache := getNamespaceKeys()
+	if cache == nil {
 		return nil, errors.New("namespace key cache not initialized; call LaunchNamespaceKeyMaintenance first")
 	}
-	iss, err := getRegistryIssValue(prefix)
-	if err != nil {
-		return nil, err
-	}
-	jwksUrl := iss + "/.well-known/issuer.jwks"
-
-	item := namespaceKeys.Get(prefix)
-	if item == nil || item.Value() == nil {
-		return nil, errors.Errorf("failed to load issuer information for namespace %s", prefix)
-	}
-	fetcher := item.Value()
-	if fetchedWithin(fetcher, jwksUrl, jwksForcedRefreshInterval) {
-		return nil, nil
-	}
-
-	refreshCtx, cancel := context.WithTimeout(ctx, jwksFetchTimeout)
-	defer cancel()
-	return fetcher.Refresh(refreshCtx, jwksUrl)
-}
-
-// fetchedWithin reports whether the fetcher last attempted to retrieve the
-// given URL less than d ago.  The jwk cache records the attempt time whether
-// or not it succeeded, so this throttles retries against a failing registry
-// as well as refreshes against a healthy one.
-func fetchedWithin(fetcher *jwk.Cache, jwksUrl string, d time.Duration) bool {
-	snapshot := fetcher.Snapshot()
-	if snapshot == nil {
-		return false
-	}
-	for _, entry := range snapshot.Entries {
-		if entry.URL == jwksUrl {
-			return time.Since(entry.LastFetched) < d
-		}
-	}
-	return false
+	return cache.Refresh(ctx, prefix, registryJwksResolver(prefix))
 }
 
 // signingKeyId returns the key ID named in the token's JWS header, or an empty
@@ -309,34 +225,41 @@ func verifyToken(ctx context.Context, tokenStr, namespace, audience string, requ
 		return
 	}
 
-	// A namespace's registered keys churn as services re-register or rotate
-	// them.  The background refresher only runs every jwksMinRefreshInterval,
-	// so a token signed by a newly registered key would otherwise be rejected
-	// until that interval elapsed.  When the token names a key we do not hold,
-	// pull the keyset again (rate-limited) before deciding.
+	scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{requiredScope}, false)
+	verify := func(keys jwk.Set) error {
+		_, verifyErr := token.VerifyWithKeyset(tokenStr, keys,
+			jwt.WithAudience(audience),
+			jwt.WithValidator(scopeValidator),
+			jwt.WithClaimValue("iss", issuerUrl),
+		)
+		return verifyErr
+	}
+
+	verifyErr := verify(keyset)
+	if verifyErr == nil {
+		ok = true
+		return
+	}
+
+	// Verification failed.  A namespace's registered keys churn as services
+	// re-register or rotate them, so before rejecting, check whether the token
+	// was signed by a key we simply have not seen yet; the keys are otherwise
+	// only re-read on their revalidation schedule.  Parsing the token again is
+	// confined to this path so that the common case pays for one parse.
 	if kid := signingKeyId(tokenStr); kid != "" && keyset != nil {
 		if _, found := keyset.LookupKeyID(kid); !found {
-			refreshed, rerr := refreshNamespaceKeys(ctx, namespace)
-			if rerr != nil {
-				// Keep going with the keys we have: the token may still verify,
-				// and if it does not the verification error is the useful one.
-				log.Debugf("Failed to refresh keys for namespace %s after seeing unknown key ID %s: %v", namespace, kid, rerr)
+			refreshed, refreshErr := refreshNamespaceKeys(ctx, namespace)
+			if refreshErr != nil {
+				log.Debugf("Failed to re-read keys for namespace %s after seeing unknown key ID %s: %v", namespace, kid, refreshErr)
 			} else if refreshed != nil {
-				keyset = refreshed
+				if verifyErr = verify(refreshed); verifyErr == nil {
+					ok = true
+					return
+				}
 			}
 		}
 	}
 
-	scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{requiredScope}, false)
-	_, err = token.VerifyWithKeyset(tokenStr, keyset,
-		jwt.WithAudience(audience),
-		jwt.WithValidator(scopeValidator),
-		jwt.WithClaimValue("iss", issuerUrl),
-	)
-	if err == nil {
-		ok = true
-	} else {
-		err = errors.Wrap(err, "failed to verify token")
-	}
+	err = errors.Wrap(verifyErr, "failed to verify token")
 	return
 }

--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -42,6 +43,39 @@ var (
 	// A thread-safe cache for the namespace public keys
 	namespaceKeys *ttlcache.Cache[string, *jwk.Cache]
 )
+
+const (
+	// namespaceKeyTTL bounds how long a namespace's key fetcher is retained
+	// after it stops being used.  Entries in active use are kept alive
+	// indefinitely (see the touch-on-hit note in LaunchNamespaceKeyMaintenance).
+	namespaceKeyTTL = 15 * time.Minute
+
+	// jwksMinRefreshInterval is the floor on how often the background
+	// refresher re-fetches a namespace's JWKS from the registry.  Key
+	// rotations are normally picked up within this interval.
+	jwksMinRefreshInterval = 15 * time.Minute
+
+	// jwksFetchTimeout bounds a single synchronous JWKS fetch.
+	jwksFetchTimeout = 10 * time.Second
+)
+
+// jwksForcedRefreshInterval rate-limits the out-of-band refresh triggered by a
+// token naming a key we do not hold, so that a stream of bogus key IDs cannot
+// become a stream of registry fetches.  A variable so tests can drive the
+// rotation path without waiting it out.
+var jwksForcedRefreshInterval = 30 * time.Second
+
+// jwksErrSink reports background JWKS refresh failures, which the jwk cache
+// otherwise discards silently.  Without it, a namespace whose refreshes have
+// been failing keeps serving its last known good keys with nothing in the log
+// to explain why a rotated key never took effect.
+type jwksErrSink struct {
+	iss string
+}
+
+func (s jwksErrSink) Error(err error) {
+	log.Warningf("Background JWKS refresh failed for issuer %s (serving last known good keys): %v", s.iss, err)
+}
 
 // Launches a background goroutine that periodically expires
 // the namespace key cache
@@ -62,20 +96,33 @@ func LaunchNamespaceKeyMaintenance(ctx context.Context, egrp *errgroup.Group) {
 			// The actual location of the JWKS at the registry
 			jwksUrl := iss + "/.well-known/issuer.jwks"
 
-			ar := jwk.NewCache(ctx)
+			ar := jwk.NewCache(ctx, jwk.WithErrSink(jwksErrSink{iss: iss}))
 			client := &http.Client{Transport: config.GetBasicTransport()}
-			if err = ar.Register(jwksUrl, jwk.WithMinRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
+			if err = ar.Register(jwksUrl, jwk.WithMinRefreshInterval(jwksMinRefreshInterval), jwk.WithHTTPClient(client)); err != nil {
 				log.Errorln("Failed to fetch issuer information for", iss, "from JWKS URL", jwksUrl, ":", err)
 				return nil
 			}
+			// Register does not fetch; the first fetch happens in
+			// getRegistryIssuerInfo, which can report a failure to the caller
+			// and retry on the next request.
 			log.Debugln("Setting public key cache for issuer", iss)
 			item := cache.Set(prefix, ar, ttlcache.DefaultTTL)
 			return item
 		},
 	)
+	// Touch-on-hit is deliberately left enabled here, unlike the token
+	// authorization caches fixed for #3696.  Entries hold self-refreshing
+	// jwk.Cache fetchers rather than authorization decisions, and the keyset
+	// lives inside the fetcher: a namespace's registered keys do churn, but
+	// those changes arrive through the fetcher's own refresh loop no matter
+	// how old the entry is, so extending an entry never prolongs a stale key.
+	// Dropping a fetcher, by contrast, discards the last known good keyset
+	// with it.  Keeping busy prefixes pinned therefore means a registry
+	// outage cannot break token verification for the namespaces that are
+	// actually in use, while the TTL still reclaims fetchers for idle ones.
 	namespaceKeys = ttlcache.New(
-		ttlcache.WithTTL[string, *jwk.Cache](15*time.Minute),
-		ttlcache.WithLoader(loader),
+		ttlcache.WithTTL[string, *jwk.Cache](namespaceKeyTTL),
+		ttlcache.WithLoader(ttlcache.NewSuppressedLoader(loader, nil)),
 	)
 
 	go namespaceKeys.Start()
@@ -128,16 +175,93 @@ func getRegistryIssuerInfo(ctx context.Context, prefix string) (iss string, keys
 	}
 
 	item := namespaceKeys.Get(prefix)
-	if item.Value() == nil {
+	if item == nil || item.Value() == nil {
 		err = errors.Errorf("failed to load issuer information for namespace %s: namespace may not be registered in the registry or registry endpoint is unreachable", prefix)
 		return
 	}
-	keyset, err = item.Value().Get(ctx, jwksUrl)
+	fetcher := item.Value()
+	keyset, err = fetcher.Get(ctx, jwksUrl)
+	if err == nil && keyset != nil && keyset.Len() > 0 {
+		return
+	}
+
+	// We have no usable keys for this namespace.  The fetcher may simply be
+	// new, or it may be one whose earlier fetch failed: the jwk cache stamps
+	// an entry as fetched before the attempt, so a fetcher that has never
+	// succeeded is never retried by Get and keeps returning nothing.  Force
+	// one attempt so the namespace recovers as soon as the registry does.
+	// A fetcher already holding keys never reaches this path, which is what
+	// keeps a registry outage from disturbing namespaces that are in use.
+	refreshCtx, cancel := context.WithTimeout(ctx, jwksFetchTimeout)
+	defer cancel()
+	keyset, err = fetcher.Refresh(refreshCtx, jwksUrl)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to retrieve keyset from JWKS URL %s for namespace %s", jwksUrl, prefix)
 		return
 	}
 	return
+}
+
+// refreshNamespaceKeys forces an out-of-band JWKS fetch for the namespace,
+// rate-limited to one attempt per jwksForcedRefreshInterval.  It returns the
+// refreshed keyset, or nil when the rate limit suppressed the fetch.  A failed
+// fetch leaves the fetcher's last known good keyset untouched.
+func refreshNamespaceKeys(ctx context.Context, prefix string) (jwk.Set, error) {
+	if namespaceKeys == nil {
+		return nil, errors.New("namespace key cache not initialized; call LaunchNamespaceKeyMaintenance first")
+	}
+	iss, err := getRegistryIssValue(prefix)
+	if err != nil {
+		return nil, err
+	}
+	jwksUrl := iss + "/.well-known/issuer.jwks"
+
+	item := namespaceKeys.Get(prefix)
+	if item == nil || item.Value() == nil {
+		return nil, errors.Errorf("failed to load issuer information for namespace %s", prefix)
+	}
+	fetcher := item.Value()
+	if fetchedWithin(fetcher, jwksUrl, jwksForcedRefreshInterval) {
+		return nil, nil
+	}
+
+	refreshCtx, cancel := context.WithTimeout(ctx, jwksFetchTimeout)
+	defer cancel()
+	return fetcher.Refresh(refreshCtx, jwksUrl)
+}
+
+// fetchedWithin reports whether the fetcher last attempted to retrieve the
+// given URL less than d ago.  The jwk cache records the attempt time whether
+// or not it succeeded, so this throttles retries against a failing registry
+// as well as refreshes against a healthy one.
+func fetchedWithin(fetcher *jwk.Cache, jwksUrl string, d time.Duration) bool {
+	snapshot := fetcher.Snapshot()
+	if snapshot == nil {
+		return false
+	}
+	for _, entry := range snapshot.Entries {
+		if entry.URL == jwksUrl {
+			return time.Since(entry.LastFetched) < d
+		}
+	}
+	return false
+}
+
+// signingKeyId returns the key ID named in the token's JWS header, or an empty
+// string when the token does not name one.
+func signingKeyId(tokenStr string) string {
+	msg, err := jws.Parse([]byte(tokenStr))
+	if err != nil {
+		return ""
+	}
+	for _, sig := range msg.Signatures() {
+		if hdrs := sig.ProtectedHeaders(); hdrs != nil {
+			if kid := hdrs.KeyID(); kid != "" {
+				return kid
+			}
+		}
+	}
+	return ""
 }
 
 // Create a signed JWT appropriate for retrieving requests from the connection broker
@@ -183,6 +307,24 @@ func verifyToken(ctx context.Context, tokenStr, namespace, audience string, requ
 	if err != nil {
 		err = errors.Wrapf(err, "failed to get issuer info for namespace %s", namespace)
 		return
+	}
+
+	// A namespace's registered keys churn as services re-register or rotate
+	// them.  The background refresher only runs every jwksMinRefreshInterval,
+	// so a token signed by a newly registered key would otherwise be rejected
+	// until that interval elapsed.  When the token names a key we do not hold,
+	// pull the keyset again (rate-limited) before deciding.
+	if kid := signingKeyId(tokenStr); kid != "" && keyset != nil {
+		if _, found := keyset.LookupKeyID(kid); !found {
+			refreshed, rerr := refreshNamespaceKeys(ctx, namespace)
+			if rerr != nil {
+				// Keep going with the keys we have: the token may still verify,
+				// and if it does not the verification error is the useful one.
+				log.Debugf("Failed to refresh keys for namespace %s after seeing unknown key ID %s: %v", namespace, kid, rerr)
+			} else if refreshed != nil {
+				keyset = refreshed
+			}
+		}
 	}
 
 	scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{requiredScope}, false)

--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -268,19 +268,29 @@ func verifyToken(ctx context.Context, tokenStr, namespace, audience string, requ
 	}
 
 	// Verification failed.  A namespace's registered keys churn as services
-	// re-register or rotate them, so before rejecting, check whether the token
-	// was signed by a key we simply have not seen yet; the keys are otherwise
-	// only re-read on their revalidation schedule.  Parsing the token again is
-	// confined to this path so that the common case pays for one parse.
-	if kid := signingKeyId(tokenStr); kid != "" && keyset != nil {
-		if _, found := keyset.LookupKeyID(kid); !found {
-			refreshed, refreshErr := refreshNamespaceKeys(ctx, namespace)
-			if refreshErr != nil {
-				log.Debugf("Failed to re-read keys for namespace %s after seeing unknown key ID %s: %v", namespace, kid, refreshErr)
-			} else if refreshed != nil {
-				if verifyErr = verify(refreshed); verifyErr == nil {
-					ok = true
-					return
+	// re-register or rotate them, so before rejecting, consider whether the
+	// token was signed by a key we have not seen yet; the keys are otherwise
+	// only re-read on their revalidation schedule.
+	//
+	// Deciding that costs another parse of the token, so it is worth reaching
+	// only when it could change the answer.  A rejected claim -- expired,
+	// wrong audience, insufficient scope -- says nothing about the keys, and
+	// neither does a signature failure while the throttle would refuse to
+	// re-read them anyway.  Both checks are cheap and both are common: the
+	// first covers ordinary expired tokens, the second covers a caller sending
+	// a run of tokens with made-up signing keys.
+	cache := getNamespaceKeys()
+	if errors.Is(verifyErr, token.ErrTokenSignature) && keyset != nil && cache != nil && cache.CanRefresh(namespace) {
+		if kid := signingKeyId(tokenStr); kid != "" {
+			if _, found := keyset.LookupKeyID(kid); !found {
+				refreshed, refreshErr := refreshNamespaceKeys(ctx, namespace)
+				if refreshErr != nil {
+					log.Debugf("Failed to re-read keys for namespace %s after seeing unknown key ID %s: %v", namespace, kid, refreshErr)
+				} else if refreshed != nil {
+					if verifyErr = verify(refreshed); verifyErr == nil {
+						ok = true
+						return
+					}
 				}
 			}
 		}

--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"net/url"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -38,13 +38,10 @@ import (
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
-var (
-	// namespaceKeys caches the registry's public keys for each namespace,
-	// keyed by namespace prefix.  Guarded by namespaceKeysMu: it is installed
-	// at startup and cleared at shutdown while requests may be reading it.
-	namespaceKeys   *token.JwksCache
-	namespaceKeysMu sync.RWMutex
-)
+// namespaceKeys caches the registry's public keys for each namespace, keyed by
+// namespace prefix.  It is installed at startup and cleared at shutdown while
+// requests may be reading it, so it is swapped atomically.
+var namespaceKeys atomic.Pointer[token.JwksCache]
 
 // namespaceKeyCapacity bounds how many namespaces are tracked at once.  The
 // prefix is taken from the request before the caller's token has been verified,
@@ -89,15 +86,11 @@ func LaunchNamespaceKeyMaintenance(ctx context.Context, egrp *errgroup.Group) {
 }
 
 func getNamespaceKeys() *token.JwksCache {
-	namespaceKeysMu.RLock()
-	defer namespaceKeysMu.RUnlock()
-	return namespaceKeys
+	return namespaceKeys.Load()
 }
 
 func setNamespaceKeys(cache *token.JwksCache) {
-	namespaceKeysMu.Lock()
-	defer namespaceKeysMu.Unlock()
-	namespaceKeys = cache
+	namespaceKeys.Store(cache)
 }
 
 // registryJwksResolver returns the location of the registry's JWKS for the
@@ -112,9 +105,36 @@ func registryJwksResolver(prefix string) token.JwksUrlResolver {
 	}
 }
 
+// validateNamespacePrefix rejects a prefix that would not address the namespace
+// it names.  The prefix reaches us from the request body, before the caller's
+// token has been verified, and it is joined into the registry's URL path;
+// joining cleans the result, so ".." segments would silently walk out of the
+// registry's API path and point the lookup somewhere else on the registry.
+func validateNamespacePrefix(prefix string) error {
+	if prefix == "" {
+		return errors.New("namespace prefix is empty")
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		return errors.Errorf("namespace prefix %q does not begin with '/'", prefix)
+	}
+	// Only relative segments are rejected.  Cache prefixes legitimately embed a
+	// URL (/caches/https://cache.com), so the prefix is not required to survive
+	// path.Clean unchanged -- just to not walk upward.
+	for _, segment := range strings.Split(prefix, "/") {
+		if segment == "." || segment == ".." {
+			return errors.Errorf("namespace prefix %q contains a relative path segment", prefix)
+		}
+	}
+	return nil
+}
+
 // Given a namespace prefix, return the value that should be used
 // by the `iss` claim in a token for this federation's registry.
 func getRegistryIssValue(prefix string) (iss string, err error) {
+	if err = validateNamespacePrefix(prefix); err != nil {
+		return
+	}
+
 	fedInfo, err := config.GetFederation(context.Background())
 	if err != nil {
 		return

--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -73,6 +73,12 @@ func LaunchNamespaceKeyMaintenance(ctx context.Context, egrp *errgroup.Group) {
 	setNamespaceKeys(token.NewJwksCache(ctx, egrp,
 		token.WithJwksCapacity(namespaceKeyCapacity),
 		token.WithJwksRetryInterval(namespaceKeyRetryInterval),
+		// The registry's answers here are specific: 404 for a namespace that is
+		// not registered, 403 for one whose approval has been withdrawn.  Those
+		// are the two ways a federation administrator removes a service, so
+		// stop trusting the cached keys instead of serving them until the
+		// staleness ceiling.
+		token.WithJwksDropOnAbsence(),
 	))
 
 	egrp.Go(func() error {

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -406,6 +407,83 @@ func TestVerifyToken_StopsAfterNamespaceDeregistered(t *testing.T) {
 					"rather than being carried to the staleness ceiling")
 		})
 	}
+}
+
+// TestVerifyToken_BogusTokensDoNotDriveRegistryTraffic verifies that a caller
+// sending a run of tokens signed by keys the registry never issued cannot turn
+// each one into a registry fetch.  The unknown key ID is the signal that makes
+// the broker re-read a namespace's keys, so it is exactly what such a caller
+// would aim at.
+func TestVerifyToken_BogusTokensDoNotDriveRegistryTraffic(t *testing.T) {
+	registry := newJwksTestServer(t)
+	registry.rotateTo(t, "key-1")
+
+	ctx := setupBrokerKeyTest(t, registry.server.URL)
+	const prefix = "/caches/example"
+	const audience = "https://broker.example.com"
+
+	// Prime the keys so the run below starts from a normal state.
+	_, _, err := getRegistryIssuerInfo(ctx, prefix)
+	require.NoError(t, err)
+	fetchesBefore := registry.fetchCount()
+
+	// Each token is signed by a key of its own, so every one names a key ID the
+	// cached set does not contain.
+	for i := 0; i < 25; i++ {
+		attacker := generateSigningKey(t, fmt.Sprintf("bogus-%d", i))
+		tok := mintBrokerToken(t, attacker, prefix, audience, token_scopes.Broker_Reverse)
+		ok, _ := verifyToken(ctx, tok, prefix, audience, token_scopes.Broker_Reverse)
+		require.False(t, ok, "a token signed by an unknown key must not verify")
+	}
+
+	assert.LessOrEqual(t, registry.fetchCount()-fetchesBefore, 1,
+		"a run of tokens with unknown signing keys should not become a run of registry fetches")
+}
+
+// TestVerifyToken_ExpiredTokenDoesNotRefresh verifies that a rejected claim does
+// not send the broker back to the registry: the keys are not in question.
+func TestVerifyToken_ExpiredTokenDoesNotRefresh(t *testing.T) {
+	registry := newJwksTestServer(t)
+	key := registry.rotateTo(t, "key-1")
+
+	withNamespaceKeyRetryInterval(t, 0)
+	ctx := setupBrokerKeyTest(t, registry.server.URL)
+	const prefix = "/caches/example"
+	const audience = "https://broker.example.com"
+
+	_, _, err := getRegistryIssuerInfo(ctx, prefix)
+	require.NoError(t, err)
+	fetchesBefore := registry.fetchCount()
+
+	iss, err := getRegistryIssValue(prefix)
+	require.NoError(t, err)
+	expired, err := jwt.NewBuilder().
+		Issuer(iss).
+		Subject("test-subject").
+		Audience([]string{audience}).
+		IssuedAt(time.Now().Add(-time.Hour)).
+		Expiration(time.Now().Add(-30*time.Minute)).
+		Claim("scope", token_scopes.Broker_Reverse.String()).
+		Build()
+	require.NoError(t, err)
+	signed, err := jwt.Sign(expired, jwt.WithKey(jwa.ES256, key))
+	require.NoError(t, err)
+
+	ok, _ := verifyToken(ctx, string(signed), prefix, audience, token_scopes.Broker_Reverse)
+	require.False(t, ok, "an expired token must not verify")
+	assert.Equal(t, fetchesBefore, registry.fetchCount(),
+		"a rejected claim says nothing about the keys, so it should not trigger a re-read")
+}
+
+// generateSigningKey makes a signing key that no registry vouches for.
+func generateSigningKey(t *testing.T, kid string) jwk.Key {
+	privEC, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key, err := jwk.FromRaw(privEC)
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, key.Set(jwk.AlgorithmKey, jwa.ES256))
+	return key
 }
 
 // withNamespaceKeyRetryInterval sets the fetch throttle for the duration of a

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -72,8 +72,17 @@ type jwksTestServer struct {
 	mu      sync.Mutex
 	keys    jwk.Set
 	down    bool
+	status  int
 	fetches int
 	server  *httptest.Server
+}
+
+// setStatus makes the stand-in registry answer with the given status, as it
+// does for a namespace that is not registered (404) or not approved (403).
+func (s *jwksTestServer) setStatus(code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = code
 }
 
 func newJwksTestServer(t *testing.T) *jwksTestServer {
@@ -84,6 +93,11 @@ func newJwksTestServer(t *testing.T) *jwksTestServer {
 		s.fetches++
 		if s.down {
 			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if s.status != 0 {
+			w.WriteHeader(s.status)
+			_, _ = w.Write([]byte(`{"status":"error","msg":"namespace prefix was not found"}`))
 			return
 		}
 		data, err := json.Marshal(s.keys)
@@ -310,6 +324,45 @@ func TestRefreshNamespaceKeys_RateLimited(t *testing.T) {
 		assert.Nil(t, set, "a refresh inside the throttle window should be suppressed")
 	}
 	assert.Equal(t, fetchesAfterFirst, registry.fetchCount(), "the registry should not be contacted")
+}
+
+// TestVerifyToken_StopsAfterNamespaceDeregistered verifies that a namespace the
+// registry no longer vouches for stops verifying promptly, rather than being
+// carried by its cached keys until the staleness ceiling.  The registry answers
+// 404 for a prefix that is not registered and 403 for one whose approval has
+// been withdrawn; both are how an administrator removes a service.
+func TestVerifyToken_StopsAfterNamespaceDeregistered(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			registry := newJwksTestServer(t)
+			key := registry.rotateTo(t, "key-1")
+
+			withNamespaceKeyRetryInterval(t, 0)
+			ctx := setupBrokerKeyTest(t, registry.server.URL)
+			const prefix = "/caches/example"
+			const audience = "https://broker.example.com"
+
+			tok := mintBrokerToken(t, key, prefix, audience, token_scopes.Broker_Reverse)
+			ok, err := verifyToken(ctx, tok, prefix, audience, token_scopes.Broker_Reverse)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			// The namespace is removed from the registry.  Cached keys stay
+			// usable until they next come up for revalidation, so drive the
+			// refreshes the revalidation schedule would perform; the keys are
+			// dropped once the registry has repeated itself.
+			registry.setStatus(status)
+			for i := 0; i < 2; i++ {
+				_, err = refreshNamespaceKeys(ctx, prefix)
+				require.Error(t, err)
+			}
+
+			ok, _ = verifyToken(ctx, tok, prefix, audience, token_scopes.Broker_Reverse)
+			assert.False(t, ok,
+				"a de-registered namespace should stop verifying once the registry has said so, "+
+					"rather than being carried to the staleness ceiling")
+		})
+	}
 }
 
 // withNamespaceKeyRetryInterval sets the fetch throttle for the duration of a

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -153,7 +152,7 @@ func setupBrokerKeyTest(t *testing.T, registryEndpoint string) context.Context {
 		_ = egrp.Wait()
 	})
 
-	namespaceKeys = nil
+	setNamespaceKeys(nil)
 	LaunchNamespaceKeyMaintenance(ctx, egrp)
 	return ctx
 }
@@ -178,8 +177,9 @@ func mintBrokerToken(t *testing.T, key jwk.Key, prefix, audience string, scope t
 	return string(signed)
 }
 
-// TestGetRegistryIssuerInfo_LoadFailures verifies that namespace key loading
-// failures surface as errors rather than panics.
+// TestGetRegistryIssuerInfo_LoadFailures verifies that an unreachable registry
+// surfaces as an error, and that calling in before the cache is initialized
+// does the same rather than panicking.
 func TestGetRegistryIssuerInfo_LoadFailures(t *testing.T) {
 	// Point the federation at a registry endpoint that refuses connections.
 	ctx := setupBrokerKeyTest(t, "https://127.0.0.1:1")
@@ -187,26 +187,27 @@ func TestGetRegistryIssuerInfo_LoadFailures(t *testing.T) {
 	_, _, err := getRegistryIssuerInfo(ctx, "/caches/example")
 	require.Error(t, err)
 
-	// A prefix the loader declines to cache at all must produce an error,
-	// not a nil-pointer panic.  Restore the launched cache via Cleanup so the
-	// shutdown goroutine stops the right (started) cache even if this check
-	// panics.
-	orig := namespaceKeys
-	t.Cleanup(func() { namespaceKeys = orig })
-	namespaceKeys = ttlcache.New[string, *jwk.Cache]()
+	// Restore the launched cache via Cleanup so the shutdown goroutine still
+	// sees it even if the check below fails.
+	orig := getNamespaceKeys()
+	t.Cleanup(func() { setNamespaceKeys(orig) })
+	setNamespaceKeys(nil)
 	_, _, err = getRegistryIssuerInfo(ctx, "/caches/other")
 	require.Error(t, err)
 }
 
 // TestGetRegistryIssuerInfo_RecoversAfterRegistryOutage verifies that a
-// namespace whose first JWKS fetch failed is retried on the next request.  The
-// jwk cache marks an entry as fetched even when the attempt failed, so without
-// an explicit refresh such a fetcher would never fetch again.
+// namespace whose first fetch failed is retried on a later request rather than
+// being stuck with no keys.
 func TestGetRegistryIssuerInfo_RecoversAfterRegistryOutage(t *testing.T) {
 	registry := newJwksTestServer(t)
 	registry.rotateTo(t, "key-1")
 	registry.setDown(true)
 
+	// Stand in for the throttle window having elapsed between the two
+	// requests below; TestRefreshNamespaceKeys_RateLimited covers the throttle
+	// itself.
+	withNamespaceKeyRetryInterval(t, 0)
 	ctx := setupBrokerKeyTest(t, registry.server.URL)
 	const prefix = "/caches/example"
 
@@ -259,10 +260,9 @@ func TestVerifyToken_PicksUpRotatedKey(t *testing.T) {
 	registry := newJwksTestServer(t)
 	firstKey := registry.rotateTo(t, "key-1")
 
-	// Let the rotation path fire without waiting out the rate limit.
-	orig := jwksForcedRefreshInterval
-	jwksForcedRefreshInterval = 0
-	t.Cleanup(func() { jwksForcedRefreshInterval = orig })
+	// Let the rotation path fire without waiting out the throttle.  This is read
+	// when the cache is built, so it has to be set before the setup below.
+	withNamespaceKeyRetryInterval(t, 0)
 
 	ctx := setupBrokerKeyTest(t, registry.server.URL)
 	const prefix = "/caches/example"
@@ -288,13 +288,14 @@ func TestVerifyToken_PicksUpRotatedKey(t *testing.T) {
 	assert.False(t, ok, "a token signed by the retired key should be rejected")
 }
 
-// TestRefreshNamespaceKeys_RateLimited verifies that forced refreshes are
+// TestRefreshNamespaceKeys_RateLimited verifies that out-of-band refreshes are
 // throttled, so a stream of tokens naming unknown key IDs cannot become a
 // stream of registry fetches.
 func TestRefreshNamespaceKeys_RateLimited(t *testing.T) {
 	registry := newJwksTestServer(t)
 	registry.rotateTo(t, "key-1")
 
+	withNamespaceKeyRetryInterval(t, time.Hour)
 	ctx := setupBrokerKeyTest(t, registry.server.URL)
 	const prefix = "/caches/example"
 
@@ -302,19 +303,20 @@ func TestRefreshNamespaceKeys_RateLimited(t *testing.T) {
 	require.NoError(t, err)
 	fetchesAfterFirst := registry.fetchCount()
 
-	// The initial fetch just happened, so a forced refresh is suppressed.
-	set, err := refreshNamespaceKeys(ctx, prefix)
-	require.NoError(t, err)
-	assert.Nil(t, set, "a refresh within the rate-limit window should be suppressed")
+	// The initial fetch just happened, so a refresh is suppressed.
+	for i := 0; i < 3; i++ {
+		set, err := refreshNamespaceKeys(ctx, prefix)
+		require.NoError(t, err)
+		assert.Nil(t, set, "a refresh inside the throttle window should be suppressed")
+	}
 	assert.Equal(t, fetchesAfterFirst, registry.fetchCount(), "the registry should not be contacted")
+}
 
-	// With the window elapsed, the refresh goes through.
-	orig := jwksForcedRefreshInterval
-	jwksForcedRefreshInterval = 0
-	t.Cleanup(func() { jwksForcedRefreshInterval = orig })
-
-	set, err = refreshNamespaceKeys(ctx, prefix)
-	require.NoError(t, err)
-	require.NotNil(t, set, "a refresh outside the rate-limit window should proceed")
-	assert.Greater(t, registry.fetchCount(), fetchesAfterFirst)
+// withNamespaceKeyRetryInterval sets the fetch throttle for the duration of a
+// test.  The cache reads it when it is built, so callers must set it before
+// launching the key cache.
+func withNamespaceKeyRetryInterval(t *testing.T, d time.Duration) {
+	orig := namespaceKeyRetryInterval
+	namespaceKeyRetryInterval = d
+	t.Cleanup(func() { namespaceKeyRetryInterval = orig })
 }

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -19,16 +19,29 @@
 package broker
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
 func TestGetCacheHostnameFromToken(t *testing.T) {
@@ -51,4 +64,257 @@ func TestGetCacheHostnameFromToken(t *testing.T) {
 	hostname, err := getCacheHostnameFromToken(tokByte)
 	require.NoError(t, err)
 	assert.Equal(t, "https://cache.com", hostname)
+}
+
+// jwksTestServer is a stand-in registry that serves a namespace's JWKS.  Its
+// key set can be rotated and the whole server can be taken "down" to simulate
+// a registry outage, while counting the fetches it actually served.
+type jwksTestServer struct {
+	mu      sync.Mutex
+	keys    jwk.Set
+	down    bool
+	fetches int
+	server  *httptest.Server
+}
+
+func newJwksTestServer(t *testing.T) *jwksTestServer {
+	s := &jwksTestServer{keys: jwk.NewSet()}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.fetches++
+		if s.down {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		data, err := json.Marshal(s.keys)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+// rotateTo generates a fresh signing key with the given key ID, publishes only
+// that key, and returns the private half for signing tokens.
+func (s *jwksTestServer) rotateTo(t *testing.T, kid string) jwk.Key {
+	privEC, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	priv, err := jwk.FromRaw(privEC)
+	require.NoError(t, err)
+	require.NoError(t, priv.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, priv.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	pub, err := priv.PublicKey()
+	require.NoError(t, err)
+	require.NoError(t, pub.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, pub.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(pub))
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys = set
+	return priv
+}
+
+func (s *jwksTestServer) setDown(down bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.down = down
+}
+
+func (s *jwksTestServer) fetchCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fetches
+}
+
+// setupBrokerKeyTest points the federation at the given stand-in registry and
+// launches a fresh namespace key cache.
+func setupBrokerKeyTest(t *testing.T, registryEndpoint string) context.Context {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	test_utils.InitClient(t, nil)
+
+	test_utils.MockFederationRoot(t, &pelican_url.FederationDiscovery{
+		RegistryEndpoint: registryEndpoint,
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	egrp, ctx := errgroup.WithContext(ctx)
+	t.Cleanup(func() {
+		cancel()
+		_ = egrp.Wait()
+	})
+
+	namespaceKeys = nil
+	LaunchNamespaceKeyMaintenance(ctx, egrp)
+	return ctx
+}
+
+// mintBrokerToken signs a broker token for the namespace with the given key.
+func mintBrokerToken(t *testing.T, key jwk.Key, prefix, audience string, scope token_scopes.TokenScope) string {
+	iss, err := getRegistryIssValue(prefix)
+	require.NoError(t, err)
+
+	tok, err := jwt.NewBuilder().
+		Issuer(iss).
+		Subject("test-subject").
+		Audience([]string{audience}).
+		IssuedAt(time.Now()).
+		Expiration(time.Now().Add(time.Minute)).
+		Claim("scope", scope.String()).
+		Build()
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, key))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// TestGetRegistryIssuerInfo_LoadFailures verifies that namespace key loading
+// failures surface as errors rather than panics.
+func TestGetRegistryIssuerInfo_LoadFailures(t *testing.T) {
+	// Point the federation at a registry endpoint that refuses connections.
+	ctx := setupBrokerKeyTest(t, "https://127.0.0.1:1")
+
+	_, _, err := getRegistryIssuerInfo(ctx, "/caches/example")
+	require.Error(t, err)
+
+	// A prefix the loader declines to cache at all must produce an error,
+	// not a nil-pointer panic.  Restore the launched cache via Cleanup so the
+	// shutdown goroutine stops the right (started) cache even if this check
+	// panics.
+	orig := namespaceKeys
+	t.Cleanup(func() { namespaceKeys = orig })
+	namespaceKeys = ttlcache.New[string, *jwk.Cache]()
+	_, _, err = getRegistryIssuerInfo(ctx, "/caches/other")
+	require.Error(t, err)
+}
+
+// TestGetRegistryIssuerInfo_RecoversAfterRegistryOutage verifies that a
+// namespace whose first JWKS fetch failed is retried on the next request.  The
+// jwk cache marks an entry as fetched even when the attempt failed, so without
+// an explicit refresh such a fetcher would never fetch again.
+func TestGetRegistryIssuerInfo_RecoversAfterRegistryOutage(t *testing.T) {
+	registry := newJwksTestServer(t)
+	registry.rotateTo(t, "key-1")
+	registry.setDown(true)
+
+	ctx := setupBrokerKeyTest(t, registry.server.URL)
+	const prefix = "/caches/example"
+
+	_, _, err := getRegistryIssuerInfo(ctx, prefix)
+	require.Error(t, err, "a down registry should surface an error")
+
+	// The registry comes back.  The cached fetcher is reused, so recovery
+	// depends on the forced refresh rather than on the entry expiring.
+	registry.setDown(false)
+
+	_, keyset, err := getRegistryIssuerInfo(ctx, prefix)
+	require.NoError(t, err, "keys should be retrieved once the registry recovers")
+	require.NotNil(t, keyset)
+	assert.Equal(t, 1, keyset.Len())
+}
+
+// TestGetRegistryIssuerInfo_ServesLastKnownGoodWhileRegistryDown verifies that
+// once a namespace's keys have been retrieved, a registry outage does not
+// disturb them: the cached keyset is served without touching the network.
+func TestGetRegistryIssuerInfo_ServesLastKnownGoodWhileRegistryDown(t *testing.T) {
+	registry := newJwksTestServer(t)
+	registry.rotateTo(t, "key-1")
+
+	ctx := setupBrokerKeyTest(t, registry.server.URL)
+	const prefix = "/caches/example"
+
+	_, keyset, err := getRegistryIssuerInfo(ctx, prefix)
+	require.NoError(t, err)
+	require.NotNil(t, keyset)
+	fetchesAfterFirst := registry.fetchCount()
+	require.Positive(t, fetchesAfterFirst)
+
+	registry.setDown(true)
+
+	for i := 0; i < 3; i++ {
+		_, keyset, err = getRegistryIssuerInfo(ctx, prefix)
+		require.NoError(t, err, "a registry outage must not break a namespace whose keys are already cached")
+		require.NotNil(t, keyset)
+		_, found := keyset.LookupKeyID("key-1")
+		assert.True(t, found, "the last known good key should still be served")
+	}
+	assert.Equal(t, fetchesAfterFirst, registry.fetchCount(),
+		"serving cached keys should not contact the registry")
+}
+
+// TestVerifyToken_PicksUpRotatedKey verifies that a token signed by a key
+// registered after the keyset was cached is accepted without waiting for the
+// background refresh interval.
+func TestVerifyToken_PicksUpRotatedKey(t *testing.T) {
+	registry := newJwksTestServer(t)
+	firstKey := registry.rotateTo(t, "key-1")
+
+	// Let the rotation path fire without waiting out the rate limit.
+	orig := jwksForcedRefreshInterval
+	jwksForcedRefreshInterval = 0
+	t.Cleanup(func() { jwksForcedRefreshInterval = orig })
+
+	ctx := setupBrokerKeyTest(t, registry.server.URL)
+	const prefix = "/caches/example"
+	const audience = "https://broker.example.com"
+
+	tok := mintBrokerToken(t, firstKey, prefix, audience, token_scopes.Broker_Reverse)
+	ok, err := verifyToken(ctx, tok, prefix, audience, token_scopes.Broker_Reverse)
+	require.NoError(t, err)
+	assert.True(t, ok, "a token signed by the registered key should verify")
+
+	// The namespace rotates to a new key; the cached keyset still holds only
+	// the old one.
+	secondKey := registry.rotateTo(t, "key-2")
+	rotatedTok := mintBrokerToken(t, secondKey, prefix, audience, token_scopes.Broker_Reverse)
+
+	ok, err = verifyToken(ctx, rotatedTok, prefix, audience, token_scopes.Broker_Reverse)
+	require.NoError(t, err, "an unknown key ID should trigger a refresh rather than a hard failure")
+	assert.True(t, ok, "a token signed by a newly registered key should verify")
+
+	// The retired key must no longer verify, since the refreshed set replaced it.
+	staleTok := mintBrokerToken(t, firstKey, prefix, audience, token_scopes.Broker_Reverse)
+	ok, _ = verifyToken(ctx, staleTok, prefix, audience, token_scopes.Broker_Reverse)
+	assert.False(t, ok, "a token signed by the retired key should be rejected")
+}
+
+// TestRefreshNamespaceKeys_RateLimited verifies that forced refreshes are
+// throttled, so a stream of tokens naming unknown key IDs cannot become a
+// stream of registry fetches.
+func TestRefreshNamespaceKeys_RateLimited(t *testing.T) {
+	registry := newJwksTestServer(t)
+	registry.rotateTo(t, "key-1")
+
+	ctx := setupBrokerKeyTest(t, registry.server.URL)
+	const prefix = "/caches/example"
+
+	_, _, err := getRegistryIssuerInfo(ctx, prefix)
+	require.NoError(t, err)
+	fetchesAfterFirst := registry.fetchCount()
+
+	// The initial fetch just happened, so a forced refresh is suppressed.
+	set, err := refreshNamespaceKeys(ctx, prefix)
+	require.NoError(t, err)
+	assert.Nil(t, set, "a refresh within the rate-limit window should be suppressed")
+	assert.Equal(t, fetchesAfterFirst, registry.fetchCount(), "the registry should not be contacted")
+
+	// With the window elapsed, the refresh goes through.
+	orig := jwksForcedRefreshInterval
+	jwksForcedRefreshInterval = 0
+	t.Cleanup(func() { jwksForcedRefreshInterval = orig })
+
+	set, err = refreshNamespaceKeys(ctx, prefix)
+	require.NoError(t, err)
+	require.NotNil(t, set, "a refresh outside the rate-limit window should proceed")
+	assert.Greater(t, registry.fetchCount(), fetchesAfterFirst)
 }

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -65,6 +65,49 @@ func TestGetCacheHostnameFromToken(t *testing.T) {
 	assert.Equal(t, "https://cache.com", hostname)
 }
 
+// TestGetRegistryIssValue_RejectsTraversal verifies that a namespace prefix
+// cannot walk out of the registry's API path.  The prefix arrives in the
+// request body before the caller's token is verified and is joined into the
+// registry URL, and joining cleans the result, so ".." segments would silently
+// aim the key lookup at some other path on the registry.
+func TestGetRegistryIssValue_RejectsTraversal(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	test_utils.InitClient(t, nil)
+	test_utils.MockFederationRoot(t, &pelican_url.FederationDiscovery{
+		RegistryEndpoint: "https://registry.example.com",
+	}, nil)
+
+	t.Run("Rejected", func(t *testing.T) {
+		for _, prefix := range []string{
+			"",
+			"caches/example",
+			"../../../../evil",
+			"/caches/../../origins/secret",
+			"/caches/x/../../../../../../etc/passwd",
+			"/caches/./example",
+		} {
+			_, err := getRegistryIssValue(prefix)
+			assert.Error(t, err, "prefix %q should be rejected", prefix)
+		}
+	})
+
+	t.Run("Accepted", func(t *testing.T) {
+		// A cache's prefix embeds the cache's URL, so a prefix is not required
+		// to survive path cleaning unchanged.
+		for _, prefix := range []string{
+			"/caches/example",
+			"/origins/example",
+			"/caches/https://cache.example.com",
+			"/foo/bar/baz",
+		} {
+			iss, err := getRegistryIssValue(prefix)
+			require.NoError(t, err, "prefix %q should be accepted", prefix)
+			assert.Contains(t, iss, "https://registry.example.com/api/v1.0/registry")
+		}
+	})
+}
+
 // jwksTestServer is a stand-in registry that serves a namespace's JWKS.  Its
 // key set can be rotated and the whole server can be taken "down" to simulate
 // a registry outage, while counting the fetches it actually served.

--- a/identity/cached_lookup.go
+++ b/identity/cached_lookup.go
@@ -122,14 +122,22 @@ func NewCachedLookupWithTTL(strategy LookupStrategy, positiveTTL, negativeTTL ti
 		},
 	)
 
+	// Touch-on-hit must stay disabled on all three caches: extending an
+	// entry's lifetime on every read would let a continuously-active user
+	// keep stale identity data forever — most importantly a secondary-GID
+	// list (which feeds setgroups(2)) from before an admin revoked a group
+	// membership, and cached negative results past the point the account
+	// was created.  With it disabled, staleness is bounded by the TTLs.
 	cl.userCache = ttlcache.New[string, cachedUserResult](
 		ttlcache.WithTTL[string, cachedUserResult](positiveTTL),
+		ttlcache.WithDisableTouchOnHit[string, cachedUserResult](),
 		ttlcache.WithLoader[string, cachedUserResult](ttlcache.NewSuppressedLoader[string, cachedUserResult](userLoader, nil)),
 		ttlcache.WithCapacity[string, cachedUserResult](4096),
 	)
 
 	cl.gidCache = ttlcache.New[string, cachedGIDResult](
 		ttlcache.WithTTL[string, cachedGIDResult](positiveTTL),
+		ttlcache.WithDisableTouchOnHit[string, cachedGIDResult](),
 		ttlcache.WithLoader[string, cachedGIDResult](ttlcache.NewSuppressedLoader[string, cachedGIDResult](gidLoader, nil)),
 		ttlcache.WithCapacity[string, cachedGIDResult](4096),
 	)
@@ -150,6 +158,7 @@ func NewCachedLookupWithTTL(strategy LookupStrategy, positiveTTL, negativeTTL ti
 
 	cl.secondaryCache = ttlcache.New[string, cachedSecondaryResult](
 		ttlcache.WithTTL[string, cachedSecondaryResult](positiveTTL),
+		ttlcache.WithDisableTouchOnHit[string, cachedSecondaryResult](),
 		ttlcache.WithLoader[string, cachedSecondaryResult](ttlcache.NewSuppressedLoader[string, cachedSecondaryResult](secondaryLoader, nil)),
 		ttlcache.WithCapacity[string, cachedSecondaryResult](4096),
 	)

--- a/identity/cached_lookup_test.go
+++ b/identity/cached_lookup_test.go
@@ -318,3 +318,53 @@ func TestCachedLookup_SecondaryCache(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, int64(2), mock.secondaryCalls.Load(), "expected negative cache hit for secondary")
 }
+
+// TestCachedLookup_ReadsDoNotExtendExpiry verifies that cache reads do not
+// touch (extend) an entry's expiry.  Without ttlcache's WithDisableTouchOnHit,
+// a continuously-active user would never be re-resolved, so revoked group
+// memberships (and cached negative lookups) would persist indefinitely.
+func TestCachedLookup_ReadsDoNotExtendExpiry(t *testing.T) {
+	mock := &mockStrategyWithSecondary{
+		mockStrategy: *newMockStrategy(),
+		secondaryMap: map[string][]uint32{
+			"alice": {2000, 3000},
+		},
+	}
+	cached := NewCachedLookup(mock)
+
+	_, err := cached.UidForUser("alice")
+	require.NoError(t, err)
+	_, err = cached.GidForGroup("users")
+	require.NoError(t, err)
+	_, err = cached.SecondaryGidsForUser("alice")
+	require.NoError(t, err)
+	_, err = cached.UidForUser("nonexistent")
+	require.Error(t, err)
+
+	userExpiry := cached.userCache.Get("alice").ExpiresAt()
+	gidExpiry := cached.gidCache.Get("users").ExpiresAt()
+	secondaryExpiry := cached.secondaryCache.Get("alice").ExpiresAt()
+	negativeExpiry := cached.userCache.Get("nonexistent").ExpiresAt()
+
+	// Let the wall clock advance so a touch-on-hit, if present, would
+	// produce a visibly later expiry on the re-reads below.
+	time.Sleep(20 * time.Millisecond)
+
+	_, err = cached.UidForUser("alice")
+	require.NoError(t, err)
+	_, err = cached.GidForGroup("users")
+	require.NoError(t, err)
+	_, err = cached.SecondaryGidsForUser("alice")
+	require.NoError(t, err)
+	_, err = cached.UidForUser("nonexistent")
+	require.Error(t, err)
+
+	assert.True(t, userExpiry.Equal(cached.userCache.Get("alice").ExpiresAt()),
+		"a read must not extend the user entry's expiry")
+	assert.True(t, gidExpiry.Equal(cached.gidCache.Get("users").ExpiresAt()),
+		"a read must not extend the group entry's expiry")
+	assert.True(t, secondaryExpiry.Equal(cached.secondaryCache.Get("alice").ExpiresAt()),
+		"a read must not extend the secondary-GID entry's expiry")
+	assert.True(t, negativeExpiry.Equal(cached.userCache.Get("nonexistent").ExpiresAt()),
+		"a read must not extend a negative entry's expiry")
+}

--- a/local_cache/cache_authz.go
+++ b/local_cache/cache_authz.go
@@ -21,19 +21,16 @@ package local_cache
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"path"
 	"slices"
 	"sync/atomic"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -41,15 +38,13 @@ import (
 
 type (
 	authConfig struct {
-		ns         atomic.Pointer[[]server_structs.NamespaceAd]
-		issuers    atomic.Pointer[map[string]bool]
-		issuerKeys *ttlcache.Cache[string, authConfigItem]
+		ns      atomic.Pointer[[]server_structs.NamespaceAd]
+		issuers atomic.Pointer[map[string]bool]
+		// ctx bounds key fetches.  They are shared between requests, so they
+		// must not be tied to whichever request happened to trigger one.
+		ctx        context.Context
+		issuerKeys *token.JwksCache
 		tokenAuthz *ttlcache.Cache[string, authzResult]
-	}
-
-	authConfigItem struct {
-		set jwk.Set
-		err error
 	}
 
 	acls []token_scopes.ResourceScope
@@ -77,37 +72,13 @@ const tokenAuthzTTL = 5 * time.Minute
 func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 	ac = &authConfig{}
 
-	loader := ttlcache.LoaderFunc[string, authConfigItem](
-		func(cache *ttlcache.Cache[string, authConfigItem], issuerUrl string) *ttlcache.Item[string, authConfigItem] {
-			var ar *jwk.Cache
-			jwksUrl, err := token.LookupIssuerJwksUrl(ctx, issuerUrl)
-			if err != nil {
-				log.Errorln("Failed to lookup JWKS URL:", err)
-			} else {
-				ar = jwk.NewCache(ctx)
-				client := &http.Client{Transport: config.GetBasicTransport()}
-				if err = ar.Register(jwksUrl.String(), jwk.WithMinRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
-					log.Errorln("Failed to register JWKS URL with cache: ", err)
-				} else {
-					log.Debugln("Setting public key cache for issuer", issuerUrl)
-				}
-			}
-
-			ttl := ttlcache.DefaultTTL
-			var item *ttlcache.Item[string, authConfigItem]
-			if ar != nil {
-				item = cache.Set(issuerUrl, authConfigItem{set: jwk.NewCachedSet(ar, jwksUrl.String()), err: nil}, ttl)
-			} else {
-				ttl = time.Duration(5 * time.Minute)
-				item = cache.Set(issuerUrl, authConfigItem{set: nil, err: err}, ttl)
-			}
-			return item
-		},
-	)
-	ac.issuerKeys = ttlcache.New[string, authConfigItem](
-		ttlcache.WithTTL[string, authConfigItem](15*time.Minute),
-		ttlcache.WithLoader[string, authConfigItem](ttlcache.NewSuppressedLoader[string, authConfigItem](loader, nil)),
-	)
+	// Issuer keys are fetched and aged by the shared cache, which serves the
+	// last keys it retrieved through an issuer outage and stops trusting them
+	// once they are too old to confirm.  The key space here comes from the
+	// namespaces the director advertises rather than from a request, so no
+	// capacity bound is needed.
+	ac.ctx = ctx
+	ac.issuerKeys = token.NewJwksCache(ctx, egrp)
 
 	// Touch-on-hit must stay disabled: the token's exp is only checked in the
 	// loader, so letting a Get refresh the entry would keep an actively-used
@@ -119,23 +90,28 @@ func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 	)
 
 	egrp.Go(func() error {
-		ac.issuerKeys.Start()
-		return nil
-	})
-	egrp.Go(func() error {
 		ac.tokenAuthz.Start()
 		return nil
 	})
 	egrp.Go(func() error {
 		<-ctx.Done()
-		ac.issuerKeys.Stop()
-		ac.issuerKeys.DeleteAll()
 		ac.tokenAuthz.Stop()
 		ac.tokenAuthz.DeleteAll()
 		return nil
 	})
 
 	return
+}
+
+// issuerJwksResolver locates an issuer's JWKS through OIDC discovery.
+func issuerJwksResolver(issuerUrl string) token.JwksUrlResolver {
+	return func(ctx context.Context) (string, error) {
+		jwksUrl, err := token.LookupIssuerJwksUrl(ctx, issuerUrl)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to look up the JWKS URL for issuer %s", issuerUrl)
+		}
+		return jwksUrl.String(), nil
+	}
 }
 
 func (ac *authConfig) updateConfig(nsAds []server_structs.NamespaceAd) error {
@@ -222,28 +198,17 @@ func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.
 		return
 	}
 
-	issuerConfItem := ac.issuerKeys.Get(issuer)
-	if issuerConfItem == nil {
-		err = errors.Errorf("unable to determine keys for issuer %s", issuer)
+	if ac.issuerKeys == nil {
+		err = errors.New("issuer key cache is not initialized")
+		return
+	}
+	keyset, err := ac.issuerKeys.Keys(ac.ctx, issuer, issuerJwksResolver(issuer))
+	if err != nil {
+		err = errors.Wrapf(err, "unable to determine keys for issuer %s", issuer)
 		return
 	}
 
-	issuerConf := issuerConfItem.Value()
-	if issuerConf.err != nil {
-		err = issuerConf.err
-		return
-	}
-
-	item := issuerConfItem.Value()
-	if item.set == nil {
-		if item.err == nil {
-			err = item.err
-		} else {
-			err = errors.Errorf("failed to fetch public key set")
-		}
-		return
-	}
-	tok, err = token.VerifyWithKeyset(tokenStr, item.set)
+	tok, err = token.VerifyWithKeyset(tokenStr, keyset)
 	if err != nil {
 		err = errors.Wrap(err, "unable to get resource scopes because verification failed")
 		return

--- a/local_cache/cache_authz.go
+++ b/local_cache/cache_authz.go
@@ -180,7 +180,10 @@ func nsAdsAuthzEqual(old, new []server_structs.NamespaceAd) bool {
 	return true
 }
 
-func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.ResourceScope, issuer string, err error) {
+// getResourceScopes verifies the token and returns the scopes it carries, its
+// issuer, and its expiration.  The expiration comes from the verified token so
+// that callers do not have to parse it a second time.
+func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.ResourceScope, issuer string, expiration time.Time, err error) {
 	if tokenStr == "" {
 		return
 	}
@@ -214,6 +217,7 @@ func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.
 		return
 	}
 
+	expiration = tok.Expiration()
 	scopes = token_scopes.ParseResourceScopeString(tok)
 
 	return
@@ -250,12 +254,12 @@ func calcResourceScopes(rs token_scopes.ResourceScope, basePaths []string, restr
 // Public namespaces always grant read ACLs regardless of the token's
 // validity.  An invalid or untrusted token only prevents private-namespace
 // ACLs from being generated; it is not an error.
-func (ac *authConfig) getAcls(token string) (newAcls acls, tokenTrusted bool, err error) {
+func (ac *authConfig) getAcls(token string) (newAcls acls, tokenTrusted bool, expiration time.Time, err error) {
 	namespaces := ac.ns.Load()
 	if namespaces == nil {
 		return
 	}
-	resources, issuer, tokenErr := ac.getResourceScopes(token)
+	resources, issuer, expiration, tokenErr := ac.getResourceScopes(token)
 	tokenTrusted = (tokenErr == nil)
 	if tokenErr != nil && token != "" {
 		log.Debugln("Token validation failed (public ACLs still granted):", tokenErr)
@@ -294,7 +298,7 @@ func (ac *authConfig) getAcls(token string) (newAcls acls, tokenTrusted bool, er
 }
 
 func (ac *authConfig) loader(cache *ttlcache.Cache[string, authzResult], tokenStr string) *ttlcache.Item[string, authzResult] {
-	newAcls, tokenTrusted, tokenValidationErr := ac.getAcls(tokenStr)
+	newAcls, tokenTrusted, expiration, tokenValidationErr := ac.getAcls(tokenStr)
 	if tokenValidationErr != nil && tokenStr == "" {
 		// Non-token-related error (e.g., namespace config issue) should
 		// be logged and result in a nil return.
@@ -322,23 +326,18 @@ func (ac *authConfig) loader(cache *ttlcache.Cache[string, authzResult], tokenSt
 	ttl := ttlcache.DefaultTTL
 	if !tokenTrusted && tokenStr != "" {
 		ttl = 30 * time.Second
-	} else if tokenTrusted {
-		// Cap the cache entry's lifetime at the token's own expiry (plus the
-		// clock-skew leeway the verifier grants) so the cached authorization
-		// never outlives the token itself.  getAcls has already verified the
-		// token's signature, so the claims can be trusted despite the unsafe
-		// parse.
-		if tok, err := token.UnsafeParseClaims(tokenStr); err == nil {
-			if exp := tok.Expiration(); !exp.IsZero() {
-				remaining := time.Until(exp) + token.ClockSkewLeeway
-				if remaining <= 0 {
-					log.Warningln("Rejecting expired token")
-					return nil
-				}
-				if remaining < tokenAuthzTTL {
-					ttl = remaining
-				}
-			}
+	} else if tokenTrusted && !expiration.IsZero() {
+		// Cap the cache entry's lifetime at the token's own expiry, plus the
+		// clock skew leeway the verifier grants, so the cached authorization
+		// never outlives the token itself.  The expiry comes from the token
+		// getAcls verified, so it needs no separate parse.
+		remaining := time.Until(expiration) + token.ClockSkewLeeway
+		if remaining <= 0 {
+			log.Warningln("Rejecting expired token")
+			return nil
+		}
+		if remaining < tokenAuthzTTL {
+			ttl = remaining
 		}
 	}
 

--- a/local_cache/cache_authz.go
+++ b/local_cache/cache_authz.go
@@ -69,6 +69,11 @@ type (
 	}
 )
 
+// tokenAuthzTTL is the maximum lifetime of a cached token-authorization
+// result.  Individual entries may be given a shorter TTL when the token
+// itself expires sooner.
+const tokenAuthzTTL = 5 * time.Minute
+
 func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 	ac = &authConfig{}
 
@@ -104,8 +109,12 @@ func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 		ttlcache.WithLoader[string, authConfigItem](ttlcache.NewSuppressedLoader[string, authConfigItem](loader, nil)),
 	)
 
+	// Touch-on-hit must stay disabled: the token's exp is only checked in the
+	// loader, so letting a Get refresh the entry would keep an actively-used
+	// token authorized indefinitely past its expiry.
 	ac.tokenAuthz = ttlcache.New[string, authzResult](
-		ttlcache.WithTTL[string, authzResult](5*time.Minute),
+		ttlcache.WithTTL[string, authzResult](tokenAuthzTTL),
+		ttlcache.WithDisableTouchOnHit[string, authzResult](),
 		ttlcache.WithLoader[string, authzResult](ttlcache.LoaderFunc[string, authzResult](ac.loader)),
 	)
 
@@ -319,9 +328,9 @@ func (ac *authConfig) getAcls(token string) (newAcls acls, tokenTrusted bool, er
 	return
 }
 
-func (ac *authConfig) loader(cache *ttlcache.Cache[string, authzResult], token string) *ttlcache.Item[string, authzResult] {
-	newAcls, tokenTrusted, tokenValidationErr := ac.getAcls(token)
-	if tokenValidationErr != nil && token == "" {
+func (ac *authConfig) loader(cache *ttlcache.Cache[string, authzResult], tokenStr string) *ttlcache.Item[string, authzResult] {
+	newAcls, tokenTrusted, tokenValidationErr := ac.getAcls(tokenStr)
+	if tokenValidationErr != nil && tokenStr == "" {
 		// Non-token-related error (e.g., namespace config issue) should
 		// be logged and result in a nil return.
 		log.Warningln("Failed to compute ACLs:", tokenValidationErr)
@@ -329,7 +338,7 @@ func (ac *authConfig) loader(cache *ttlcache.Cache[string, authzResult], token s
 	}
 
 	var tokenError string
-	if !tokenTrusted && token != "" {
+	if !tokenTrusted && tokenStr != "" {
 		// Include a human-readable reason so authorize() can return actionable
 		// deny reasons.  The underlying error is not exposed in full to avoid
 		// sensitive data leakage, but we include enough detail to be useful.
@@ -338,7 +347,7 @@ func (ac *authConfig) loader(cache *ttlcache.Cache[string, authzResult], token s
 		} else {
 			tokenError = "token validation failed"
 		}
-	} else if token == "" {
+	} else if tokenStr == "" {
 		// No token provided — public ACLs only.
 		tokenError = "no token provided"
 	}
@@ -346,11 +355,29 @@ func (ac *authConfig) loader(cache *ttlcache.Cache[string, authzResult], token s
 	// Use a shorter TTL for unrecognized tokens to bound memory usage
 	// from attackers sending many junk tokens (DoS mitigation).
 	ttl := ttlcache.DefaultTTL
-	if !tokenTrusted && token != "" {
+	if !tokenTrusted && tokenStr != "" {
 		ttl = 30 * time.Second
+	} else if tokenTrusted {
+		// Cap the cache entry's lifetime at the token's own expiry (plus the
+		// clock-skew leeway the verifier grants) so the cached authorization
+		// never outlives the token itself.  getAcls has already verified the
+		// token's signature, so the claims can be trusted despite the unsafe
+		// parse.
+		if tok, err := token.UnsafeParseClaims(tokenStr); err == nil {
+			if exp := tok.Expiration(); !exp.IsZero() {
+				remaining := time.Until(exp) + token.ClockSkewLeeway
+				if remaining <= 0 {
+					log.Warningln("Rejecting expired token")
+					return nil
+				}
+				if remaining < tokenAuthzTTL {
+					ttl = remaining
+				}
+			}
+		}
 	}
 
-	item := cache.Set(token, authzResult{scopes: newAcls, tokenError: tokenError}, ttl)
+	item := cache.Set(tokenStr, authzResult{scopes: newAcls, tokenError: tokenError}, ttl)
 	return item
 }
 

--- a/local_cache/cache_authz_test.go
+++ b/local_cache/cache_authz_test.go
@@ -64,7 +64,7 @@ func TestGetAcls_PublicNamespaceWithInvalidToken(t *testing.T) {
 	require.NoError(t, ac.updateConfig(nsAds))
 
 	t.Run("EmptyToken", func(t *testing.T) {
-		acls, trusted, err := ac.getAcls("")
+		acls, trusted, _, err := ac.getAcls("")
 		require.NoError(t, err)
 		assert.True(t, trusted, "empty token should be treated as trusted (no token)")
 		require.Len(t, acls, 1)
@@ -73,7 +73,7 @@ func TestGetAcls_PublicNamespaceWithInvalidToken(t *testing.T) {
 	})
 
 	t.Run("GarbageToken", func(t *testing.T) {
-		acls, trusted, err := ac.getAcls("not-a-real-jwt")
+		acls, trusted, _, err := ac.getAcls("not-a-real-jwt")
 		require.NoError(t, err)
 		assert.False(t, trusted, "garbage token should not be trusted")
 		require.Len(t, acls, 1, "Public ACLs must still be granted")
@@ -107,7 +107,7 @@ func TestGetAcls_MixedNamespaces(t *testing.T) {
 	require.NoError(t, ac.updateConfig(nsAds))
 
 	t.Run("InvalidTokenGetsOnlyPublicACLs", func(t *testing.T) {
-		acls, trusted, err := ac.getAcls("bad-token")
+		acls, trusted, _, err := ac.getAcls("bad-token")
 		require.NoError(t, err)
 		assert.False(t, trusted)
 
@@ -201,7 +201,7 @@ func TestGetAcls_HierarchicalNamespaceOR(t *testing.T) {
 		}
 		require.NoError(t, ac.updateConfig(nsAds))
 
-		acls, _, err := ac.getAcls("")
+		acls, _, _, err := ac.getAcls("")
 		require.NoError(t, err)
 		// Only the public namespace contributes (no valid token).
 		require.Len(t, acls, 1)
@@ -228,7 +228,7 @@ func TestGetAcls_HierarchicalNamespaceOR(t *testing.T) {
 		}
 		require.NoError(t, ac.updateConfig(nsAds))
 
-		acls, _, err := ac.getAcls("")
+		acls, _, _, err := ac.getAcls("")
 		require.NoError(t, err)
 		// Only the child's public namespace contributes.
 		require.Len(t, acls, 1)
@@ -252,7 +252,7 @@ func TestGetAcls_HierarchicalNamespaceOR(t *testing.T) {
 		}
 		require.NoError(t, ac.updateConfig(nsAds))
 
-		acls, _, err := ac.getAcls("")
+		acls, _, _, err := ac.getAcls("")
 		require.NoError(t, err)
 		require.Len(t, acls, 2)
 

--- a/local_cache/cache_authz_test.go
+++ b/local_cache/cache_authz_test.go
@@ -20,14 +20,25 @@ package local_cache
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
@@ -369,4 +380,153 @@ func TestNsAdsAuthzEqual(t *testing.T) {
 		assert.True(t, nsAdsAuthzEqual(nil, nil))
 		assert.True(t, nsAdsAuthzEqual([]server_structs.NamespaceAd{}, []server_structs.NamespaceAd{}))
 	})
+}
+
+// newTestIssuerServer generates a signing key and starts an HTTP server that
+// publishes its public half via JWKS along with the OpenID discovery document.
+// It returns the signing key and the issuer URL.
+func newTestIssuerServer(t *testing.T) (jwk.Key, string) {
+	privEC, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key, err := jwk.FromRaw(privEC)
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, "test-key"))
+	require.NoError(t, key.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	pubKey, err := key.PublicKey()
+	require.NoError(t, err)
+	require.NoError(t, pubKey.Set(jwk.KeyIDKey, "test-key"))
+	require.NoError(t, pubKey.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	jwks := jwk.NewSet()
+	require.NoError(t, jwks.AddKey(pubKey))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(jwks)
+		_, _ = w.Write(data)
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		cfg := map[string]interface{}{
+			"issuer":   "http://" + r.Host,
+			"jwks_uri": "http://" + r.Host + "/jwks",
+		}
+		data, _ := json.Marshal(cfg)
+		_, _ = w.Write(data)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return key, server.URL
+}
+
+// mintTestToken creates a signed token from the given issuer with an explicit
+// expiration time.
+func mintTestToken(t *testing.T, key jwk.Key, issuer string, exp time.Time, scopes string) string {
+	tok, err := jwt.NewBuilder().
+		Issuer(issuer).
+		Subject("alice").
+		IssuedAt(time.Now().Add(-5*time.Minute)).
+		Expiration(exp).
+		Claim("scope", scopes).
+		Audience([]string{"https://wlcg.cern.ch/jwt/v1/any"}).
+		Build()
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, key))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// TestAuthorize_TokenExpiryBoundsCacheEntry verifies the fixes for issue
+// #3696 in the local cache: a cached authorization entry must not outlive the
+// token that produced it, and a cache read must not extend the entry's
+// lifetime (touch-on-hit).
+func TestAuthorize_TokenExpiryBoundsCacheEntry(t *testing.T) {
+	key, issuerURL := newTestIssuerServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp, ctx := errgroup.WithContext(ctx)
+
+	ac := newAuthConfig(ctx, egrp)
+
+	parsedIssuer, err := url.Parse(issuerURL)
+	require.NoError(t, err)
+	nsAds := []server_structs.NamespaceAd{
+		{
+			Path: "/data",
+			Caps: server_structs.Capabilities{Reads: true},
+			Issuer: []server_structs.TokenIssuer{{
+				IssuerUrl: *parsedIssuer,
+				BasePaths: []string{"/data"},
+			}},
+		},
+	}
+	require.NoError(t, ac.updateConfig(nsAds))
+
+	tokenLifetime := 30 * time.Second
+	now := time.Now()
+	tokenStr := mintTestToken(t, key, issuerURL, now.Add(tokenLifetime), "storage.read:/")
+
+	ok, reason := ac.authorize(token_scopes.Wlcg_Storage_Read, "/data/file.txt", tokenStr)
+	require.True(t, ok, "a currently-valid token should authorize (denied: %s)", reason)
+
+	item := ac.tokenAuthz.Get(tokenStr)
+	require.NotNil(t, item)
+	maxExpiry := now.Add(tokenLifetime + token.ClockSkewLeeway + 10*time.Second)
+	assert.True(t, item.ExpiresAt().Before(maxExpiry),
+		"cache entry expiry %v should be clamped near the token's exp, not the default TTL", item.ExpiresAt())
+
+	// A read must not push the entry's expiry out.  Let the wall clock advance
+	// so that a touch-on-hit, if present, would produce a visibly later expiry.
+	firstExpiry := item.ExpiresAt()
+	time.Sleep(20 * time.Millisecond)
+	ok, _ = ac.authorize(token_scopes.Wlcg_Storage_Read, "/data/file.txt", tokenStr)
+	require.True(t, ok)
+	item = ac.tokenAuthz.Get(tokenStr)
+	require.NotNil(t, item)
+	assert.True(t, firstExpiry.Equal(item.ExpiresAt()),
+		"a cache read must not extend the entry's expiry (was %v, now %v)", firstExpiry, item.ExpiresAt())
+
+	cancel()
+	_ = egrp.Wait()
+}
+
+// TestAuthorize_ExpiredTokenDenied verifies that a token whose exp is past
+// (beyond the verifier's clock-skew leeway) no longer grants access to a
+// private namespace.
+func TestAuthorize_ExpiredTokenDenied(t *testing.T) {
+	key, issuerURL := newTestIssuerServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp, ctx := errgroup.WithContext(ctx)
+
+	ac := newAuthConfig(ctx, egrp)
+
+	parsedIssuer, err := url.Parse(issuerURL)
+	require.NoError(t, err)
+	nsAds := []server_structs.NamespaceAd{
+		{
+			Path: "/data",
+			Caps: server_structs.Capabilities{Reads: true},
+			Issuer: []server_structs.TokenIssuer{{
+				IssuerUrl: *parsedIssuer,
+				BasePaths: []string{"/data"},
+			}},
+		},
+	}
+	require.NoError(t, ac.updateConfig(nsAds))
+
+	tokenStr := mintTestToken(t, key, issuerURL,
+		time.Now().Add(-2*token.ClockSkewLeeway), "storage.read:/")
+
+	ok, reason := ac.authorize(token_scopes.Wlcg_Storage_Read, "/data/file.txt", tokenStr)
+	assert.False(t, ok, "an expired token must not authorize")
+	assert.Contains(t, reason, "token validation failed")
+
+	cancel()
+	_ = egrp.Wait()
 }

--- a/origin_serve/authz.go
+++ b/origin_serve/authz.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -50,17 +49,15 @@ type (
 		// change rather than per request: SetTokenHintHeaders runs on every
 		// request a standalone origin serves, and rebuilding the ads there costs
 		// a url.Parse per issuer per request.  Swapped together with exports.
-		nsAds      atomic.Pointer[[]server_structs.NamespaceAd]
-		issuers    atomic.Pointer[map[string]bool]
-		audiences  []string // accepted audience values (origin URL + wildcards)
-		issuerKeys *ttlcache.Cache[string, authConfigItem]
+		nsAds     atomic.Pointer[[]server_structs.NamespaceAd]
+		issuers   atomic.Pointer[map[string]bool]
+		audiences []string // accepted audience values (origin URL + wildcards)
+		// ctx bounds key fetches.  They are shared between requests, so they
+		// must not be tied to whichever request happened to trigger one.
+		ctx        context.Context
+		issuerKeys *token.JwksCache
 		tokenAuthz *ttlcache.Cache[string, cachedTokenInfo]
 		userMapper *UserMapper // Maps JWT claims to local users/groups
-	}
-
-	authConfigItem struct {
-		set jwk.Set
-		err error
 	}
 
 	// cachedTokenInfo stores authorization scopes, user info, and issuer for a token
@@ -146,37 +143,13 @@ func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 	refreshInterval := param.Origin_UserMapfileRefreshInterval.GetDuration()
 	ac.userMapper.StartPeriodicRefresh(refreshInterval)
 
-	loader := ttlcache.LoaderFunc[string, authConfigItem](
-		func(cache *ttlcache.Cache[string, authConfigItem], issuerUrl string) *ttlcache.Item[string, authConfigItem] {
-			var ar *jwk.Cache
-			jwksUrl, err := token.LookupIssuerJwksUrl(ctx, issuerUrl)
-			if err != nil {
-				log.Errorln("Failed to lookup JWKS URL:", err)
-			} else {
-				ar = jwk.NewCache(ctx)
-				client := &http.Client{Transport: config.GetBasicTransport()}
-				if err = ar.Register(jwksUrl.String(), jwk.WithMinRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
-					log.Errorln("Failed to register JWKS URL with cache: ", err)
-				} else {
-					log.Debugln("Setting public key cache for issuer", issuerUrl)
-				}
-			}
-
-			ttl := ttlcache.DefaultTTL
-			var item *ttlcache.Item[string, authConfigItem]
-			if ar != nil {
-				item = cache.Set(issuerUrl, authConfigItem{set: jwk.NewCachedSet(ar, jwksUrl.String()), err: nil}, ttl)
-			} else {
-				ttl = time.Duration(5 * time.Minute)
-				item = cache.Set(issuerUrl, authConfigItem{set: nil, err: err}, ttl)
-			}
-			return item
-		},
-	)
-	ac.issuerKeys = ttlcache.New[string, authConfigItem](
-		ttlcache.WithTTL[string, authConfigItem](15*time.Minute),
-		ttlcache.WithLoader[string, authConfigItem](ttlcache.NewSuppressedLoader[string, authConfigItem](loader, nil)),
-	)
+	// Issuer keys are fetched and aged by the shared cache, which serves the
+	// last keys it retrieved through an issuer outage and stops trusting them
+	// once they are too old to confirm.  The key space here comes from the
+	// export configuration rather than from a request, so no capacity bound is
+	// needed.
+	ac.ctx = ctx
+	ac.issuerKeys = token.NewJwksCache(ctx, egrp)
 
 	// Touch-on-hit must stay disabled: the token's exp is only checked in the
 	// loader, so letting a Get refresh the entry would keep an actively-used
@@ -188,23 +161,28 @@ func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 	)
 
 	egrp.Go(func() error {
-		ac.issuerKeys.Start()
-		return nil
-	})
-	egrp.Go(func() error {
 		ac.tokenAuthz.Start()
 		return nil
 	})
 	egrp.Go(func() error {
 		<-ctx.Done()
-		ac.issuerKeys.Stop()
-		ac.issuerKeys.DeleteAll()
 		ac.tokenAuthz.Stop()
 		ac.tokenAuthz.DeleteAll()
 		return nil
 	})
 
 	return
+}
+
+// issuerJwksResolver locates an issuer's JWKS through OIDC discovery.
+func issuerJwksResolver(issuerUrl string) token.JwksUrlResolver {
+	return func(ctx context.Context) (string, error) {
+		jwksUrl, err := token.LookupIssuerJwksUrl(ctx, issuerUrl)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to look up the JWKS URL for issuer %s", issuerUrl)
+		}
+		return jwksUrl.String(), nil
+	}
 }
 
 func (ac *authConfig) updateConfig(exports []server_utils.OriginExport) error {
@@ -279,28 +257,17 @@ func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.
 		return
 	}
 
-	issuerConfItem := ac.issuerKeys.Get(issuer)
-	if issuerConfItem == nil {
-		err = errors.Errorf("unable to determine keys for issuer %s", issuer)
+	if ac.issuerKeys == nil {
+		err = errors.New("issuer key cache is not initialized")
+		return
+	}
+	keyset, err := ac.issuerKeys.Keys(ac.ctx, issuer, issuerJwksResolver(issuer))
+	if err != nil {
+		err = errors.Wrapf(err, "unable to determine keys for issuer %s", issuer)
 		return
 	}
 
-	issuerConf := issuerConfItem.Value()
-	if issuerConf.err != nil {
-		err = issuerConf.err
-		return
-	}
-
-	item := issuerConfItem.Value()
-	if item.set == nil {
-		if item.err != nil {
-			err = item.err
-		} else {
-			err = errors.Errorf("failed to fetch public key set")
-		}
-		return
-	}
-	tok, err = token.VerifyWithKeyset(tokenStr, item.set)
+	tok, err = token.VerifyWithKeyset(tokenStr, keyset)
 	if err != nil {
 		// Token signature or claims validation failed — mark as unverified
 		tokenErr := NewTokenValidationError("failed to verify token signature or claims").

--- a/origin_serve/authz.go
+++ b/origin_serve/authz.go
@@ -78,6 +78,11 @@ type (
 
 var globalAuthConfig *authConfig
 
+// tokenAuthzTTL is the maximum lifetime of a cached token-authorization
+// result.  Individual entries may be given a shorter TTL when the token
+// itself expires sooner.
+const tokenAuthzTTL = 5 * time.Minute
+
 // hasPathPrefix checks if the request path is under the authorized prefix.
 // Unlike strings.HasPrefix, this checks path boundaries to prevent
 // access to /foo/bar2 when only /foo/bar is authorized.
@@ -173,8 +178,12 @@ func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 		ttlcache.WithLoader[string, authConfigItem](ttlcache.NewSuppressedLoader[string, authConfigItem](loader, nil)),
 	)
 
+	// Touch-on-hit must stay disabled: the token's exp is only checked in the
+	// loader, so letting a Get refresh the entry would keep an actively-used
+	// token authorized indefinitely past its expiry.
 	ac.tokenAuthz = ttlcache.New[string, cachedTokenInfo](
-		ttlcache.WithTTL[string, cachedTokenInfo](5*time.Minute),
+		ttlcache.WithTTL[string, cachedTokenInfo](tokenAuthzTTL),
+		ttlcache.WithDisableTouchOnHit[string, cachedTokenInfo](),
 		ttlcache.WithLoader[string, cachedTokenInfo](ttlcache.LoaderFunc[string, cachedTokenInfo](ac.loader)),
 	)
 
@@ -435,10 +444,26 @@ func (ac *authConfig) loader(cache *ttlcache.Cache[string, cachedTokenInfo], tok
 		return nil
 	}
 
-	// Extract issuer from the token (claims are unverified at this point; used only for logging)
+	// Re-parse the claims to pick up the issuer (for logging) and the expiry.
+	// getAcls has already verified the token's signature and validity, so the
+	// claims can be trusted despite the unsafe parse.
 	issuer := ""
+	ttl := ttlcache.DefaultTTL
 	if tok, err := token.UnsafeParseClaims(tokenStr); err == nil {
 		issuer = tok.Issuer()
+		// Cap the cache entry's lifetime at the token's own expiry (plus the
+		// clock-skew leeway the verifier grants) so the cached authorization
+		// never outlives the token itself.
+		if exp := tok.Expiration(); !exp.IsZero() {
+			remaining := time.Until(exp) + token.ClockSkewLeeway
+			if remaining <= 0 {
+				log.Warningln("Rejecting expired token")
+				return nil
+			}
+			if remaining < tokenAuthzTTL {
+				ttl = remaining
+			}
+		}
 	}
 
 	// Extract user information from the token at cache time (only once)
@@ -455,7 +480,7 @@ func (ac *authConfig) loader(cache *ttlcache.Cache[string, cachedTokenInfo], tok
 		UserInfo: userInfo,
 		Issuer:   issuer,
 	}
-	item := cache.Set(tokenStr, info, ttlcache.DefaultTTL)
+	item := cache.Set(tokenStr, info, ttl)
 	return item
 }
 

--- a/origin_serve/authz.go
+++ b/origin_serve/authz.go
@@ -206,7 +206,10 @@ func (ac *authConfig) updateConfig(exports []server_utils.OriginExport) error {
 	return nil
 }
 
-func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.ResourceScope, issuer string, err error) {
+// getResourceScopes verifies the token and returns the scopes it carries, its
+// issuer, and its expiration.  The expiration comes from the verified token so
+// that callers do not have to parse it a second time.
+func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.ResourceScope, issuer string, expiration time.Time, err error) {
 	if tokenStr == "" {
 		return
 	}
@@ -308,6 +311,7 @@ func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.
 		}
 	}
 
+	expiration = tok.Expiration()
 	scopes = token_scopes.ParseResourceScopeString(tok)
 
 	return
@@ -350,12 +354,12 @@ func (ac *authConfig) SetTokenHintHeaders(hdr http.Header, resource string) {
 }
 
 // Given a token, calculate the corresponding access control list
-func (ac *authConfig) getAcls(token string) (newAcls acls, err error) {
+func (ac *authConfig) getAcls(token string) (newAcls acls, issuer string, expiration time.Time, err error) {
 	exports := ac.exports.Load()
 	if exports == nil {
 		return
 	}
-	resources, issuer, err := ac.getResourceScopes(token)
+	resources, issuer, expiration, err := ac.getResourceScopes(token)
 	if err != nil {
 		return
 	}
@@ -404,32 +408,26 @@ func (ac *authConfig) getAcls(token string) (newAcls acls, err error) {
 }
 
 func (ac *authConfig) loader(cache *ttlcache.Cache[string, cachedTokenInfo], tokenStr string) *ttlcache.Item[string, cachedTokenInfo] {
-	acls, err := ac.getAcls(tokenStr)
+	acls, issuer, expiration, err := ac.getAcls(tokenStr)
 	if err != nil {
 		// If the token is not a valid one signed by a known issuer, do not keep it in memory (avoids a DoS)
 		log.Warningln("Rejecting invalid token:", err)
 		return nil
 	}
 
-	// Re-parse the claims to pick up the issuer (for logging) and the expiry.
-	// getAcls has already verified the token's signature and validity, so the
-	// claims can be trusted despite the unsafe parse.
-	issuer := ""
+	// Cap the cache entry's lifetime at the token's own expiry, plus the clock
+	// skew leeway the verifier grants, so the cached authorization never
+	// outlives the token itself.  The expiry comes from the token getAcls
+	// verified, so it needs no separate parse.
 	ttl := ttlcache.DefaultTTL
-	if tok, err := token.UnsafeParseClaims(tokenStr); err == nil {
-		issuer = tok.Issuer()
-		// Cap the cache entry's lifetime at the token's own expiry (plus the
-		// clock-skew leeway the verifier grants) so the cached authorization
-		// never outlives the token itself.
-		if exp := tok.Expiration(); !exp.IsZero() {
-			remaining := time.Until(exp) + token.ClockSkewLeeway
-			if remaining <= 0 {
-				log.Warningln("Rejecting expired token")
-				return nil
-			}
-			if remaining < tokenAuthzTTL {
-				ttl = remaining
-			}
+	if !expiration.IsZero() {
+		remaining := time.Until(expiration) + token.ClockSkewLeeway
+		if remaining <= 0 {
+			log.Warningln("Rejecting expired token")
+			return nil
+		}
+		if remaining < tokenAuthzTTL {
+			ttl = remaining
 		}
 	}
 

--- a/origin_serve/authz_test.go
+++ b/origin_serve/authz_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
@@ -663,6 +664,134 @@ func TestAudienceValidation(t *testing.T) {
 			assert.Equal(t, tt.authorized, authorized, "audience check should match expected result")
 		})
 	}
+}
+
+// newTestIssuerServer generates a signing key and starts an HTTP server that
+// publishes its public half via JWKS along with the OpenID discovery document.
+// It returns the signing key and the issuer URL.
+func newTestIssuerServer(t *testing.T) (jwk.Key, string) {
+	key := generateTestKey(t)
+	pubKey, err := key.PublicKey()
+	require.NoError(t, err)
+	require.NoError(t, pubKey.Set(jwk.KeyIDKey, "test-key"))
+	require.NoError(t, pubKey.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	jwks := jwk.NewSet()
+	require.NoError(t, jwks.AddKey(pubKey))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(jwks)
+		_, _ = w.Write(data)
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		cfg := map[string]interface{}{
+			"issuer":   "http://" + r.Host,
+			"jwks_uri": "http://" + r.Host + "/jwks",
+		}
+		data, _ := json.Marshal(cfg)
+		_, _ = w.Write(data)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return key, server.URL
+}
+
+// createTestTokenWithExpiration is like createTestToken but with an explicit
+// expiration time; the WLCG wildcard audience is always included.
+func createTestTokenWithExpiration(t *testing.T, key jwk.Key, issuer string, subject string, exp time.Time, scopes string) string {
+	tok, err := jwt.NewBuilder().
+		Issuer(issuer).
+		Subject(subject).
+		IssuedAt(time.Now().Add(-5*time.Minute)).
+		Expiration(exp).
+		Claim("scope", scopes).
+		Audience([]string{"https://wlcg.cern.ch/jwt/v1/any"}).
+		Build()
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, key))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// TestTokenAuthzCacheClampsToTokenExpiry verifies the fixes for issue #3696:
+// a cached authorization entry must not outlive the token that produced it,
+// and a cache read must not extend the entry's lifetime (touch-on-hit).
+func TestTokenAuthzCacheClampsToTokenExpiry(t *testing.T) {
+	key, issuerURL := newTestIssuerServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp := &errgroup.Group{}
+
+	exports := []server_utils.OriginExport{
+		{
+			FederationPrefix: "/data",
+			StoragePrefix:    "/tmp/data",
+			IssuerUrls:       []string{issuerURL},
+			Capabilities: server_structs.Capabilities{
+				Reads: true,
+			},
+		},
+	}
+	require.NoError(t, InitAuthConfig(ctx, egrp, exports))
+	ac := GetAuthConfig()
+
+	tokenLifetime := 30 * time.Second
+	now := time.Now()
+	tokenStr := createTestTokenWithExpiration(t, key, issuerURL, "alice", now.Add(tokenLifetime), "storage.read:/file.txt")
+
+	require.True(t, ac.authorize(token_scopes.Wlcg_Storage_Read, "/data/file.txt", tokenStr),
+		"a currently-valid token should authorize")
+
+	item := ac.tokenAuthz.Get(tokenStr)
+	require.NotNil(t, item)
+	maxExpiry := now.Add(tokenLifetime + token.ClockSkewLeeway + 10*time.Second)
+	assert.True(t, item.ExpiresAt().Before(maxExpiry),
+		"cache entry expiry %v should be clamped near the token's exp, not the default TTL", item.ExpiresAt())
+
+	// A read must not push the entry's expiry out.  Let the wall clock advance
+	// so that a touch-on-hit, if present, would produce a visibly later expiry.
+	firstExpiry := item.ExpiresAt()
+	time.Sleep(20 * time.Millisecond)
+	require.True(t, ac.authorize(token_scopes.Wlcg_Storage_Read, "/data/file.txt", tokenStr))
+	item = ac.tokenAuthz.Get(tokenStr)
+	require.NotNil(t, item)
+	assert.True(t, firstExpiry.Equal(item.ExpiresAt()),
+		"a cache read must not extend the entry's expiry (was %v, now %v)", firstExpiry, item.ExpiresAt())
+}
+
+// TestTokenAuthzRejectsExpiredToken verifies that a token whose exp is past
+// (beyond the verifier's clock-skew leeway) is denied and never cached.
+func TestTokenAuthzRejectsExpiredToken(t *testing.T) {
+	key, issuerURL := newTestIssuerServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp := &errgroup.Group{}
+
+	exports := []server_utils.OriginExport{
+		{
+			FederationPrefix: "/data",
+			StoragePrefix:    "/tmp/data",
+			IssuerUrls:       []string{issuerURL},
+			Capabilities: server_structs.Capabilities{
+				Reads: true,
+			},
+		},
+	}
+	require.NoError(t, InitAuthConfig(ctx, egrp, exports))
+	ac := GetAuthConfig()
+
+	tokenStr := createTestTokenWithExpiration(t, key, issuerURL, "alice",
+		time.Now().Add(-2*token.ClockSkewLeeway), "storage.read:/file.txt")
+
+	assert.False(t, ac.authorize(token_scopes.Wlcg_Storage_Read, "/data/file.txt", tokenStr),
+		"an expired token must not authorize")
+	assert.Nil(t, ac.tokenAuthz.Get(tokenStr), "an expired token must not be cached")
 }
 
 // BenchmarkPathPrefixCheck benchmarks path prefix validation

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -469,7 +469,7 @@ func authMiddleware() gin.HandlerFunc {
 		// not need scopes matching the origin's exports.
 		if disableDirectClients && federationCtx == nil && len(fedIssuers) > 0 {
 			for _, tok := range tokens {
-				_, issuer, fedErr := ac.getResourceScopes(tok)
+				_, issuer, _, fedErr := ac.getResourceScopes(tok)
 				if fedErr != nil {
 					continue
 				}

--- a/origin_serve/pstore_serving_test.go
+++ b/origin_serve/pstore_serving_test.go
@@ -41,7 +41,6 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -148,7 +147,7 @@ func newServedOrigin(t *testing.T, exports []server_utils.OriginExport, storageD
 	require.NotNil(t, ac)
 	for _, export := range exports {
 		for _, issuer := range export.IssuerUrls {
-			ac.issuerKeys.Set(issuer, authConfigItem{set: set}, ttlcache.DefaultTTL)
+			ac.issuerKeys.Set(issuer, set)
 		}
 	}
 

--- a/token/jwks_cache.go
+++ b/token/jwks_cache.go
@@ -20,6 +20,8 @@ package token
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -67,12 +69,13 @@ type JwksCache struct {
 type JwksUrlResolver func(ctx context.Context) (string, error)
 
 type jwksCacheOptions struct {
-	ttl          time.Duration
-	capacity     uint64
-	revalidate   time.Duration
-	maxStale     time.Duration
-	retry        time.Duration
-	fetchTimeout time.Duration
+	ttl           time.Duration
+	capacity      uint64
+	revalidate    time.Duration
+	maxStale      time.Duration
+	retry         time.Duration
+	fetchTimeout  time.Duration
+	dropOnAbsence bool
 }
 
 type JwksCacheOption func(*jwksCacheOptions)
@@ -113,6 +116,56 @@ func WithJwksFetchTimeout(d time.Duration) JwksCacheOption {
 	return func(o *jwksCacheOptions) { o.fetchTimeout = d }
 }
 
+// WithJwksDropOnAbsence makes the cache discard an issuer's keys when the
+// issuer is reachable and reports that they should not be used: HTTP 404 or
+// 410 (no such issuer) or 403 (known but not permitted).  Verification then
+// fails immediately rather than coasting on cached keys until the staleness
+// ceiling.
+//
+// Enable it only where those codes are known to mean revocation.  Pelican's
+// registry says exactly that: 404 for a namespace that is not registered, 403
+// for one whose approval has been withdrawn.  For a general OIDC issuer the
+// same codes are more likely to be a misconfigured proxy, and dropping keys
+// would turn that into an outage.
+//
+// The report has to be repeated before the keys are dropped, so that a single
+// bad response cannot revoke a namespace.
+func WithJwksDropOnAbsence() JwksCacheOption {
+	return func(o *jwksCacheOptions) { o.dropOnAbsence = true }
+}
+
+// JwksFetchError reports a JWKS endpoint that answered with something other
+// than a keyset.
+type JwksFetchError struct {
+	URL        string
+	StatusCode int
+}
+
+func (e *JwksFetchError) Error() string {
+	return fmt.Sprintf("JWKS endpoint %s returned HTTP %d", e.URL, e.StatusCode)
+}
+
+// IsAbsence reports whether the issuer is telling us these keys should not be
+// used, as opposed to being unable to answer.  A server that is reachable
+// enough to say "no such issuer" (404, 410) or "not permitted" (403) has given
+// a real answer; a timeout, a refused connection, or a 5xx has not.
+func (e *JwksFetchError) IsAbsence() bool {
+	switch e.StatusCode {
+	case http.StatusNotFound, http.StatusGone, http.StatusForbidden:
+		return true
+	}
+	return false
+}
+
+// absenceConfirmations is how many consecutive absence reports it takes to drop
+// an issuer's keys.  More than one, so that a single bad response from a
+// misconfigured or half-migrated registry cannot revoke a namespace.
+const absenceConfirmations = 2
+
+// maxJwksBytes bounds how much of a JWKS response is read, so a misbehaving or
+// hostile endpoint cannot feed unbounded data into the parser.
+const maxJwksBytes = 1 << 20
+
 const (
 	defaultJwksTTL          = time.Hour
 	defaultJwksRevalidate   = 15 * time.Minute
@@ -133,6 +186,10 @@ type jwksEntry struct {
 	set         jwk.Set
 	lastGood    time.Time
 	lastAttempt time.Time
+	// absences counts consecutive reports from the issuer that these keys
+	// should not be used.  Reset by anything else, so an outage in the middle
+	// of a run of them does not carry the count forward.
+	absences int
 }
 
 func (e *jwksEntry) keys() (jwk.Set, time.Time) {
@@ -160,6 +217,32 @@ func (e *jwksEntry) recordSuccess(url string, set jwk.Set) {
 	e.url = url
 	e.set = set
 	e.lastGood = time.Now()
+	e.absences = 0
+}
+
+// recordAbsence notes that the issuer reported these keys should not be used,
+// and reports how many such reports have arrived in a row.
+func (e *jwksEntry) recordAbsence() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.absences++
+	return e.absences
+}
+
+// clearAbsences forgets the run of absence reports, so that an unrelated
+// failure does not count toward dropping the keys.
+func (e *jwksEntry) clearAbsences() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.absences = 0
+}
+
+// dropKeys discards the cached keys, so the next lookup has to fetch.
+func (e *jwksEntry) dropKeys() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.set = nil
+	e.lastGood = time.Time{}
 }
 
 func (e *jwksEntry) resolvedUrl() string {
@@ -296,6 +379,39 @@ func (c *JwksCache) Set(key string, set jwk.Set) {
 	entry.recordSuccess(entry.resolvedUrl(), set)
 }
 
+// fetchJwks retrieves and parses a keyset.  It checks the HTTP status itself
+// rather than using jwk.Fetch, which does not: without that check a non-200
+// response reaches the parser and surfaces as a confusing parse failure, and
+// the status code that says whether the issuer actually answered is lost.
+func fetchJwks(ctx context.Context, url string) (jwk.Set, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build a request for %s", url)
+	}
+
+	client := &http.Client{Transport: config.GetBasicTransport()}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to reach %s", url)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &JwksFetchError{URL: url, StatusCode: resp.StatusCode}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxJwksBytes))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read the response from %s", url)
+	}
+
+	set, err := jwk.Parse(body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse the keyset from %s", url)
+	}
+	return set, nil
+}
+
 func (c *JwksCache) entry(key string) *jwksEntry {
 	item := c.entries.Get(key)
 	if item == nil {
@@ -327,10 +443,22 @@ func (c *JwksCache) fetch(ctx context.Context, key string, entry *jwksEntry, res
 			url = resolved
 		}
 
-		client := &http.Client{Transport: config.GetBasicTransport()}
-		set, err := jwk.Fetch(fetchCtx, url, jwk.WithHTTPClient(client))
+		set, err := fetchJwks(fetchCtx, url)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to fetch public keys for %s from %s", key, url)
+			var fetchErr *JwksFetchError
+			if errors.As(err, &fetchErr) && fetchErr.IsAbsence() {
+				// The issuer answered, and the answer is that these keys are
+				// not to be used.  Wait for it to say so more than once before
+				// acting, so one bad response cannot revoke an issuer.
+				if seen := entry.recordAbsence(); c.opts.dropOnAbsence && seen >= absenceConfirmations {
+					log.Warningf("Discarding cached public keys for %s: %v (reported %d times in a row)", key, err, seen)
+					entry.dropKeys()
+					c.entries.Delete(key)
+				}
+			} else {
+				entry.clearAbsences()
+			}
+			return nil, errors.Wrapf(err, "failed to fetch public keys for %s", key)
 		}
 		entry.recordSuccess(url, set)
 		log.Debugf("Fetched %d public key(s) for %s from %s", set.Len(), key, url)

--- a/token/jwks_cache.go
+++ b/token/jwks_cache.go
@@ -283,6 +283,19 @@ func (c *JwksCache) Refresh(ctx context.Context, key string, resolve JwksUrlReso
 	return c.fetch(ctx, key, entry, resolve)
 }
 
+// Set installs a keyset directly, as though it had just been fetched.  It is
+// for callers that obtain an issuer's keys through some channel other than an
+// HTTP fetch, and for tests that would otherwise have to stand up a JWKS
+// endpoint.  The keys age from here like any other, so they are revalidated
+// against the issuer once they pass the revalidate interval.
+func (c *JwksCache) Set(key string, set jwk.Set) {
+	entry := c.entry(key)
+	if entry == nil {
+		return
+	}
+	entry.recordSuccess(entry.resolvedUrl(), set)
+}
+
 func (c *JwksCache) entry(key string) *jwksEntry {
 	item := c.entries.Get(key)
 	if item == nil {

--- a/token/jwks_cache.go
+++ b/token/jwks_cache.go
@@ -32,6 +32,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
+	"golang.org/x/time/rate"
 
 	"github.com/pelicanplatform/pelican/config"
 )
@@ -62,6 +63,11 @@ type JwksCache struct {
 	opts    jwksCacheOptions
 	entries *ttlcache.Cache[string, *jwksEntry]
 	group   singleflight.Group
+	// limiter caps outbound fetches across all keys.  The per-key throttle
+	// does nothing against a caller that varies the key, so without this a
+	// stream of unknown issuers would become a stream of requests to whoever
+	// serves them.
+	limiter *rate.Limiter
 }
 
 // JwksUrlResolver returns the JWKS URL for a cache key.  It is called once per
@@ -76,6 +82,8 @@ type jwksCacheOptions struct {
 	retry         time.Duration
 	fetchTimeout  time.Duration
 	dropOnAbsence bool
+	fetchRate     float64
+	fetchBurst    int
 }
 
 type JwksCacheOption func(*jwksCacheOptions)
@@ -114,6 +122,17 @@ func WithJwksRetryInterval(d time.Duration) JwksCacheOption {
 // WithJwksFetchTimeout bounds a single JWKS fetch.
 func WithJwksFetchTimeout(d time.Duration) JwksCacheOption {
 	return func(o *jwksCacheOptions) { o.fetchTimeout = d }
+}
+
+// WithJwksFetchRate caps outbound fetches across all keys, in requests per
+// second with the given burst.  The per-key throttle bounds how often one
+// issuer is contacted; this bounds the total, which is what a caller that
+// varies the key would otherwise get around.
+func WithJwksFetchRate(perSecond float64, burst int) JwksCacheOption {
+	return func(o *jwksCacheOptions) {
+		o.fetchRate = perSecond
+		o.fetchBurst = burst
+	}
 }
 
 // WithJwksDropOnAbsence makes the cache discard an issuer's keys when the
@@ -171,6 +190,13 @@ const (
 	defaultJwksRevalidate   = 15 * time.Minute
 	defaultJwksRetry        = 30 * time.Second
 	defaultJwksFetchTimeout = 10 * time.Second
+
+	// A federation has tens of issuers in active use, each fetched a few times
+	// an hour, so these bind only on a caller working through issuers it has
+	// invented.  The burst covers a cold start where many issuers are looked up
+	// at once.
+	defaultJwksFetchRate  = 5
+	defaultJwksFetchBurst = 32
 
 	// defaultJwksMaxStale is deliberately long enough to ride out an issuer
 	// outage that starts on a Friday and is not looked at until Monday.
@@ -260,6 +286,8 @@ func NewJwksCache(ctx context.Context, egrp *errgroup.Group, options ...JwksCach
 		maxStale:     defaultJwksMaxStale,
 		retry:        defaultJwksRetry,
 		fetchTimeout: defaultJwksFetchTimeout,
+		fetchRate:    defaultJwksFetchRate,
+		fetchBurst:   defaultJwksFetchBurst,
 	}
 	for _, o := range options {
 		o(&opts)
@@ -289,6 +317,9 @@ func NewJwksCache(ctx context.Context, egrp *errgroup.Group, options ...JwksCach
 		ctx:     ctx,
 		opts:    opts,
 		entries: ttlcache.New(cacheOpts...),
+	}
+	if opts.fetchRate > 0 && opts.fetchBurst > 0 {
+		kc.limiter = rate.NewLimiter(rate.Limit(opts.fetchRate), opts.fetchBurst)
 	}
 
 	egrp.Go(func() error {
@@ -412,6 +443,21 @@ func fetchJwks(ctx context.Context, url string) (jwk.Set, error) {
 	return set, nil
 }
 
+// CanRefresh reports whether a refresh for this key would be attempted rather
+// than turned away by the throttle.  Callers use it to skip work they would
+// only do in order to decide whether to refresh; it is advisory, since the
+// throttle is re-checked when the fetch actually runs.
+func (c *JwksCache) CanRefresh(key string) bool {
+	item := c.entries.Get(key)
+	if item == nil || item.Value() == nil {
+		return true
+	}
+	entry := item.Value()
+	entry.mu.RLock()
+	defer entry.mu.RUnlock()
+	return entry.lastAttempt.IsZero() || time.Since(entry.lastAttempt) >= c.opts.retry
+}
+
 func (c *JwksCache) entry(key string) *jwksEntry {
 	item := c.entries.Get(key)
 	if item == nil {
@@ -426,6 +472,13 @@ func (c *JwksCache) entry(key string) *jwksEntry {
 func (c *JwksCache) fetch(ctx context.Context, key string, entry *jwksEntry, resolve JwksUrlResolver) (jwk.Set, error) {
 	ch := c.group.DoChan(key, func() (interface{}, error) {
 		if !entry.beginAttempt(c.opts.retry) {
+			return nil, nil
+		}
+		// Shed rather than queue: waiting here would let a caller working
+		// through invented issuers pile up goroutines, which is the thing the
+		// cap is for.  A caller that already has keys keeps serving them.
+		if c.limiter != nil && !c.limiter.Allow() {
+			log.Debugf("Skipping a key fetch for %s: the cache is at its fetch rate limit", key)
 			return nil, nil
 		}
 
@@ -451,9 +504,13 @@ func (c *JwksCache) fetch(ctx context.Context, key string, entry *jwksEntry, res
 				// not to be used.  Wait for it to say so more than once before
 				// acting, so one bad response cannot revoke an issuer.
 				if seen := entry.recordAbsence(); c.opts.dropOnAbsence && seen >= absenceConfirmations {
+					// Drop the keys but keep the entry: it carries the time of
+					// the last attempt, which is what stops a namespace that
+					// keeps being asked for, and keeps being reported absent,
+					// from producing a fetch per request.  The TTL reclaims it
+					// once the requests stop.
 					log.Warningf("Discarding cached public keys for %s: %v (reported %d times in a row)", key, err, seen)
 					entry.dropKeys()
-					c.entries.Delete(key)
 				}
 			} else {
 				entry.clearAbsences()

--- a/token/jwks_cache.go
+++ b/token/jwks_cache.go
@@ -1,0 +1,345 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package token
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/pelicanplatform/pelican/config"
+)
+
+// JwksCache caches the public keys of remote issuers.  Callers key it by
+// whatever identifies the issuer to them (a namespace prefix, an issuer URL)
+// and supply a resolver that turns that key into a JWKS URL; the resolver runs
+// once per cached entry.
+//
+// The cache is built around two bounds that callers can reason about:
+//
+//   - Keys are re-fetched once they are older than the revalidate interval, so
+//     that is the routine upper bound on how long a key rotation goes
+//     unnoticed.  Revalidation happens out of band: the request that notices
+//     the keys are stale is served from the existing set rather than made to
+//     wait for the network.
+//   - Keys are served through a fetch failure, so an unreachable issuer does
+//     not break verification for issuers already in use, but only up to the
+//     maximum staleness.  Past that the cache fails closed rather than keep
+//     trusting keys it has not been able to confirm.
+//
+// Fetch attempts for one key are throttled and collapsed, so neither a down
+// issuer nor a burst of concurrent requests turns into a burst of outbound
+// requests.  Nothing here starts a goroutine per cached issuer: an entry holds
+// a keyset and some timestamps, so evicting one actually reclaims it.
+type JwksCache struct {
+	ctx     context.Context
+	opts    jwksCacheOptions
+	entries *ttlcache.Cache[string, *jwksEntry]
+	group   singleflight.Group
+}
+
+// JwksUrlResolver returns the JWKS URL for a cache key.  It is called once per
+// entry, on the first fetch, and may perform I/O (e.g. OIDC discovery).
+type JwksUrlResolver func(ctx context.Context) (string, error)
+
+type jwksCacheOptions struct {
+	ttl          time.Duration
+	capacity     uint64
+	revalidate   time.Duration
+	maxStale     time.Duration
+	retry        time.Duration
+	fetchTimeout time.Duration
+}
+
+type JwksCacheOption func(*jwksCacheOptions)
+
+// WithJwksTTL bounds how long an unused entry is retained.  Entries still in
+// use are kept alive as they are read; this only reclaims idle ones.
+func WithJwksTTL(d time.Duration) JwksCacheOption {
+	return func(o *jwksCacheOptions) { o.ttl = d }
+}
+
+// WithJwksCapacity bounds how many issuers are tracked at once, evicting the
+// least recently used first.  Set this whenever the key is influenced by a
+// remote caller, so that unknown keys cannot grow the cache without limit.
+func WithJwksCapacity(n uint64) JwksCacheOption {
+	return func(o *jwksCacheOptions) { o.capacity = n }
+}
+
+// WithJwksRevalidateInterval sets how old a keyset may become before it is
+// refreshed out of band.
+func WithJwksRevalidateInterval(d time.Duration) JwksCacheOption {
+	return func(o *jwksCacheOptions) { o.revalidate = d }
+}
+
+// WithJwksMaxStaleness sets the ceiling on serving keys that could not be
+// re-fetched.  Past it, Keys fails instead of returning the cached set.
+func WithJwksMaxStaleness(d time.Duration) JwksCacheOption {
+	return func(o *jwksCacheOptions) { o.maxStale = d }
+}
+
+// WithJwksRetryInterval sets the minimum spacing between fetch attempts for a
+// single key.
+func WithJwksRetryInterval(d time.Duration) JwksCacheOption {
+	return func(o *jwksCacheOptions) { o.retry = d }
+}
+
+// WithJwksFetchTimeout bounds a single JWKS fetch.
+func WithJwksFetchTimeout(d time.Duration) JwksCacheOption {
+	return func(o *jwksCacheOptions) { o.fetchTimeout = d }
+}
+
+const (
+	defaultJwksTTL          = time.Hour
+	defaultJwksRevalidate   = 15 * time.Minute
+	defaultJwksRetry        = 30 * time.Second
+	defaultJwksFetchTimeout = 10 * time.Second
+
+	// defaultJwksMaxStale is deliberately long enough to ride out an issuer
+	// outage that starts on a Friday and is not looked at until Monday.
+	defaultJwksMaxStale = 72 * time.Hour
+)
+
+// jwksEntry holds one issuer's keys.  lastGood records successful fetches only,
+// which is what bounds staleness; lastAttempt records every attempt, including
+// failures, which is what throttles retries.
+type jwksEntry struct {
+	mu          sync.RWMutex
+	url         string
+	set         jwk.Set
+	lastGood    time.Time
+	lastAttempt time.Time
+}
+
+func (e *jwksEntry) keys() (jwk.Set, time.Time) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.set, e.lastGood
+}
+
+// beginAttempt records a fetch attempt unless one happened too recently,
+// reporting whether the caller should proceed.  Checking and stamping under one
+// lock keeps two callers from both deciding to fetch.
+func (e *jwksEntry) beginAttempt(retry time.Duration) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.lastAttempt.IsZero() && time.Since(e.lastAttempt) < retry {
+		return false
+	}
+	e.lastAttempt = time.Now()
+	return true
+}
+
+func (e *jwksEntry) recordSuccess(url string, set jwk.Set) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.url = url
+	e.set = set
+	e.lastGood = time.Now()
+}
+
+func (e *jwksEntry) resolvedUrl() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.url
+}
+
+// NewJwksCache builds a key cache.  The context bounds the lifetime of the
+// cache and of every fetch it performs.
+func NewJwksCache(ctx context.Context, egrp *errgroup.Group, options ...JwksCacheOption) *JwksCache {
+	opts := jwksCacheOptions{
+		ttl:          defaultJwksTTL,
+		revalidate:   defaultJwksRevalidate,
+		maxStale:     defaultJwksMaxStale,
+		retry:        defaultJwksRetry,
+		fetchTimeout: defaultJwksFetchTimeout,
+	}
+	for _, o := range options {
+		o(&opts)
+	}
+
+	cacheOpts := []ttlcache.Option[string, *jwksEntry]{
+		ttlcache.WithTTL[string, *jwksEntry](opts.ttl),
+		// Touch-on-hit stays enabled: an entry holds keys plus the time they
+		// were fetched, and staleness is enforced from those timestamps rather
+		// than from the entry's expiry.  Extending a busy entry therefore
+		// cannot prolong a stale key, while dropping one would discard the keys
+		// that let verification survive an issuer outage.
+		ttlcache.WithLoader[string, *jwksEntry](
+			ttlcache.NewSuppressedLoader[string, *jwksEntry](
+				ttlcache.LoaderFunc[string, *jwksEntry](
+					func(cache *ttlcache.Cache[string, *jwksEntry], key string) *ttlcache.Item[string, *jwksEntry] {
+						return cache.Set(key, &jwksEntry{}, ttlcache.DefaultTTL)
+					},
+				), nil),
+		),
+	}
+	if opts.capacity > 0 {
+		cacheOpts = append(cacheOpts, ttlcache.WithCapacity[string, *jwksEntry](opts.capacity))
+	}
+
+	kc := &JwksCache{
+		ctx:     ctx,
+		opts:    opts,
+		entries: ttlcache.New(cacheOpts...),
+	}
+
+	egrp.Go(func() error {
+		kc.entries.Start()
+		return nil
+	})
+	egrp.Go(func() error {
+		<-ctx.Done()
+		kc.entries.Stop()
+		kc.entries.DeleteAll()
+		return nil
+	})
+
+	return kc
+}
+
+// Keys returns the issuer's public keys, fetching them if they are not cached
+// and refreshing them once they age past the revalidate interval.  Cached keys
+// are returned through a fetch failure until they exceed the maximum staleness,
+// after which an error is returned instead.
+func (c *JwksCache) Keys(ctx context.Context, key string, resolve JwksUrlResolver) (jwk.Set, error) {
+	entry := c.entry(key)
+	if entry == nil {
+		return nil, errors.Errorf("failed to create a key cache entry for %s", key)
+	}
+
+	set, lastGood := entry.keys()
+	if set != nil && set.Len() > 0 {
+		age := time.Since(lastGood)
+		switch {
+		case age < c.opts.revalidate:
+			return set, nil
+		case age < c.opts.maxStale:
+			// Serve the keys we have and refresh behind the request, so a
+			// routine refresh never shows up as request latency.
+			go func() {
+				if _, err := c.fetch(c.ctx, key, entry, resolve); err != nil {
+					log.Debugf("Background key refresh for %s failed (serving keys fetched %v ago): %v",
+						key, age.Truncate(time.Second), err)
+				}
+			}()
+			return set, nil
+		}
+
+		// The keys are older than we are willing to trust.  Try once more, and
+		// refuse to hand them out if that does not work.
+		fresh, err := c.fetch(ctx, key, entry, resolve)
+		if err == nil && fresh != nil {
+			return fresh, nil
+		}
+		return nil, errors.Errorf("refusing to use public keys for %s: the last successful refresh was %v ago, over the %v limit",
+			key, age.Truncate(time.Second), c.opts.maxStale)
+	}
+
+	fresh, err := c.fetch(ctx, key, entry, resolve)
+	if err != nil {
+		return nil, err
+	}
+	if fresh == nil {
+		return nil, errors.Errorf("no public keys cached for %s and the last fetch attempt was too recent to retry", key)
+	}
+	return fresh, nil
+}
+
+// Refresh fetches an issuer's keys out of band, subject to the same throttle as
+// any other attempt.  It returns nil without error when the throttle suppressed
+// the fetch, and leaves the cached keys in place when the fetch fails.  Use it
+// when something suggests the cached keys are out of date before they are due
+// for revalidation, such as a token naming an unknown key ID.
+func (c *JwksCache) Refresh(ctx context.Context, key string, resolve JwksUrlResolver) (jwk.Set, error) {
+	entry := c.entry(key)
+	if entry == nil {
+		return nil, errors.Errorf("failed to create a key cache entry for %s", key)
+	}
+	return c.fetch(ctx, key, entry, resolve)
+}
+
+func (c *JwksCache) entry(key string) *jwksEntry {
+	item := c.entries.Get(key)
+	if item == nil {
+		return nil
+	}
+	return item.Value()
+}
+
+// fetch retrieves the issuer's keys, collapsing concurrent callers for the same
+// key into one request.  It returns a nil set, and no error, when the throttle
+// suppressed the attempt.
+func (c *JwksCache) fetch(ctx context.Context, key string, entry *jwksEntry, resolve JwksUrlResolver) (jwk.Set, error) {
+	ch := c.group.DoChan(key, func() (interface{}, error) {
+		if !entry.beginAttempt(c.opts.retry) {
+			return nil, nil
+		}
+
+		// Fetches are shared between callers, so they run under the cache's
+		// context rather than any one request's.
+		fetchCtx, cancel := context.WithTimeout(c.ctx, c.opts.fetchTimeout)
+		defer cancel()
+
+		url := entry.resolvedUrl()
+		if url == "" {
+			resolved, err := resolve(fetchCtx)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to determine the JWKS URL for %s", key)
+			}
+			url = resolved
+		}
+
+		client := &http.Client{Transport: config.GetBasicTransport()}
+		set, err := jwk.Fetch(fetchCtx, url, jwk.WithHTTPClient(client))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch public keys for %s from %s", key, url)
+		}
+		entry.recordSuccess(url, set)
+		log.Debugf("Fetched %d public key(s) for %s from %s", set.Len(), key, url)
+		return set, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		// The caller went away; any fetch already in flight continues for
+		// whoever else is waiting on it.
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		if res.Val == nil {
+			return nil, nil
+		}
+		set, ok := res.Val.(jwk.Set)
+		if !ok {
+			return nil, errors.Errorf("key cache returned an unexpected type for %s", key)
+		}
+		return set, nil
+	}
+}

--- a/token/jwks_cache_test.go
+++ b/token/jwks_cache_test.go
@@ -44,6 +44,7 @@ type jwksServer struct {
 	mu      sync.Mutex
 	keys    jwk.Set
 	down    bool
+	status  int
 	fetches int
 	server  *httptest.Server
 }
@@ -56,6 +57,12 @@ func newJwksServer(t *testing.T) *jwksServer {
 		s.fetches++
 		if s.down {
 			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if s.status != 0 {
+			// Mimic the registry, which answers with a JSON error document.
+			w.WriteHeader(s.status)
+			_, _ = w.Write([]byte(`{"status":"error","msg":"namespace prefix was not found"}`))
 			return
 		}
 		data, err := json.Marshal(s.keys)
@@ -92,6 +99,15 @@ func (s *jwksServer) setDown(down bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.down = down
+}
+
+// setStatus makes the server answer every request with the given status,
+// standing in for a registry reporting that a namespace is unregistered (404)
+// or no longer approved (403).  Zero restores normal service.
+func (s *jwksServer) setStatus(code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = code
 }
 
 func (s *jwksServer) fetchCount() int {
@@ -271,6 +287,128 @@ func TestJwksCache_EvictsLeastRecentlyUsed(t *testing.T) {
 		require.NoError(t, err)
 	}
 	assert.LessOrEqual(t, kc.entries.Len(), 2, "the cache must not grow past its capacity")
+}
+
+// TestJwksCache_DropsKeysWhenIssuerReportsAbsence verifies that an issuer which
+// is reachable and says the keys should not be used causes them to be
+// discarded, rather than served until the staleness ceiling.  This is how a
+// de-registered or de-approved namespace stops verifying promptly.
+func TestJwksCache_DropsKeysWhenIssuerReportsAbsence(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusGone, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			issuer := newJwksServer(t)
+			issuer.rotateTo(t, "key-1")
+			kc := newTestJwksCache(t,
+				WithJwksDropOnAbsence(),
+				WithJwksRevalidateInterval(0), // always due for revalidation
+				WithJwksRetryInterval(0),
+			)
+
+			_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+			require.NoError(t, err)
+
+			issuer.setStatus(status)
+
+			// Each read serves the cached keys and revalidates behind it, so the
+			// keys drop once the issuer has repeated itself.
+			require.Eventually(t, func() bool {
+				_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+				return err != nil
+			}, 5*time.Second, 10*time.Millisecond, "keys should stop being served once the issuer reports them absent")
+		})
+	}
+}
+
+// TestJwksCache_KeepsKeysOnSingleAbsence verifies that one bad response does not
+// revoke an issuer: a registry that 404s once and then recovers should leave
+// verification undisturbed.
+func TestJwksCache_KeepsKeysOnSingleAbsence(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t,
+		WithJwksDropOnAbsence(),
+		WithJwksRetryInterval(0),
+	)
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+
+	// One absence, then the issuer is healthy again.
+	issuer.setStatus(http.StatusNotFound)
+	_, err = kc.Refresh(context.Background(), "issuer-a", issuer.resolver())
+	require.Error(t, err)
+	issuer.setStatus(0)
+
+	set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err, "a single absence must not discard the keys")
+	require.NotNil(t, set)
+	_, found := set.LookupKeyID("key-1")
+	assert.True(t, found)
+}
+
+// TestJwksCache_KeepsKeysWhenIssuerCannotAnswer verifies that the drop applies
+// only to real answers: an issuer that is down, however many times, leaves the
+// cached keys in place.
+func TestJwksCache_KeepsKeysWhenIssuerCannotAnswer(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t,
+		WithJwksDropOnAbsence(),
+		WithJwksRetryInterval(0),
+	)
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+
+	issuer.setDown(true)
+	for i := 0; i < 5; i++ {
+		_, err = kc.Refresh(context.Background(), "issuer-a", issuer.resolver())
+		require.Error(t, err)
+	}
+
+	set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err, "an unreachable issuer must not discard the keys")
+	require.NotNil(t, set)
+	_, found := set.LookupKeyID("key-1")
+	assert.True(t, found)
+}
+
+// TestJwksCache_AbsenceIgnoredWithoutOption verifies that the drop is opt-in:
+// without it, a 404 is just another failed fetch and the keys keep serving.
+func TestJwksCache_AbsenceIgnoredWithoutOption(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t, WithJwksRetryInterval(0))
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+
+	issuer.setStatus(http.StatusNotFound)
+	for i := 0; i < 5; i++ {
+		_, err = kc.Refresh(context.Background(), "issuer-a", issuer.resolver())
+		require.Error(t, err)
+	}
+
+	set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err, "without the option, keys should still be served")
+	require.NotNil(t, set)
+}
+
+// TestJwksCache_ReportsHttpStatus verifies that a non-200 response is reported
+// as such, rather than reaching the parser and surfacing as a parse failure.
+func TestJwksCache_ReportsHttpStatus(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	issuer.setStatus(http.StatusNotFound)
+	kc := newTestJwksCache(t, WithJwksRetryInterval(0))
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.Error(t, err)
+
+	var fetchErr *JwksFetchError
+	require.ErrorAs(t, err, &fetchErr)
+	assert.Equal(t, http.StatusNotFound, fetchErr.StatusCode)
+	assert.True(t, fetchErr.IsAbsence())
 }
 
 // TestJwksCache_ResolverFailure verifies that a resolver error is reported and

--- a/token/jwks_cache_test.go
+++ b/token/jwks_cache_test.go
@@ -1,0 +1,292 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package token
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// jwksServer is a stand-in issuer whose keys can be rotated and which can be
+// taken down, counting the requests it serves.
+type jwksServer struct {
+	mu      sync.Mutex
+	keys    jwk.Set
+	down    bool
+	fetches int
+	server  *httptest.Server
+}
+
+func newJwksServer(t *testing.T) *jwksServer {
+	s := &jwksServer{keys: jwk.NewSet()}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.fetches++
+		if s.down {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		data, err := json.Marshal(s.keys)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *jwksServer) rotateTo(t *testing.T, kid string) {
+	privEC, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	priv, err := jwk.FromRaw(privEC)
+	require.NoError(t, err)
+	pub, err := priv.PublicKey()
+	require.NoError(t, err)
+	require.NoError(t, pub.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, pub.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(pub))
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys = set
+}
+
+func (s *jwksServer) setDown(down bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.down = down
+}
+
+func (s *jwksServer) fetchCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fetches
+}
+
+func (s *jwksServer) resolver() JwksUrlResolver {
+	return func(context.Context) (string, error) { return s.server.URL, nil }
+}
+
+// newTestJwksCache builds a cache whose goroutines are cleaned up with the test.
+func newTestJwksCache(t *testing.T, options ...JwksCacheOption) *JwksCache {
+	ctx, cancel := context.WithCancel(context.Background())
+	egrp, ctx := errgroup.WithContext(ctx)
+	t.Cleanup(func() {
+		cancel()
+		_ = egrp.Wait()
+	})
+	return NewJwksCache(ctx, egrp, options...)
+}
+
+func TestJwksCache_FetchesAndCaches(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t)
+
+	set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+	require.NotNil(t, set)
+	_, found := set.LookupKeyID("key-1")
+	assert.True(t, found)
+	assert.Equal(t, 1, issuer.fetchCount())
+
+	// A second read inside the revalidate window is served from cache.
+	set, err = kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+	require.NotNil(t, set)
+	assert.Equal(t, 1, issuer.fetchCount(), "a cached keyset should not be re-fetched")
+}
+
+// TestJwksCache_ServesThroughOutage verifies that an issuer going down does not
+// break verification for keys already cached.
+func TestJwksCache_ServesThroughOutage(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t)
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+	fetches := issuer.fetchCount()
+
+	issuer.setDown(true)
+	for i := 0; i < 3; i++ {
+		set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+		require.NoError(t, err, "an outage must not break an issuer whose keys are cached")
+		_, found := set.LookupKeyID("key-1")
+		assert.True(t, found)
+	}
+	assert.Equal(t, fetches, issuer.fetchCount(), "serving cached keys should not contact the issuer")
+}
+
+// TestJwksCache_FailsClosedPastMaxStaleness verifies the ceiling: once the keys
+// are older than the limit and cannot be refreshed, they are no longer served.
+func TestJwksCache_FailsClosedPastMaxStaleness(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	// Everything is immediately stale, so the next read must revalidate.
+	kc := newTestJwksCache(t,
+		WithJwksRevalidateInterval(0),
+		WithJwksMaxStaleness(0),
+		WithJwksRetryInterval(0),
+	)
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+
+	issuer.setDown(true)
+	_, err = kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.Error(t, err, "keys past the staleness ceiling must not be served")
+	assert.Contains(t, err.Error(), "refusing to use public keys")
+
+	// Once the issuer is reachable again the keys are usable.
+	issuer.setDown(false)
+	set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+	require.NotNil(t, set)
+}
+
+// TestJwksCache_RevalidatesInBackground verifies that a stale-but-usable keyset
+// is served immediately while a refresh happens out of band.
+func TestJwksCache_RevalidatesInBackground(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t,
+		WithJwksRevalidateInterval(0), // always due for revalidation
+		WithJwksRetryInterval(0),
+	)
+
+	set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+	_, found := set.LookupKeyID("key-1")
+	require.True(t, found)
+
+	issuer.rotateTo(t, "key-2")
+
+	// The read is served from the cached set; the refresh happens behind it.
+	set, err = kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+	require.NotNil(t, set)
+
+	require.Eventually(t, func() bool {
+		set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+		if err != nil {
+			return false
+		}
+		_, found := set.LookupKeyID("key-2")
+		return found
+	}, 5*time.Second, 10*time.Millisecond, "the rotated key should be picked up by the background refresh")
+}
+
+// TestJwksCache_ThrottlesAttempts verifies that a down issuer is not contacted
+// once per request.
+func TestJwksCache_ThrottlesAttempts(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.setDown(true)
+	kc := newTestJwksCache(t, WithJwksRetryInterval(time.Hour))
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.Error(t, err)
+	assert.Equal(t, 1, issuer.fetchCount())
+
+	for i := 0; i < 5; i++ {
+		_, err = kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+		require.Error(t, err)
+	}
+	assert.Equal(t, 1, issuer.fetchCount(), "repeated requests must not each contact a down issuer")
+}
+
+// TestJwksCache_CollapsesConcurrentFetches verifies that a burst of concurrent
+// requests for an uncached issuer produces one outbound fetch.
+func TestJwksCache_CollapsesConcurrentFetches(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t, WithJwksRetryInterval(0))
+
+	var wg sync.WaitGroup
+	errs := make([]error, 16)
+	start := make(chan struct{})
+	for i := 0; i < len(errs); i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "concurrent caller %d", i)
+	}
+	assert.Equal(t, 1, issuer.fetchCount(), "concurrent misses should collapse into one fetch")
+}
+
+// TestJwksCache_EvictsLeastRecentlyUsed verifies the capacity bound, which is
+// what keeps caller-influenced keys from growing the cache without limit.
+func TestJwksCache_EvictsLeastRecentlyUsed(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t, WithJwksCapacity(2), WithJwksRetryInterval(0))
+
+	for _, key := range []string{"a", "b", "c"} {
+		_, err := kc.Keys(context.Background(), key, issuer.resolver())
+		require.NoError(t, err)
+	}
+	assert.LessOrEqual(t, kc.entries.Len(), 2, "the cache must not grow past its capacity")
+}
+
+// TestJwksCache_ResolverFailure verifies that a resolver error is reported and
+// does not poison the entry against a later attempt.
+func TestJwksCache_ResolverFailure(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t, WithJwksRetryInterval(0))
+
+	failing := func(context.Context) (string, error) {
+		return "", errors.New("discovery unavailable")
+	}
+	_, err := kc.Keys(context.Background(), "issuer-a", failing)
+	require.Error(t, err)
+
+	set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err, "a later attempt should succeed once the URL resolves")
+	require.NotNil(t, set)
+}

--- a/token/jwks_cache_test.go
+++ b/token/jwks_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -295,6 +296,57 @@ func TestJwksCache_ThrottlesAttempts(t *testing.T) {
 		require.Error(t, err)
 	}
 	assert.Equal(t, 1, issuer.fetchCount(), "repeated requests must not each contact a down issuer")
+}
+
+// TestJwksCache_CapsFetchesAcrossKeys verifies the bound that matters against a
+// caller who varies the key: the per-key throttle does nothing there, so the
+// cache limits fetches in aggregate.
+func TestJwksCache_CapsFetchesAcrossKeys(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t,
+		WithJwksRetryInterval(0), // per-key throttle disabled; only the cap is left
+		WithJwksFetchRate(1, 4),
+	)
+
+	// Every key is new, so each lookup would fetch if nothing capped it.
+	for i := 0; i < 50; i++ {
+		_, _ = kc.Keys(context.Background(), fmt.Sprintf("issuer-%d", i), issuer.resolver())
+	}
+
+	assert.LessOrEqual(t, issuer.fetchCount(), 8,
+		"a run of unknown issuers should not become a run of fetches (saw %d)", issuer.fetchCount())
+}
+
+// TestJwksCache_AbsenceKeepsThrottleState verifies that discarding keys does not
+// discard the record of when the issuer was last asked.  Losing it would let a
+// namespace that is being requested constantly, and reported absent every time,
+// produce a fetch per request.
+func TestJwksCache_AbsenceKeepsThrottleState(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t, WithJwksDropOnAbsence(), WithJwksRetryInterval(0))
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+
+	// Two absences discard the keys.
+	issuer.setStatus(http.StatusNotFound)
+	for i := 0; i < 2; i++ {
+		_, err = kc.Refresh(context.Background(), "issuer-a", issuer.resolver())
+		require.Error(t, err)
+	}
+
+	// From here the throttle should govern, so a burst of lookups for the same
+	// namespace must not each contact the issuer.
+	kc.opts.retry = time.Hour
+	before := issuer.fetchCount()
+	for i := 0; i < 10; i++ {
+		_, err = kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+		require.Error(t, err, "the namespace has no usable keys")
+	}
+	assert.Equal(t, before, issuer.fetchCount(),
+		"dropping keys must not reset the throttle and let every request fetch")
 }
 
 // TestJwksCache_CollapsesConcurrentFetches verifies that a burst of concurrent

--- a/token/jwks_cache_test.go
+++ b/token/jwks_cache_test.go
@@ -45,6 +45,7 @@ type jwksServer struct {
 	keys    jwk.Set
 	down    bool
 	status  int
+	delay   time.Duration
 	fetches int
 	server  *httptest.Server
 }
@@ -52,21 +53,32 @@ type jwksServer struct {
 func newJwksServer(t *testing.T) *jwksServer {
 	s := &jwksServer{keys: jwk.NewSet()}
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Snapshot the state and release the lock before answering, so a
+		// deliberately slow response does not block the test's own accessors.
 		s.mu.Lock()
-		defer s.mu.Unlock()
 		s.fetches++
-		if s.down {
+		down, status, delay := s.down, s.status, s.delay
+		var data []byte
+		var marshalErr error
+		if !down && status == 0 {
+			data, marshalErr = json.Marshal(s.keys)
+		}
+		s.mu.Unlock()
+
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		if down {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		if s.status != 0 {
+		if status != 0 {
 			// Mimic the registry, which answers with a JSON error document.
-			w.WriteHeader(s.status)
+			w.WriteHeader(status)
 			_, _ = w.Write([]byte(`{"status":"error","msg":"namespace prefix was not found"}`))
 			return
 		}
-		data, err := json.Marshal(s.keys)
-		if err != nil {
+		if marshalErr != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -108,6 +120,13 @@ func (s *jwksServer) setStatus(code int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.status = code
+}
+
+// setDelay makes every response take at least d, standing in for a slow issuer.
+func (s *jwksServer) setDelay(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.delay = d
 }
 
 func (s *jwksServer) fetchCount() int {
@@ -228,6 +247,36 @@ func TestJwksCache_RevalidatesInBackground(t *testing.T) {
 		_, found := set.LookupKeyID("key-2")
 		return found
 	}, 5*time.Second, 10*time.Millisecond, "the rotated key should be picked up by the background refresh")
+}
+
+// TestJwksCache_RevalidationDoesNotBlockCallers verifies that revalidation
+// happens behind the request rather than in front of it: once keys are cached,
+// no lookup waits on the issuer, however slow it is.  Only a cold lookup, with
+// nothing cached to serve, pays for the fetch.
+func TestJwksCache_RevalidationDoesNotBlockCallers(t *testing.T) {
+	issuer := newJwksServer(t)
+	issuer.rotateTo(t, "key-1")
+	kc := newTestJwksCache(t,
+		WithJwksRevalidateInterval(0), // always due for revalidation
+		WithJwksRetryInterval(0),
+	)
+
+	_, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+	require.NoError(t, err)
+
+	// From here on the issuer is slow enough that waiting on it would be
+	// obvious in the timings below.
+	issuer.setDelay(500 * time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		start := time.Now()
+		set, err := kc.Keys(context.Background(), "issuer-a", issuer.resolver())
+		elapsed := time.Since(start)
+		require.NoError(t, err)
+		require.NotNil(t, set)
+		assert.Less(t, elapsed, 100*time.Millisecond,
+			"a lookup with keys cached should not wait on the issuer (took %v)", elapsed)
+	}
 }
 
 // TestJwksCache_ThrottlesAttempts verifies that a down issuer is not contacted

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -85,6 +85,17 @@ var (
 	registeredServerJWKSResolver atomic.Pointer[RegisteredServerJWKSResolver]
 )
 
+// Verification fails for two quite different reasons, and callers sometimes
+// need to tell them apart: a signature that does not check out may mean the
+// signing key is one we have not seen, and is worth re-reading the issuer's
+// keys over, while a rejected claim (expired, wrong audience, insufficient
+// scope) says nothing about the keys.  Wrap both so errors.Is can distinguish
+// them without matching on message text.
+var (
+	ErrTokenSignature = errors_default.New("failed to verify token signature")
+	ErrTokenClaims    = errors_default.New("failed to validate token claims")
+)
+
 func init() {
 	authChecker = &AuthCheckImpl{}
 }
@@ -326,7 +337,7 @@ func UnsafeParseClaims(tokenStr string) (jwt.Token, error) {
 func VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
 	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to verify token signature")
+		return nil, fmt.Errorf("%w: %w", ErrTokenSignature, err)
 	}
 	validateOpts := make([]jwt.ValidateOption, 0, len(opts)+3)
 	validateOpts = append(validateOpts, opts...)
@@ -336,7 +347,7 @@ func VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateO
 		jwt.WithAcceptableSkew(0),
 	)
 	if err := jwt.Validate(tok, validateOpts...); err != nil {
-		return nil, errors.Wrap(err, "failed to validate token claims")
+		return nil, fmt.Errorf("%w: %w", ErrTokenClaims, err)
 	}
 	return tok, nil
 }
@@ -352,7 +363,7 @@ func VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateO
 func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
 	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to verify token signature")
+		return nil, fmt.Errorf("%w: %w", ErrTokenSignature, err)
 	}
 	// Build the final option slice with a defensive copy
 	// to avoid mutating the caller's backing array.
@@ -364,7 +375,7 @@ func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption)
 		jwt.WithAcceptableSkew(ClockSkewLeeway),
 	)
 	if err := jwt.Validate(tok, validateOpts...); err != nil {
-		return nil, errors.Wrap(err, "failed to validate token claims")
+		return nil, fmt.Errorf("%w: %w", ErrTokenClaims, err)
 	}
 	return tok, nil
 }


### PR DESCRIPTION
Fixes #3696

## Origin and local cache: expired tokens kept working

Both cache token authorization in a ttlcache keyed by the raw token string, and neither passed `WithDisableTouchOnHit`. Signature and `exp` are checked only in the cache loader, which runs on a miss, so every cache read pushed the entry's expiry out by another TTL. A client that presented its token at least once every 5 minutes was never re-validated, and the token kept authorizing after `exp` passed. There is no revocation list in Pelican; `exp` is the revocation mechanism.

Both caches now disable touch-on-hit. Each entry's TTL is also clamped to the token's own `exp` plus the clock skew leeway that `VerifyWithKeyset` already allows, so a token shorter-lived than the cache TTL is not honored past its expiry.

Affects origins on the v2 backends (`posixv2`, `ssh`, `s3v2`, `httpsv2`, `globusv2`, `pstore`) and the local cache. A default `posix` origin is fronted by XRootD and uses a different authorization path.

## Identity lookups: revoked group membership kept working

The user, group, and secondary GID caches in `CachedLookup` were missing the same option. The secondary GID list feeds `setgroups(2)` in the multiuser filesystem, so removing a user from a group had no effect for as long as that user stayed active. Negative lookups had the reverse problem: a client retrying more than once a minute kept a "no such user" result alive past the point the account was created, which is what the short negative TTL exists to avoid.

## JWKS caching: one implementation instead of three

Review turned up that issuer key caching was written five times across the tree, with different behavior and different bugs in each copy. `origin_serve` and `local_cache` were the same code twice. This adds one implementation in `token/` and moves the broker, origin, and local cache onto it. The director's copy and `token`'s own federation cache are left for a follow-up; the latter also has an unsynchronized lazy init worth fixing.

The shared cache is built around two bounds:

* Keys are re-fetched once they age past a revalidate interval, out of band, so the request that notices staleness is served from the cached set rather than waiting on the network. That interval is the routine bound on how long a key rotation goes unnoticed.
* Keys keep being served through fetch failures, so an unreachable registry does not break verification for issuers in use, but only up to 72h. Past that it fails closed. 72h so an outage that starts Friday evening does not take the federation down before someone looks at it Monday.

Fetches for one issuer are throttled and collapsed with singleflight, and the cache can be capacity-bounded.

Three real bugs fall out of the conversion:

* **A goroutine leak with an unauthenticated trigger.** `jwk.NewCache` starts five goroutines tied to the server context, not to the cache entry, so evicting an entry stopped nothing: every prefix ever queried kept polling the registry every 15 minutes for the life of the process, and the next request for it built another one. In the broker the cache key is the prefix from the request body, read before the caller's token is verified, so made-up prefixes could drive both goroutine growth and registry traffic. The shared cache holds a keyset and timestamps, so eviction actually reclaims. The broker's cache is also capacity-bounded now.
* **A namespace whose first fetch failed was never retried.** httprc stamps an entry as fetched before attempting it, so `Get` skipped the fetch from then on and returned nothing until the entry expired, which touch-on-hit could prevent indefinitely.
* **A down registry was contacted once per request**, with callers queuing behind each other's 10s fetch timeouts, since httprc serializes fetches per entry.

Two smaller ones: the rotated-key check moved to the verification-failure path, since it was parsing every token twice on the happy path; and `namespaceKeys` was read without synchronization while the shutdown goroutine cleared it.

## De-registration takes effect promptly

The registry answers 404 for a prefix that is not registered and 403 for one whose approval has been withdrawn — the two ways an administrator removes a service. Those were indistinguishable from the registry being unreachable, so removing a service took up to the 72h ceiling to have any effect on a namespace with traffic.

The cache now treats 403/404/410 as the issuer saying the keys should not be used, and discards them; everything else (timeouts, refused connections, 5xx) still means "cannot answer" and keeps serving the last known good keys. The report has to arrive twice in a row, so one bad response from a half-migrated registry cannot revoke a namespace. Revocation lands at the next revalidation, roughly 15 minutes rather than 72 hours.

This is opt-in and on for the broker only. For a general OIDC issuer those codes are more likely a misbehaving proxy than a revocation, and dropping keys would turn a misconfiguration into an outage.

Fetching also moved off `jwk.Fetch`, which does not check the HTTP status at all: a non-200 reached the parser and surfaced as a parse failure, discarding the status code that distinguishes an answer from an outage.

## Bounding what an unverified caller can make the broker do

The broker's cache key is the namespace prefix from the request body, read before the caller's token is verified, so it is worth being careful about what that can drive.

* The prefix is joined into the registry URL, and joining cleans the path, so `..` segments walked out of `/api/v1.0/registry/` and aimed the lookup elsewhere on the registry. It stayed on the registry's host and a token still had to be signed by whatever keys that path served, so it was not an impersonation route, but relative segments are now rejected. Prefixes are not required to be canonical otherwise, since a cache's prefix legitimately embeds a URL.
* The per-key throttle and singleflight group are both keyed by namespace, so neither helps against a caller varying the prefix: a run of invented prefixes was a run of registry fetches, one per prefix. Fetches are now capped in aggregate (5/s, burst 32 by default) and shed rather than queued, so attempts cannot pile up as goroutines.
* An unknown key ID is what makes the broker re-read a namespace's keys, so tokens with invented signing keys aimed straight at it. That path is bounded by the per-namespace throttle, and the check that leads to it now runs only on a signature failure (not on an expired token or a wrong audience, which say nothing about the keys) and only when the throttle would allow the re-read. `VerifyWithKeyset` gained sentinel errors so callers can tell the two failure kinds apart without matching message text.

Also: `namespaceKeys` is an atomic pointer rather than a mutex-guarded global, matching how `authConfig` holds its swapped-in state.

Separately, the authz loaders were re-parsing the token to read its expiry when `getResourceScopes` already had the verified token and threw it away — four parses per cache miss in `origin_serve`. The expiry is now returned from the verified token.

## Testing

Regression tests in all five packages, including the shared cache's bounds: serving through an outage, failing closed past the ceiling, background revalidation not blocking callers, throttling, aggregate rate capping, singleflight collapsing, and capacity eviction. For each fix I reverted it and confirmed the test fails. `token`, `broker`, and `identity` are clean under `-race`; the broker needed a one-line test fix to get there, in its own commit.

`origin_serve` and `local_cache` have 37 failing tests on this branch. The same 37 fail on `main` — they need a federation test environment this laptop does not have — and I diffed the two lists to confirm the sets are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
