### PR TITLE
Make a failing client command say why it failed

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,9 +36,23 @@ run:
 
 linters:
   enable:
+    - forbidigo
     - misspell
   disable:
     - staticcheck
+  settings:
+    forbidigo:
+      # Match against the resolved package, so a local variable named "os"
+      # cannot trip the rule and a dot-import cannot slip past it.
+      analyze-types: true
+      forbid:
+        - pattern: ^os\.Exit$
+          pkg: ^os$
+          msg: >-
+            os.Exit runs no defers, so the asynchronous log writer never drains
+            and the line explaining the exit is lost -- the process dies
+            silently. Use exitWithError/exitWithErrorf to report a fatal error,
+            or exitWithFlush when the message has already been reported.
   exclusions:
     generated: lax
     presets:
@@ -51,6 +65,15 @@ linters:
       - builtin$
       - examples$
       - reference$
+    rules:
+      # The os.Exit ban is about the CLI's log-writer drain, so it applies only
+      # to the command package. The one sanctioned call, inside exitWithFlush
+      # itself, carries a //nolint:forbidigo directive.
+      - linters: [forbidigo]
+        path-except: ^cmd/
+      # A test binary's own exit does not go through the CLI's shutdown path.
+      - linters: [forbidigo]
+        path: _test\.go$
 formatters:
   enable:
     - gofmt

--- a/cmd/config_mgr.go
+++ b/cmd/config_mgr.go
@@ -53,7 +53,7 @@ func printConfig(useJSON bool) {
 	config, err := config.GetCredentialConfigContents()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to get credential configuration contents:", err)
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	var config_b []byte
 	if useJSON {
@@ -63,7 +63,7 @@ func printConfig(useJSON bool) {
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to convert object to YAML:", err)
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	fmt.Println(string(config_b))
 }
@@ -88,14 +88,14 @@ func addConfigSubcommands(configCmd *cobra.Command) {
 			input_config_b, err := os.ReadFile(args[0])
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to read config file:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 
 			input_config := config.CredentialConfig{}
 			err = yaml.Unmarshal(input_config_b, &input_config)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to parse config file:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 
 			// Serialize the overwrite against any concurrent credential-file
@@ -105,7 +105,7 @@ func addConfigSubcommands(configCmd *cobra.Command) {
 			})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Unable to save replaced configuration file:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 		},
 	})
@@ -118,10 +118,10 @@ func addConfigSubcommands(configCmd *cobra.Command) {
 			err := config.ResetPassword()
 			if err != nil {
 				if handleIncorrectPassword(err, incorrectPasswordResetMessage) {
-					os.Exit(1)
+					exitWithFlush(1)
 				}
 				fmt.Fprintln(os.Stderr, "Failed to reset password:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 		},
 	})
@@ -133,7 +133,7 @@ func addConfigSubcommands(configCmd *cobra.Command) {
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := config.DeleteCredentials(); err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to delete local credentials:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 		},
 	})
@@ -143,14 +143,14 @@ func printOauthConfig() {
 	config, err := config.GetCredentialConfigContents()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to get configuration contents:", err)
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	fc := config.GetFederationCredentials(param.Federation_DiscoveryUrl.GetString())
 	clientList := &fc.OauthClient
 	config_b, err := yaml.Marshal(&clientList)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to convert object to YAML:", err)
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	fmt.Println(string(config_b))
 
@@ -173,7 +173,7 @@ func addTokenSubcommands(tokenCmd *cobra.Command) {
 
 			default:
 				fmt.Fprintln(os.Stderr, "Unknown value for operation type (must be 'read' or 'write')", args[0])
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 
 			pUrl, err := pelican_url.Parse(
@@ -183,12 +183,12 @@ func addTokenSubcommands(tokenCmd *cobra.Command) {
 			)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to parse URL:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 			dirResp, err := client.GetDirectorInfoForPath(cmd.Context(), pUrl, httpMethod, "")
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get director info for path:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 
 			opts := config.TokenGenerationOpts{
@@ -201,7 +201,7 @@ func addTokenSubcommands(tokenCmd *cobra.Command) {
 			token, err := client.AcquireToken(pUrl.GetRawUrl(), dirResp, opts)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get a token:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 
 			fmt.Println(token)
@@ -247,7 +247,7 @@ func addPrefixSubcommands(prefixCmd *cobra.Command) {
 			})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Unable to save configuration file:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 		},
 	})
@@ -260,7 +260,7 @@ func addPrefixSubcommands(prefixCmd *cobra.Command) {
 		Run: func(cmd *cobra.Command, args []string) {
 			if args[1] != "client_id" && args[1] != "client_secret" {
 				fmt.Fprintln(os.Stderr, "Unknown attribute to set:", args[1])
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 			// Hold the credential-file lock across the read-modify-write and
 			// re-read the wallet inside it.
@@ -288,11 +288,11 @@ func addPrefixSubcommands(prefixCmd *cobra.Command) {
 			})
 			if notPresent {
 				fmt.Fprintln(os.Stderr, "Prefix to set was not present")
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Unable to save configuration file:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 		},
 	})
@@ -325,7 +325,7 @@ func addPrefixSubcommands(prefixCmd *cobra.Command) {
 			})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Unable to save configuration file:", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 		},
 	})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,12 +21,16 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/logging"
+	"github.com/pelicanplatform/pelican/param"
 )
 
 // cliDispatchHook allows builds to handle special exec-name-based dispatch
@@ -72,7 +76,42 @@ func main() {
 func exitWithFlush(code int) {
 	logging.EnterSyncMode()
 	logging.FlushLogs(false)
-	os.Exit(code)
+	os.Exit(code) //nolint:forbidigo // the one place the process is allowed to exit
+}
+
+// reportError logs a message that explains a failing exit and, when
+// Logging.LogLocation sends the log to a file, also writes it to stderr.
+//
+// Without that mirror the terminal gets nothing at all -- the exit status is
+// the only signal -- because file logging redirects every level, including the
+// line explaining the failure. A line or two on the way out is not the log
+// spam that LogLocation exists to avoid; it is the part the user has to see.
+//
+// Arguments are formatted as by log.Errorln/fmt.Fprintln, so a call reads the
+// same as the log.Errorln it replaces. Use it for the lines leading up to an
+// exitWithError, which reports the final line itself.
+func reportError(args ...any) {
+	log.Errorln(args...)
+	if param.Logging_LogLocation.GetString() != "" {
+		fmt.Fprintln(os.Stderr, args...)
+	}
+}
+
+// reportErrorf is reportError with printf-style formatting.
+func reportErrorf(format string, args ...any) {
+	reportError(fmt.Sprintf(format, args...))
+}
+
+// exitWithError reports a fatal error and terminates with the given code.
+func exitWithError(code int, args ...any) {
+	reportError(args...)
+	exitWithFlush(code)
+}
+
+// exitWithErrorf is exitWithError with printf-style formatting.
+func exitWithErrorf(code int, format string, args ...any) {
+	reportError(fmt.Sprintf(format, args...))
+	exitWithFlush(code)
 }
 
 func handleCLI(args []string) error {

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -119,19 +119,18 @@ func copyMain(cmd *cobra.Command, args []string) {
 
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		} else {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
 	if val, err := cmd.Flags().GetBool("version"); err == nil && val {
 		config.PrintPelicanVersion(os.Stdout)
-		os.Exit(0)
+		exitWithFlush(0)
 	}
 
 	// Check for async mode
@@ -139,12 +138,12 @@ func copyMain(cmd *cobra.Command, args []string) {
 	if isAsync {
 		// Validate arguments
 		if len(args) < 2 {
-			log.Errorln("No Source or Destination")
+			reportError("No Source or Destination")
 			err = cmd.Help()
 			if err != nil {
 				log.Errorln("Failed to print out help:", err)
 			}
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		source := args[:len(args)-1]
 		dest := args[len(args)-1]
@@ -152,9 +151,8 @@ func copyMain(cmd *cobra.Command, args []string) {
 		// Ensure server is running, starting it if necessary
 		apiClient, err := ensureClientAgentRunning(cmd.Context(), 5)
 		if err != nil {
-			log.Errorln("Failed to ensure API server is running:", err)
-			log.Errorln("You can manually start it with 'pelican client-api serve --daemonize'")
-			os.Exit(1)
+			reportError("Failed to ensure API server is running:", err)
+			exitWithError(1, "You can manually start it with 'pelican client-api serve --daemonize'")
 		}
 
 		// Get flags for transfer options
@@ -164,8 +162,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 		// Get preferred caches
 		caches, err := getPreferredCaches()
 		if err != nil {
-			log.Errorln("Failed to get preferred caches:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to get preferred caches:", err)
 		}
 
 		// Convert caches to strings
@@ -202,16 +199,14 @@ func copyMain(cmd *cobra.Command, args []string) {
 			}
 			warmItems = append(warmItems, asyncWarmItem{url: dest, write: true})
 			if err := warmWalletForAsync(ctx, apiClient, warmItems); err != nil {
-				log.Errorln("Failed to prepare credentials for async transfer:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to prepare credentials for async transfer:", err)
 			}
 		}
 
 		// Create job
 		jobID, err := apiClient.CreateJob(ctx, transfers, options)
 		if err != nil {
-			log.Errorln("Failed to create job:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to create job:", err)
 		}
 
 		if outputJSON {
@@ -221,8 +216,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 			}
 			jsonBytes, err := json.MarshalIndent(result, "", "  ")
 			if err != nil {
-				log.Errorln("Failed to marshal JSON:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to marshal JSON:", err)
 			}
 			fmt.Println(string(jsonBytes))
 		} else {
@@ -239,22 +233,19 @@ func copyMain(cmd *cobra.Command, args []string) {
 			// Wait with a reasonable timeout (e.g., 1 hour)
 			err := apiClient.WaitForJob(ctx, jobID, 1*time.Hour)
 			if err != nil {
-				log.Errorln("Error waiting for job:", err)
-				os.Exit(1)
+				exitWithError(1, "Error waiting for job:", err)
 			}
 
 			// Get final status
 			finalStatus, err := apiClient.GetJobStatus(ctx, jobID)
 			if err != nil {
-				log.Errorln("Error getting final job status:", err)
-				os.Exit(1)
+				exitWithError(1, "Error getting final job status:", err)
 			}
 
 			if outputJSON {
 				jsonBytes, err := json.MarshalIndent(finalStatus, "", "  ")
 				if err != nil {
-					log.Errorln("Failed to marshal JSON:", err)
-					os.Exit(1)
+					exitWithError(1, "Failed to marshal JSON:", err)
 				}
 				fmt.Println(string(jsonBytes))
 			} else {
@@ -277,26 +268,24 @@ func copyMain(cmd *cobra.Command, args []string) {
 	transferServer, _ := cmd.Flags().GetString("transfer-server")
 	destOrigin, _ := cmd.Flags().GetString("dest-origin")
 	if destOrigin != "" && transferServer != "" {
-		log.Errorln("Cannot specify both --transfer-server and --dest-origin")
-		os.Exit(1)
+		exitWithError(1, "Cannot specify both --transfer-server and --dest-origin")
 	}
 	if destOrigin != "" {
 		originURL := strings.TrimRight(destOrigin, "/")
 		if err := pingTransferService(ctx, originURL); err != nil {
-			log.Errorf("Transfer service not available at %s: %v", originURL, err)
-			os.Exit(1)
+			exitWithErrorf(1, "Transfer service not available at %s: %v", originURL, err)
 		}
 		transferServer = originURL
 	}
 
 	if transferServer != "" {
 		if len(args) < 2 {
-			log.Errorln("No Source or Destination")
+			reportError("No Source or Destination")
 			err = cmd.Help()
 			if err != nil {
 				log.Errorln("Failed to print out help:", err)
 			}
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		source := args[:len(args)-1]
 		dest := args[len(args)-1]
@@ -309,8 +298,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 
 		err := submitToTransferServer(ctx, transferServer, serverToken, source, dest, isRecursive, srcCred, dstCred, shouldWait)
 		if err != nil {
-			log.Errorln("Transfer server submission failed:", err)
-			os.Exit(1)
+			exitWithError(1, "Transfer server submission failed:", err)
 		}
 		return
 	}
@@ -330,17 +318,17 @@ func copyMain(cmd *cobra.Command, args []string) {
 		// NOTE: The value returned by this no longer conforms to the old-style stashcp namespaces JSON.
 		// Instead, it now returns the struct provided by the registry
 		listAllNamespaces(cmd, args)
-		os.Exit(0)
+		exitWithFlush(0)
 	}
 
 	log.Debugln("Len of source:", len(args))
 	if len(args) < 2 {
-		log.Errorln("No Source or Destination")
+		reportError("No Source or Destination")
 		err = cmd.Help()
 		if err != nil {
 			log.Errorln("Failed to print out help:", err)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	source := args[:len(args)-1]
 	dest := args[len(args)-1]
@@ -351,8 +339,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 		for i, src := range source {
 			u, pErr := url.Parse(src)
 			if pErr != nil {
-				log.Errorln("Failed to parse URL:", pErr)
-				os.Exit(1)
+				exitWithError(1, "Failed to parse URL:", pErr)
 			}
 
 			// --direct is only meaningful for pelican/osdf URLs
@@ -363,8 +350,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 
 			// Check for conflicting prefercached parameter
 			if u.Query().Has("prefercached") {
-				log.Errorln("Cannot use --direct flag with URLs that have '?prefercached' query parameter")
-				os.Exit(1)
+				exitWithError(1, "Cannot use --direct flag with URLs that have '?prefercached' query parameter")
 			}
 
 			if u.RawQuery != "" {
@@ -383,17 +369,14 @@ func copyMain(cmd *cobra.Command, args []string) {
 	// as options.
 	caches, err := getPreferredCaches()
 	if err != nil {
-		log.Errorln("Failed to get preferred caches:", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to get preferred caches:", err)
 	}
 
 	if len(source) > 1 {
 		if destStat, err := os.Stat(dest); err != nil {
-			log.Errorln("Destination does not exist")
-			os.Exit(1)
+			exitWithError(1, "Destination does not exist")
 		} else if !destStat.IsDir() {
-			log.Errorln("Destination is not a collection")
-			os.Exit(1)
+			exitWithError(1, "Destination is not a collection")
 		}
 	}
 
@@ -414,20 +397,10 @@ func copyMain(cmd *cobra.Command, args []string) {
 	// Exit with failure
 	if result != nil {
 		if handleCredentialPasswordError(result) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		// Print the list of errors
-		errMsg := result.Error()
-		var te *client.TransferErrors
-		if errors.As(result, &te) {
-			errMsg = te.UserError()
-		}
-		log.Errorln("Failure transferring " + lastSrc + ": " + errMsg)
-		if client.ShouldRetry(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
-		}
-		os.Exit(1)
+		exitTransferFailure(result, "Failure transferring "+lastSrc)
 	}
 
 }

--- a/cmd/object_delete.go
+++ b/cmd/object_delete.go
@@ -22,7 +22,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -83,10 +82,9 @@ func deleteMain(cmd *cobra.Command, args []string) error {
 
 	if err != nil {
 		if handleCredentialPasswordError(err) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
-		log.Errorf("Failure deleting %s: %v", remoteDestination, err.Error())
-		os.Exit(1)
+		exitWithErrorf(1, "Failure deleting %s: %v", remoteDestination, err.Error())
 	}
 
 	return nil

--- a/cmd/object_du.go
+++ b/cmd/object_du.go
@@ -108,19 +108,19 @@ type duReport struct {
 func duMain(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	if err := config.InitClient(); err != nil {
-		log.Errorln(err)
+		reportError(err)
 		if client.IsRetryable(err) {
-			os.Exit(11)
+			exitWithFlush(11)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 
 	if len(args) == 0 {
-		log.Errorln("no path provided")
+		reportError("no path provided")
 		if helpErr := cmd.Help(); helpErr != nil {
 			log.Errorln("failed to print help:", helpErr)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 
 	tokenLocation, _ := cmd.Flags().GetString("token")
@@ -235,7 +235,7 @@ func duMain(cmd *cobra.Command, args []string) error {
 	if anyFailure {
 		// Match GNU du: totals were still printed, but the exit status reflects
 		// that at least one subtree could not be read.
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	return nil
 }

--- a/cmd/object_evict.go
+++ b/cmd/object_evict.go
@@ -22,15 +22,11 @@ package main
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/error_codes"
 )
 
 var (
@@ -75,12 +71,11 @@ func objectEvictMain(cmd *cobra.Command, args []string) error {
 
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 
 	tokenLocation, _ := cmd.Flags().GetString("token")
@@ -94,25 +89,9 @@ func objectEvictMain(cmd *cobra.Command, args []string) error {
 	message, err := client.DoEvict(ctx, source, immediate, options...)
 	if err != nil {
 		if handleCredentialPasswordError(err) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
-		errMsg := err.Error()
-		var pe error_codes.PelicanError
-		var te *client.TransferErrors
-		if errors.As(err, &te) {
-			errMsg = te.UserError()
-		}
-		if errors.Is(err, &pe) {
-			errMsg = pe.Error()
-			log.Errorln("Failure evicting " + source + ": " + errMsg)
-			os.Exit(pe.ExitCode())
-		}
-		log.Errorln("Failure evicting " + source + ": " + errMsg)
-		if client.ShouldRetry(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
-		}
-		os.Exit(1)
+		exitTransferFailure(err, "Failure evicting "+source)
 	}
 
 	fmt.Println(message)

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -27,14 +27,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/client_agent"
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/error_codes"
 	"github.com/pelicanplatform/pelican/param"
 )
 
@@ -74,13 +72,12 @@ func getMain(cmd *cobra.Command, args []string) {
 
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		} else {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
@@ -89,8 +86,7 @@ func getMain(cmd *cobra.Command, args []string) {
 	if isAsync {
 		// Validate arguments
 		if len(args) < 2 {
-			log.Errorln("No Source or Destination\nTry 'pelican object get --help' for more information.")
-			os.Exit(1)
+			exitWithError(1, "No Source or Destination\nTry 'pelican object get --help' for more information.")
 		}
 		source := args[:len(args)-1]
 		dest := args[len(args)-1]
@@ -98,9 +94,8 @@ func getMain(cmd *cobra.Command, args []string) {
 		// Ensure server is running, starting it if necessary
 		apiClient, err := ensureClientAgentRunning(cmd.Context(), 5)
 		if err != nil {
-			log.Errorln("Failed to ensure API server is running:", err)
-			log.Errorln("You can manually start it with 'pelican client-api serve --daemonize'")
-			os.Exit(1)
+			reportError("Failed to ensure API server is running:", err)
+			exitWithError(1, "You can manually start it with 'pelican client-api serve --daemonize'")
 		}
 
 		// Get flags for transfer options
@@ -111,8 +106,7 @@ func getMain(cmd *cobra.Command, args []string) {
 		// Get preferred caches
 		caches, err := getPreferredCaches()
 		if err != nil {
-			log.Errorln("Failed to get preferred caches:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to get preferred caches:", err)
 		}
 
 		// Convert caches to strings
@@ -148,16 +142,14 @@ func getMain(cmd *cobra.Command, args []string) {
 				warmItems[i] = asyncWarmItem{url: src, write: false}
 			}
 			if err := warmWalletForAsync(ctx, apiClient, warmItems); err != nil {
-				log.Errorln("Failed to prepare credentials for async transfer:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to prepare credentials for async transfer:", err)
 			}
 		}
 
 		// Create job
 		jobID, err := apiClient.CreateJob(ctx, transfers, options)
 		if err != nil {
-			log.Errorln("Failed to create job:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to create job:", err)
 		}
 
 		if outputJSON {
@@ -167,8 +159,7 @@ func getMain(cmd *cobra.Command, args []string) {
 			}
 			jsonBytes, err := json.MarshalIndent(result, "", "  ")
 			if err != nil {
-				log.Errorln("Failed to marshal JSON:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to marshal JSON:", err)
 			}
 			fmt.Println(string(jsonBytes))
 		} else {
@@ -185,22 +176,19 @@ func getMain(cmd *cobra.Command, args []string) {
 			// Wait with a reasonable timeout (e.g., 1 hour)
 			err := apiClient.WaitForJob(ctx, jobID, 1*time.Hour)
 			if err != nil {
-				log.Errorln("Error waiting for job:", err)
-				os.Exit(1)
+				exitWithError(1, "Error waiting for job:", err)
 			}
 
 			// Get final status
 			finalStatus, err := apiClient.GetJobStatus(ctx, jobID)
 			if err != nil {
-				log.Errorln("Error getting final job status:", err)
-				os.Exit(1)
+				exitWithError(1, "Error getting final job status:", err)
 			}
 
 			if outputJSON {
 				jsonBytes, err := json.MarshalIndent(finalStatus, "", "  ")
 				if err != nil {
-					log.Errorln("Failed to marshal JSON:", err)
-					os.Exit(1)
+					exitWithError(1, "Failed to marshal JSON:", err)
 				}
 				fmt.Println(string(jsonBytes))
 			} else {
@@ -231,8 +219,7 @@ func getMain(cmd *cobra.Command, args []string) {
 
 	log.Debugln("Len of source:", len(args))
 	if len(args) < 2 {
-		log.Errorln("No Source or Destination\nTry 'pelican object get --help' for more information.")
-		os.Exit(1)
+		exitWithError(1, "No Source or Destination\nTry 'pelican object get --help' for more information.")
 	}
 	source := args[:len(args)-1]
 	dest := args[len(args)-1]
@@ -244,14 +231,12 @@ func getMain(cmd *cobra.Command, args []string) {
 			packOption = "auto"
 		}
 		if _, err := client.GetBehavior(packOption); err != nil {
-			log.Errorln(err)
-			os.Exit(1)
+			exitWithError(1, err)
 		}
 		for i, src := range source {
 			newSrc, err := addQueryParam(src, "pack", packOption)
 			if err != nil {
-				log.Errorln("Failed to process --pack option:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to process --pack option:", err)
 			}
 			source[i] = newSrc
 		}
@@ -264,12 +249,10 @@ func getMain(cmd *cobra.Command, args []string) {
 			// Check for conflicting prefercached parameter
 			u, err := url.Parse(src)
 			if err != nil {
-				log.Errorln("Failed to parse URL:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to parse URL:", err)
 			}
 			if u.Query().Has("prefercached") {
-				log.Errorln("Cannot use --direct flag with URLs that have '?prefercached' query parameter")
-				os.Exit(1)
+				exitWithError(1, "Cannot use --direct flag with URLs that have '?prefercached' query parameter")
 			}
 
 			if u.RawQuery != "" {
@@ -288,17 +271,14 @@ func getMain(cmd *cobra.Command, args []string) {
 	// as options.
 	caches, err := getPreferredCaches()
 	if err != nil {
-		log.Errorln("Failed to get preferred caches:", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to get preferred caches:", err)
 	}
 
 	if len(source) > 1 {
 		if destStat, err := os.Stat(dest); err != nil {
-			log.Errorln("Destination does not exist")
-			os.Exit(1)
+			exitWithError(1, "Destination does not exist")
 		} else if !destStat.IsDir() {
-			log.Errorln("Destination is not a directory")
-			os.Exit(1)
+			exitWithError(1, "Destination is not a directory")
 		}
 	}
 
@@ -331,26 +311,9 @@ func getMain(cmd *cobra.Command, args []string) {
 	if attemptErr != nil {
 		// Print the list of errors
 		if handleCredentialPasswordError(attemptErr) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
-		errMsg := attemptErr.Error()
-		var pe error_codes.PelicanError
-		var te *client.TransferErrors
-		if errors.As(attemptErr, &te) {
-			errMsg = te.UserError()
-		}
-		if errors.Is(attemptErr, &pe) {
-			errMsg = pe.Error()
-			log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
-			os.Exit(pe.ExitCode())
-		} else { // For now, keeping this else here to catch any errors that are not classified PelicanErrors
-			log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
-			if client.ShouldRetry(attemptErr) {
-				log.Errorln("Errors are retryable")
-				os.Exit(11)
-			}
-			os.Exit(1)
-		}
+		exitTransferFailure(attemptErr, "Failure getting "+lastSrc)
 	}
 
 	// No failures so we can write the transfer stats

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -66,25 +66,24 @@ func listMain(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		} else {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
 	tokenLocation, _ := cmd.Flags().GetString("token")
 
 	if len(args) < 1 {
-		log.Errorln("no location provided")
+		reportError("no location provided")
 		err = cmd.Help()
 		if err != nil {
 			log.Errorln("failed to print out help:", err)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	object := args[len(args)-1]
 
@@ -131,20 +130,10 @@ func listMain(cmd *cobra.Command, args []string) error {
 	// Exit with failure
 	if err != nil {
 		if handleCredentialPasswordError(err) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		// Print the list of errors
-		errMsg := err.Error()
-		var te *client.TransferErrors
-		if errors.As(err, &te) {
-			errMsg = te.UserError()
-		}
-		log.Errorln("Failure getting " + object + ": " + errMsg)
-		if client.ShouldRetry(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
-		}
-		os.Exit(1)
+		exitTransferFailure(err, "Failure getting "+object)
 	}
 
 	filteredInfos := []client.FileInfo{}

--- a/cmd/object_prestage.go
+++ b/cmd/object_prestage.go
@@ -26,14 +26,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/client_agent"
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/error_codes"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
 )
@@ -65,13 +63,12 @@ func prestageMain(cmd *cobra.Command, args []string) {
 
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		} else {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
@@ -80,20 +77,19 @@ func prestageMain(cmd *cobra.Command, args []string) {
 	if isAsync {
 		// Validate arguments
 		if len(args) < 1 {
-			log.Errorln("Prefix(es) to prestage must be specified")
+			reportError("Prefix(es) to prestage must be specified")
 			err = cmd.Help()
 			if err != nil {
 				log.Errorln("Failed to print out help:", err)
 			}
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 
 		// Ensure server is running, starting it if necessary
 		apiClient, err := ensureClientAgentRunning(cmd.Context(), 5)
 		if err != nil {
-			log.Errorln("Failed to ensure API server is running:", err)
-			log.Errorln("You can manually start it with 'pelican client-api serve --daemonize'")
-			os.Exit(1)
+			reportError("Failed to ensure API server is running:", err)
+			exitWithError(1, "You can manually start it with 'pelican client-api serve --daemonize'")
 		}
 
 		// Get flags for transfer options
@@ -102,8 +98,7 @@ func prestageMain(cmd *cobra.Command, args []string) {
 		// Get preferred caches
 		caches, err := getPreferredCaches()
 		if err != nil {
-			log.Errorln("Failed to get preferred caches:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to get preferred caches:", err)
 		}
 
 		// Convert caches to strings
@@ -122,8 +117,7 @@ func prestageMain(cmd *cobra.Command, args []string) {
 		transfers := make([]client_agent.TransferRequest, len(args))
 		for i, src := range args {
 			if !pelican_url.IsPelicanURL(src) {
-				log.Errorln("Provided URL is not a valid Pelican URL:", src)
-				os.Exit(1)
+				exitWithError(1, "Provided URL is not a valid Pelican URL:", src)
 			}
 			transfers[i] = client_agent.TransferRequest{
 				Operation:   "prestage",
@@ -142,16 +136,14 @@ func prestageMain(cmd *cobra.Command, args []string) {
 				warmItems[i] = asyncWarmItem{url: src, write: false}
 			}
 			if err := warmWalletForAsync(ctx, apiClient, warmItems); err != nil {
-				log.Errorln("Failed to prepare credentials for async transfer:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to prepare credentials for async transfer:", err)
 			}
 		}
 
 		// Create job
 		jobID, err := apiClient.CreateJob(ctx, transfers, options)
 		if err != nil {
-			log.Errorln("Failed to create job:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to create job:", err)
 		}
 
 		if outputJSON {
@@ -161,8 +153,7 @@ func prestageMain(cmd *cobra.Command, args []string) {
 			}
 			jsonBytes, err := json.MarshalIndent(result, "", "  ")
 			if err != nil {
-				log.Errorln("Failed to marshal JSON:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to marshal JSON:", err)
 			}
 			fmt.Println(string(jsonBytes))
 		} else {
@@ -179,22 +170,19 @@ func prestageMain(cmd *cobra.Command, args []string) {
 			// Wait with a reasonable timeout (e.g., 1 hour)
 			err := apiClient.WaitForJob(ctx, jobID, 1*time.Hour)
 			if err != nil {
-				log.Errorln("Error waiting for job:", err)
-				os.Exit(1)
+				exitWithError(1, "Error waiting for job:", err)
 			}
 
 			// Get final job status
 			status, err := apiClient.GetJobStatus(ctx, jobID)
 			if err != nil {
-				log.Errorln("Failed to get job status:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to get job status:", err)
 			}
 
 			if outputJSON {
 				jsonBytes, err := json.MarshalIndent(status, "", "  ")
 				if err != nil {
-					log.Errorln("Failed to marshal JSON:", err)
-					os.Exit(1)
+					exitWithError(1, "Failed to marshal JSON:", err)
 				}
 				fmt.Println(string(jsonBytes))
 			} else {
@@ -202,7 +190,7 @@ func prestageMain(cmd *cobra.Command, args []string) {
 			}
 
 			if status.Status != "completed" {
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 		} else {
 			if !outputJSON {
@@ -224,12 +212,12 @@ func prestageMain(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) < 1 {
-		log.Errorln("Prefix(es) to prestage must be specified")
+		reportError("Prefix(es) to prestage must be specified")
 		err = cmd.Help()
 		if err != nil {
 			log.Errorln("Failed to print out help:", err)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 
 	log.Debugln("Prestage prefixes:", args)
@@ -238,16 +226,14 @@ func prestageMain(cmd *cobra.Command, args []string) {
 	// as options.
 	caches, err := getPreferredCaches()
 	if err != nil {
-		log.Errorln("Failed to get preferred caches:", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to get preferred caches:", err)
 	}
 
 	lastSrc := ""
 
 	for _, src := range args {
 		if !pelican_url.IsPelicanURL(src) {
-			log.Errorln("Provided URL is not a valid Pelican URL:", src)
-			os.Exit(1)
+			exitWithError(1, "Provided URL is not a valid Pelican URL:", src)
 		}
 		if _, err = client.DoPrestage(ctx, src,
 			client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation),
@@ -261,25 +247,8 @@ func prestageMain(cmd *cobra.Command, args []string) {
 	if err != nil {
 		// Print the list of errors
 		if handleCredentialPasswordError(err) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
-		errMsg := err.Error()
-		var pe error_codes.PelicanError
-		var te *client.TransferErrors
-		if errors.As(err, &te) {
-			errMsg = te.UserError()
-		}
-		if errors.Is(err, &pe) {
-			errMsg = pe.Error()
-			log.Errorln("Failure prestaging " + lastSrc + ": " + errMsg)
-			os.Exit(pe.ExitCode())
-		} else { // For now, keeping this else here to catch any errors that are not classified PelicanErrors
-			log.Errorln("Failure prestaging " + lastSrc + ": " + errMsg)
-			if client.ShouldRetry(err) {
-				log.Errorln("Errors are retryable")
-				os.Exit(11)
-			}
-			os.Exit(1)
-		}
+		exitTransferFailure(err, "Failure prestaging "+lastSrc)
 	}
 }

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -169,12 +169,11 @@ func putMain(cmd *cobra.Command, args []string) {
 
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		} else {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
@@ -187,17 +186,16 @@ func putMain(cmd *cobra.Command, args []string) {
 		// guard on the synchronous path).
 		for _, f := range []string{"metadata-file", "metadata-body", "metadata-content-type"} {
 			if v, _ := cmd.Flags().GetString(f); v != "" {
-				log.Errorf("--%s is not yet supported with --async", f)
-				os.Exit(1)
+				exitWithErrorf(1, "--%s is not yet supported with --async", f)
 			}
 		}
 		// Validate arguments
 		if len(args) < 2 {
-			log.Errorln("No Source or Destination")
+			reportError("No Source or Destination")
 			if err := cmd.Help(); err != nil {
 				log.Errorln("Failed to print out help:", err)
 			}
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		source := args[:len(args)-1]
 		dest := args[len(args)-1]
@@ -205,9 +203,8 @@ func putMain(cmd *cobra.Command, args []string) {
 		// Ensure server is running, starting it if necessary
 		apiClient, err := ensureClientAgentRunning(cmd.Context(), 5)
 		if err != nil {
-			log.Errorln("Failed to ensure API server is running:", err)
-			log.Errorln("You can manually start it with 'pelican client-api serve --daemonize'")
-			os.Exit(1)
+			reportError("Failed to ensure API server is running:", err)
+			exitWithError(1, "You can manually start it with 'pelican client-api serve --daemonize'")
 		}
 
 		// Get flags for transfer options
@@ -237,16 +234,14 @@ func putMain(cmd *cobra.Command, args []string) {
 		// explicit token file was provided.
 		if tokenLocation == "" {
 			if err := warmWalletForAsync(ctx, apiClient, []asyncWarmItem{{url: dest, write: true}}); err != nil {
-				log.Errorln("Failed to prepare credentials for async transfer:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to prepare credentials for async transfer:", err)
 			}
 		}
 
 		// Create job
 		jobID, err := apiClient.CreateJob(ctx, transfers, options)
 		if err != nil {
-			log.Errorln("Failed to create job:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to create job:", err)
 		}
 
 		if outputJSON {
@@ -256,8 +251,7 @@ func putMain(cmd *cobra.Command, args []string) {
 			}
 			jsonBytes, err := json.MarshalIndent(result, "", "  ")
 			if err != nil {
-				log.Errorln("Failed to marshal JSON:", err)
-				os.Exit(1)
+				exitWithError(1, "Failed to marshal JSON:", err)
 			}
 			fmt.Println(string(jsonBytes))
 		} else {
@@ -274,22 +268,19 @@ func putMain(cmd *cobra.Command, args []string) {
 			// Wait with a reasonable timeout (e.g., 1 hour)
 			err := apiClient.WaitForJob(ctx, jobID, 1*time.Hour)
 			if err != nil {
-				log.Errorln("Error waiting for job:", err)
-				os.Exit(1)
+				exitWithError(1, "Error waiting for job:", err)
 			}
 
 			// Get final status
 			finalStatus, err := apiClient.GetJobStatus(ctx, jobID)
 			if err != nil {
-				log.Errorln("Error getting final job status:", err)
-				os.Exit(1)
+				exitWithError(1, "Error getting final job status:", err)
 			}
 
 			if outputJSON {
 				jsonBytes, err := json.MarshalIndent(finalStatus, "", "  ")
 				if err != nil {
-					log.Errorln("Failed to marshal JSON:", err)
-					os.Exit(1)
+					exitWithError(1, "Failed to marshal JSON:", err)
 				}
 				fmt.Println(string(jsonBytes))
 			} else {
@@ -320,13 +311,12 @@ func putMain(cmd *cobra.Command, args []string) {
 	if checksumAlgorithm != "" {
 		checksumType := client.ChecksumFromHttpDigest(checksumAlgorithm)
 		if checksumType == client.AlgUnknown {
-			log.Errorln("Unknown checksum algorithm:", checksumAlgorithm)
+			reportError("Unknown checksum algorithm:", checksumAlgorithm)
 			var validAlgorithms []string
 			for _, alg := range client.KnownChecksumTypes() {
 				validAlgorithms = append(validAlgorithms, client.HttpDigestFromChecksum(alg))
 			}
-			log.Errorln("Valid algorithms are:", strings.Join(validAlgorithms, ", "))
-			os.Exit(1)
+			exitWithError(1, "Valid algorithms are:", strings.Join(validAlgorithms, ", "))
 		}
 		options = append(options, client.WithRequestChecksums([]client.ChecksumType{checksumType}))
 	}
@@ -341,11 +331,11 @@ func putMain(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) < 2 {
-		log.Errorln("No Source or Destination")
+		reportError("No Source or Destination")
 		if err := cmd.Help(); err != nil {
 			log.Errorln("Failed to print out help:", err)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	source := args[:len(args)-1]
 	dest := args[len(args)-1]
@@ -357,14 +347,12 @@ func putMain(cmd *cobra.Command, args []string) {
 			packOption = "auto"
 		}
 		if _, err := client.GetBehavior(packOption); err != nil {
-			log.Errorln(err)
-			os.Exit(1)
+			exitWithError(1, err)
 		}
 		var err error
 		dest, err = addQueryParam(dest, "pack", packOption)
 		if err != nil {
-			log.Errorln("Failed to process --pack option:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to process --pack option:", err)
 		}
 	}
 
@@ -372,25 +360,22 @@ func putMain(cmd *cobra.Command, args []string) {
 	if checksumsFile != "" {
 		parts := strings.SplitN(checksumsFile, ":", 2)
 		if len(parts) != 2 {
-			log.Errorln("invalid format for --checksums. Expected ALGORITHM:FILENAME")
-			os.Exit(1)
+			exitWithError(1, "invalid format for --checksums. Expected ALGORITHM:FILENAME")
 		}
 		algName, manifestPath := parts[0], parts[1]
 		checksumType := client.ChecksumFromHttpDigest(algName)
 		if checksumType == client.AlgUnknown {
-			log.Errorln("Unknown checksum algorithm:", algName)
+			reportError("Unknown checksum algorithm:", algName)
 			var validAlgorithms []string
 			for _, alg := range client.KnownChecksumTypes() {
 				validAlgorithms = append(validAlgorithms, client.HttpDigestFromChecksum(alg))
 			}
-			log.Errorln("Valid algorithms are:", strings.Join(validAlgorithms, ", "))
-			os.Exit(1)
+			exitWithError(1, "Valid algorithms are:", strings.Join(validAlgorithms, ", "))
 		}
 		log.Debugln("Parsing manifest file:", manifestPath)
 		manifestEntries, err := parseManifest(manifestPath)
 		if err != nil {
-			log.Errorf("failed to parse manifest file %s: %v", manifestPath, err)
-			os.Exit(1)
+			exitWithErrorf(1, "failed to parse manifest file %s: %v", manifestPath, err)
 		}
 
 		manifestMap := make(map[string]string)
@@ -401,12 +386,10 @@ func putMain(cmd *cobra.Command, args []string) {
 		for _, src := range source {
 			expectedChecksum, ok := manifestMap[src]
 			if !ok {
-				log.Errorf("source file %s not found in checksums manifest", src)
-				os.Exit(1)
+				exitWithErrorf(1, "source file %s not found in checksums manifest", src)
 			}
 			if err := verifyFileChecksum(src, expectedChecksum, checksumType); err != nil {
-				log.Errorf("checksum validation failed for %s: %v", src, err)
-				os.Exit(1)
+				exitWithErrorf(1, "checksum validation failed for %s: %v", src, err)
 			}
 			log.Infof("Checksum verified for %s", src)
 		}
@@ -433,8 +416,7 @@ func putMain(cmd *cobra.Command, args []string) {
 			options = append(options, client.WithObjectMetadataContentType(ct))
 		}
 	} else if ct, _ := cmd.Flags().GetString("metadata-content-type"); ct != "" {
-		log.Errorln("--metadata-content-type was supplied without --metadata-body; nothing to override")
-		os.Exit(1)
+		exitWithError(1, "--metadata-content-type was supplied without --metadata-body; nothing to override")
 	}
 
 	var result error
@@ -533,20 +515,10 @@ func putMain(cmd *cobra.Command, args []string) {
 	// Exit with failure
 	if result != nil {
 		if handleCredentialPasswordError(result) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		// Print the list of errors
-		errMsg := result.Error()
-		var te *client.TransferErrors
-		if errors.As(result, &te) {
-			errMsg = te.UserError()
-		}
-		log.Errorln("Failure putting " + lastSrc + ": " + errMsg)
-		if client.ShouldRetry(result) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
-		}
-		os.Exit(1)
+		exitTransferFailure(result, "Failure putting "+lastSrc)
 	}
 
 	transferStatsFile, _ := cmd.Flags().GetString("transfer-stats")

--- a/cmd/object_stat.go
+++ b/cmd/object_stat.go
@@ -23,10 +23,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -60,13 +58,12 @@ func statMain(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		} else {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
@@ -81,24 +78,24 @@ func statMain(cmd *cobra.Command, args []string) {
 		for _, checksum := range checksums {
 			checksumType := client.ChecksumFromHttpDigest(checksum)
 			if checksumType == client.AlgUnknown {
-				log.Errorf("Unknown checksum type: %s", checksum)
+				reportErrorf("Unknown checksum type: %s", checksum)
 				err = cmd.Help()
 				if err != nil {
 					log.Errorln("Failed to print out help:", err)
 				}
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 			checksumTypes = append(checksumTypes, checksumType)
 		}
 	}
 
 	if len(args) < 1 {
-		log.Errorln("No object provided")
+		reportError("No object provided")
 		err = cmd.Help()
 		if err != nil {
 			log.Errorln("Failed to print out help:", err)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	object := args[len(args)-1]
 
@@ -109,28 +106,17 @@ func statMain(cmd *cobra.Command, args []string) {
 	// Exit with failure
 	if err != nil {
 		if handleCredentialPasswordError(err) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		// Print the list of errors
-		errMsg := err.Error()
-		var te *client.TransferErrors
-		if errors.As(err, &te) {
-			errMsg = te.UserError()
-		}
-		log.Errorln("Failure getting " + object + ": " + errMsg)
-		if client.ShouldRetry(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
-		}
-		os.Exit(1)
+		exitTransferFailure(err, "Failure getting "+object)
 	}
 
 	if jsn {
 		// Print our stat info in JSON format:
 		jsonData, err := json.Marshal(statInfo)
 		if err != nil {
-			log.Errorf("Failed to parse object/collection stat info to JSON format: %v", err)
-			os.Exit(1)
+			exitWithErrorf(1, "Failed to parse object/collection stat info to JSON format: %v", err)
 		}
 		fmt.Println(string(jsonData))
 		return

--- a/cmd/object_sync.go
+++ b/cmd/object_sync.go
@@ -24,13 +24,11 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/error_codes"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
 )
@@ -62,13 +60,12 @@ func syncMain(cmd *cobra.Command, args []string) {
 
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln(err)
+		reportError(err)
 
 		if client.IsRetryable(err) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		} else {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
@@ -85,12 +82,12 @@ func syncMain(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) < 2 {
-		log.Errorln("No source or destination to sync")
+		reportError("No source or destination to sync")
 		err = cmd.Help()
 		if err != nil {
 			log.Errorln("Failed to print out help:", err)
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	sources := args[:len(args)-1]
 	dest := args[len(args)-1]
@@ -101,8 +98,7 @@ func syncMain(cmd *cobra.Command, args []string) {
 			// Both source and destination are remote: third-party-copy sync
 			for _, src := range sources {
 				if !pelican_url.IsPelicanURL(src) {
-					log.Errorln("When synchronizing between federation URLs, all sources must be pelican URLs:", src)
-					os.Exit(1)
+					exitWithError(1, "When synchronizing between federation URLs, all sources must be pelican URLs:", src)
 				}
 			}
 			log.Debugln("Synchronizing between Pelican data federation endpoints (third-party-copy)")
@@ -110,21 +106,18 @@ func syncMain(cmd *cobra.Command, args []string) {
 		} else {
 			for _, src := range sources {
 				if pelican_url.IsPelicanURL(src) {
-					log.Errorf("URL (%s) cannot be a source when synchronizing to a federation URL from local files", src)
-					os.Exit(1)
+					exitWithErrorf(1, "URL (%s) cannot be a source when synchronizing to a federation URL from local files", src)
 				}
 			}
 			log.Debugln("Synchronizing to a Pelican data federation")
 		}
 	} else {
 		if !pelican_url.IsPelicanURL(sources[0]) {
-			log.Errorln("Either the first or last argument must be a pelican:// or osdf://-style URL specifying a remote destination")
-			os.Exit(1)
+			exitWithError(1, "Either the first or last argument must be a pelican:// or osdf://-style URL specifying a remote destination")
 		}
 		for _, src := range sources {
 			if !pelican_url.IsPelicanURL(src) {
-				log.Errorln("When synchronizing to a local directory, all sources must be pelican URLs:", src)
-				os.Exit(1)
+				exitWithError(1, "When synchronizing to a local directory, all sources must be pelican URLs:", src)
 			}
 		}
 		log.Debugln("Synchronizing from a Pelican data federation")
@@ -139,18 +132,15 @@ func syncMain(cmd *cobra.Command, args []string) {
 				// Check for conflicting prefercached parameter
 				u, pErr := url.Parse(src)
 				if pErr != nil {
-					log.Errorln("Failed to parse URL:", pErr)
-					os.Exit(1)
+					exitWithError(1, "Failed to parse URL:", pErr)
 				}
 				if u.Query().Has("prefercached") {
-					log.Errorln("Cannot use --direct flag with URLs that have '?prefercached' query parameter")
-					os.Exit(1)
+					exitWithError(1, "Cannot use --direct flag with URLs that have '?prefercached' query parameter")
 				}
 
 				newSrc, pErr := addQueryParam(src, "directread", "")
 				if pErr != nil {
-					log.Errorln("Failed to process --direct option:", pErr)
-					os.Exit(1)
+					exitWithError(1, "Failed to process --direct option:", pErr)
 				}
 				sources[i] = newSrc
 			}
@@ -166,17 +156,14 @@ func syncMain(cmd *cobra.Command, args []string) {
 	// as options.
 	caches, err := getPreferredCaches()
 	if err != nil {
-		log.Errorln("Failed to get preferred caches:", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to get preferred caches:", err)
 	}
 
 	if doDownload && len(sources) > 1 {
 		if destStat, err := os.Stat(dest); err != nil {
-			log.Errorln("Destination does not exist")
-			os.Exit(1)
+			exitWithError(1, "Destination does not exist")
 		} else if !destStat.IsDir() {
-			log.Errorln("Destination is not a directory")
-			os.Exit(1)
+			exitWithError(1, "Destination is not a directory")
 		}
 	}
 
@@ -216,8 +203,7 @@ func syncMain(cmd *cobra.Command, args []string) {
 	} else {
 		for _, src := range sources {
 			if srcStat, err := os.Stat(src); err != nil {
-				log.Errorln("Source: " + src + " does not exist")
-				os.Exit(1)
+				exitWithError(1, "Source: "+src+" does not exist")
 			} else if !srcStat.IsDir() && string(dest[len(dest)-1]) == `/` {
 				log.Warningln("Destination: " + dest + " ends with '/', but the source is a file. If the destination does not exist, it will be treated as an object, not a collection.")
 			}
@@ -239,26 +225,9 @@ func syncMain(cmd *cobra.Command, args []string) {
 	// Exit with failure
 	if err != nil {
 		if handleCredentialPasswordError(err) {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		// Print the list of errors
-		errMsg := err.Error()
-		var pe error_codes.PelicanError
-		var te *client.TransferErrors
-		if errors.As(err, &te) {
-			errMsg = te.UserError()
-		}
-		if errors.Is(err, &pe) {
-			errMsg = pe.Error()
-			log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
-			os.Exit(pe.ExitCode())
-		} else { // For now, keeping this else here to catch any errors that are not classified PelicanErrors
-			log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
-			if client.ShouldRetry(err) {
-				log.Errorln("Errors are retryable")
-				os.Exit(11)
-			}
-			os.Exit(1)
-		}
+		exitTransferFailure(err, "Failure getting "+lastSrc)
 	}
 }

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -22,7 +22,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -91,7 +90,7 @@ and https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md, 
 
 func configOrigin( /*cmd*/ *cobra.Command /*args*/, []string) {
 	fmt.Println("'origin config' command is not yet implemented")
-	os.Exit(1)
+	exitWithFlush(1)
 }
 
 func init() {
@@ -222,7 +221,7 @@ instead.
 		}
 
 		if shouldCancel {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -144,7 +144,7 @@ func stashPluginMain(args []string) {
 			// Attempt to write our file and bail
 			writeClassadOutputAndBail(1, resultAds)
 
-			os.Exit(1) //exit here just in case
+			exitWithFlush(1) //exit here just in case
 		}
 	}()
 
@@ -176,10 +176,10 @@ func stashPluginMain(args []string) {
 			fmt.Println("ProtocolVersion = 2")
 			fmt.Println("SupportedMethods = \"stash, osdf, pelican\"")
 			fmt.Println("StartdAttrs = \"PelicanPluginVersion\"")
-			os.Exit(0)
+			exitWithFlush(0)
 		} else if args[0] == "-version" || args[0] == "-v" {
 			config.PrintPelicanVersion(os.Stdout)
-			os.Exit(0)
+			exitWithFlush(0)
 		} else if args[0] == "-upload" {
 			log.Debugln("Upload detected")
 			upload = true
@@ -196,15 +196,13 @@ func stashPluginMain(args []string) {
 			config.SetLogging(log.DebugLevel)
 		} else if args[0] == "-get-caches" {
 			if len(args) < 2 {
-				log.Errorln("-get-caches requires an argument")
-				os.Exit(1)
+				exitWithError(1, "-get-caches requires an argument")
 			}
 			testCachePath = args[1]
 			args = args[1:]
 			getCaches = true
 		} else if strings.HasPrefix(args[0], "-") {
-			log.Errorln("Do not understand the option:", args[0])
-			os.Exit(1)
+			exitWithError(1, "Do not understand the option:", args[0])
 		} else {
 			// Must be the start of a source / destination
 			break
@@ -239,14 +237,13 @@ func stashPluginMain(args []string) {
 		// Attempt to write our file and bail
 		writeClassadOutputAndBail(1, resultAds)
 
-		os.Exit(1) //exit here just in case
+		exitWithFlush(1) //exit here just in case
 	}
 
 	if getCaches {
 		urls, err := client.GetObjectServerHostnames(context.Background(), testCachePath)
 		if err != nil {
-			log.Errorln("Failed to get object server URLs:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to get object server URLs:", err)
 		}
 
 		serversToTry := client.ObjectServersToTry
@@ -257,7 +254,7 @@ func stashPluginMain(args []string) {
 		for _, url := range urls[:serversToTry] {
 			fmt.Println(url)
 		}
-		os.Exit(0)
+		exitWithFlush(0)
 	}
 
 	var source []string
@@ -266,7 +263,7 @@ func stashPluginMain(args []string) {
 
 	if len(args) == 0 && (infile == "" || outfile == "") {
 		fmt.Fprint(os.Stderr, "No source or destination specified\n")
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 
 	var workChan chan PluginTransfer
@@ -274,15 +271,13 @@ func stashPluginMain(args []string) {
 		// Open the input and output files
 		infileFile, err := os.Open(infile)
 		if err != nil {
-			log.Errorln("Failed to open infile:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to open infile:", err)
 		}
 		defer infileFile.Close()
 		// Read in classad from stdin
 		transfers, err = readMultiTransfers(*bufio.NewReader(infileFile))
 		if err != nil {
-			log.Errorln("Failed to read in from stdin:", err)
-			os.Exit(1)
+			exitWithError(1, "Failed to read in from stdin:", err)
 		}
 		workChan = make(chan PluginTransfer, len(transfers))
 		for _, transfer := range transfers {
@@ -300,8 +295,7 @@ func stashPluginMain(args []string) {
 			workChan <- PluginTransfer{url: srcUrl, localFile: dest}
 		}
 	} else {
-		log.Errorln("Must provide both source and destination as argument")
-		os.Exit(1)
+		exitWithError(1, "Must provide both source and destination as argument")
 	}
 	close(workChan)
 
@@ -319,8 +313,7 @@ func stashPluginMain(args []string) {
 		var err error
 		outputFile, err = os.Create(outfile)
 		if err != nil {
-			log.Errorln("Failed to open outfile:", err)
-			os.Exit(FailedOutfile) // unique error code to give us info
+			exitWithError(FailedOutfile, "Failed to open outfile:", err)
 		}
 		defer outputFile.Close()
 	}
@@ -387,16 +380,16 @@ func stashPluginMain(args []string) {
 
 	tmpSuccess, retryable, err := writeOutfile(err, resultAds, outputFile)
 	if err != nil {
-		os.Exit(FailedOutfile)
+		exitWithFlush(FailedOutfile)
 	}
 	success = tmpSuccess && success
 
 	if success {
-		os.Exit(0)
+		exitWithFlush(0)
 	} else if retryable {
-		os.Exit(Retryable)
+		exitWithFlush(Retryable)
 	} else {
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 }
 
@@ -411,8 +404,7 @@ func writeClassadOutputAndBail(exitCode int, resultAds []*classad.ClassAd) {
 		var err error
 		outputFile, err = os.Create(outfile)
 		if err != nil {
-			log.Errorln("Failed to open outfile:", err)
-			os.Exit(FailedOutfile) // Code of 3 to let us know that the outfile failed to be created
+			exitWithError(FailedOutfile, "Failed to open outfile:", err)
 		}
 		defer outputFile.Close()
 	}
@@ -427,8 +419,7 @@ func writeClassadOutputAndBail(exitCode int, resultAds []*classad.ClassAd) {
 		exitCode = 11
 	}
 
-	log.Errorln("Failure with pelican plugin. Exiting...")
-	os.Exit(exitCode)
+	exitWithError(exitCode, "Failure with pelican plugin. Exiting...")
 }
 
 // runPluginWorker performs the appropriate download or upload functions for the plugin as well as

--- a/cmd/plugin_stage.go
+++ b/cmd/plugin_stage.go
@@ -99,8 +99,7 @@ func stagePluginMain(cmd *cobra.Command, args []string) {
 
 	originPrefixUri, err := validatePrefixes(originPrefixStr, mountPrefixStr, shadowOriginPrefixStr)
 	if err != nil {
-		log.Errorln("Problem validating provided prefixes:", err)
-		os.Exit(1)
+		exitWithError(1, "Problem validating provided prefixes:", err)
 	}
 
 	originPrefixPath := path.Clean("/" + originPrefixUri.Host + "/" + originPrefixUri.Path)
@@ -125,11 +124,11 @@ func stagePluginMain(cmd *cobra.Command, args []string) {
 	if !isHook {
 		log.Debugln("Len of source:", len(args))
 		if len(args) < 1 {
-			log.Errorln("No ingest sources")
+			reportError("No ingest sources")
 			if err = cmd.Help(); err != nil {
 				log.Errorln("Failure when printing out help:", err)
 			}
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		sources = args
 		log.Debugln("Sources:", sources)
@@ -137,8 +136,7 @@ func stagePluginMain(cmd *cobra.Command, args []string) {
 		// We pass in stdin here because that is how we get the classad
 		sources, extraSources, err, exitCode = processTransferInput(os.Stdin, mountPrefixStr, originPrefixPath)
 		if err != nil {
-			log.Errorln("Failure to get sources from job's classad:", err)
-			os.Exit(exitCode)
+			exitWithError(exitCode, "Failure to get sources from job's classad:", err)
 		}
 	}
 
@@ -149,12 +147,11 @@ func stagePluginMain(cmd *cobra.Command, args []string) {
 	// Exit with failure
 	if result != nil {
 		// Print the list of errors
-		log.Errorln("Failure in staging files:", result)
+		reportError("Failure in staging files:", result)
 		if client.ShouldRetry(result) {
-			log.Errorln("Errors are retryable")
-			os.Exit(11)
+			exitWithError(11, "Errors are retryable")
 		}
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	// If we are a condor hook, we need to print the classad change out. Condor will notice it and handle the rest
 	if isHook {

--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -32,7 +32,6 @@ package main
 import (
 	"context"
 	"net/url"
-	"os"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -72,14 +71,12 @@ func getRegistryEndpoint(ctx context.Context) (string, error) {
 func registerANamespace(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln("Failed to initialize the client: ", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to initialize the client: ", err)
 	}
 
 	namespaceEndpoint, err := getRegistryEndpoint(cmd.Context())
 	if err != nil {
-		log.Errorln("Failed to get RegistryUrl from config: ", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to get RegistryUrl from config: ", err)
 	}
 
 	// Parse the namespace URL to make sure it's okay
@@ -88,34 +85,31 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 		log.Errorf("Failed to construction registration endpoint URL: %v", err)
 	}
 	if prefix == "" {
-		log.Error("Error: prefix is required")
-		os.Exit(1)
+		reportError("Error: prefix is required")
+		exitWithFlush(1)
 	}
 
 	// NamespaceRegister advertises every issuer key this server holds (with the
 	// signing key at index 0), and the registry records the full keyset
 	privateKey, err := config.GetIssuerPrivateJWK()
 	if err != nil {
-		log.Error("Failed to load private key", err)
-		os.Exit(1)
+		reportError("Failed to load private key", err)
+		exitWithFlush(1)
 	}
 
 	siteName := param.Xrootd_Sitename.GetString()
 	if siteName == "" {
-		log.Errorf("Server name isn't set. Please set the name via %s", param.Xrootd_Sitename.GetName())
-		os.Exit(1)
+		exitWithErrorf(1, "Server name isn't set. Please set the name via %s", param.Xrootd_Sitename.GetName())
 	}
 	if withIdentity {
 		err := registry_client.NamespaceRegisterWithIdentity(privateKey, registrationEndpointURL, prefix, siteName)
 		if err != nil {
-			log.Errorf("Failed to register prefix %s with identity: %v", prefix, err)
-			os.Exit(1)
+			exitWithErrorf(1, "Failed to register prefix %s with identity: %v", prefix, err)
 		}
 	} else {
 		err := registry_client.NamespaceRegister(privateKey, registrationEndpointURL, "", prefix, siteName)
 		if err != nil {
-			log.Errorf("Failed to register prefix %s: %v", prefix, err)
-			os.Exit(1)
+			exitWithErrorf(1, "Failed to register prefix %s: %v", prefix, err)
 		}
 	}
 }
@@ -123,14 +117,12 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 func deleteANamespace(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln("Failed to initialize the client: ", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to initialize the client: ", err)
 	}
 
 	namespaceEndpoint, err := getRegistryEndpoint(cmd.Context())
 	if err != nil {
-		log.Errorln("Failed to get RegistryUrl from config: ", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to get RegistryUrl from config: ", err)
 	}
 
 	deletionEndpointURL, err := url.JoinPath(namespaceEndpoint, "api", "v1.0", "registry", prefix)
@@ -140,22 +132,19 @@ func deleteANamespace(cmd *cobra.Command, args []string) {
 
 	err = registry_client.NamespaceDelete(deletionEndpointURL, prefix)
 	if err != nil {
-		log.Errorf("Failed to delete prefix %s: %v", prefix, err)
-		os.Exit(1)
+		exitWithErrorf(1, "Failed to delete prefix %s: %v", prefix, err)
 	}
 }
 
 func listAllNamespaces(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
-		log.Errorln("Failed to initialize the client: ", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to initialize the client: ", err)
 	}
 
 	namespaceEndpoint, err := getRegistryEndpoint(cmd.Context())
 	if err != nil {
-		log.Errorln("Failed to get RegistryUrl from config: ", err)
-		os.Exit(1)
+		exitWithError(1, "Failed to get RegistryUrl from config: ", err)
 	}
 
 	listEndpoint, err := url.JoinPath(namespaceEndpoint, "api", "v1.0", "registry")
@@ -165,8 +154,7 @@ func listAllNamespaces(cmd *cobra.Command, args []string) {
 
 	err = registry_client.NamespaceList(listEndpoint)
 	if err != nil {
-		log.Errorf("Failed to list namespace information: %v", err)
-		os.Exit(1)
+		exitWithErrorf(1, "Failed to list namespace information: %v", err)
 	}
 }
 

--- a/cmd/ssh_helper.go
+++ b/cmd/ssh_helper.go
@@ -63,13 +63,13 @@ func runSSHHelper(cmd *cobra.Command, args []string) {
 			output, err := ssh_posixv2.HelperStatusCmd()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+				exitWithFlush(1)
 			}
 			fmt.Println(output)
 			return
 		default:
 			fmt.Fprintf(os.Stderr, "Unknown command: %s\n", sshHelperCommand)
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 	}
 
@@ -83,6 +83,6 @@ func runSSHHelper(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 	if err := ssh_posixv2.RunHelper(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "Helper error: %v\n", err)
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 }

--- a/cmd/transfer_errors.go
+++ b/cmd/transfer_errors.go
@@ -1,0 +1,76 @@
+//go:build client
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/error_codes"
+)
+
+// classifyTransferFailure maps a failed transfer's error to the process exit
+// code and the message shown to the user.
+//
+// The *PelicanError has to be recovered with errors.As, not errors.Is. The exit
+// code and the message live on the instance sitting in the error chain, and
+// only As can hand that instance back; Is answers a yes/no question about
+// identity with a sentinel, and there is no sentinel here. Comparing against a
+// freshly declared PelicanError could therefore never match, so every
+// classified failure fell through to exit 1.
+//
+// Giving PelicanError an Is method would make this worse rather than better: it
+// would satisfy the comparison while leaving the target as the zero value,
+// whose ExitCode() is 0 -- success, reported for a transfer that failed.
+func classifyTransferFailure(err error) (code int, msg string) {
+	msg = err.Error()
+	// A TransferErrors carries a message assembled for humans; prefer it over
+	// the raw chain unless a PelicanError below supplies its own.
+	var te *client.TransferErrors
+	if errors.As(err, &te) {
+		msg = te.UserError()
+	}
+	var pe *error_codes.PelicanError
+	if errors.As(err, &pe) {
+		// A PelicanError's exit code already encodes whether it is worth
+		// retrying, so it is authoritative on its own.
+		return pe.ExitCode(), pe.Error()
+	}
+	if client.ShouldRetry(err) {
+		return Retryable, msg
+	}
+	return 1, msg
+}
+
+// exitTransferFailure reports a failed transfer and terminates with the exit
+// code its error class calls for. The prefix is the "Failure getting <url>"
+// style lead-in; the classified message is appended to it.
+//
+// Both lines reach stderr even when Logging.LogLocation is redirecting the log
+// to a file, so the reason for a non-zero exit is never invisible.
+func exitTransferFailure(err error, prefix string) {
+	code, msg := classifyTransferFailure(err)
+	if code == Retryable {
+		reportError(prefix + ": " + msg)
+		exitWithError(code, "Errors are retryable")
+	}
+	exitWithError(code, prefix+": "+msg)
+}

--- a/cmd/transfer_errors_test.go
+++ b/cmd/transfer_errors_test.go
@@ -1,0 +1,130 @@
+//go:build client
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/error_codes"
+)
+
+// TestClassifyTransferFailureExitCodes pins the exit code each error class
+// maps to. Before this was fixed the commands recovered the PelicanError with
+// errors.Is against a freshly declared value, which never matched, so every
+// classified failure exited 1 -- a permission denial was indistinguishable
+// from a usage error.
+func TestClassifyTransferFailureExitCodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantMsg  string
+	}{
+		{
+			name:     "authorization error keeps its own exit code",
+			err:      errors.Wrap(error_codes.NewAuthorizationError(errors.New("Permission denied: not authorized")), "failed download"),
+			wantCode: 7,
+			wantMsg:  "Authorization Error: Error code 4000: Permission denied: not authorized",
+		},
+		{
+			name:     "director contact error keeps its own exit code",
+			err:      errors.Wrap(error_codes.NewContact_DirectorError(errors.New("404: no sources found")), "failed download"),
+			wantCode: 6,
+			wantMsg:  "Contact.Director Error: Error code 3001: 404: no sources found",
+		},
+		{
+			name:     "specification error keeps its own exit code",
+			err:      error_codes.NewSpecification_FileNotFoundError(errors.New("no such object")),
+			wantCode: 8,
+			wantMsg:  "Specification.FileNotFound Error: Error code 5011: no such object",
+		},
+		{
+			name:     "unclassified error falls back to 1",
+			err:      errors.New("something went sideways"),
+			wantCode: 1,
+			wantMsg:  "something went sideways",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, msg := classifyTransferFailure(tc.err)
+			assert.Equal(t, tc.wantCode, code)
+			assert.Equal(t, tc.wantMsg, msg)
+		})
+	}
+}
+
+// TestPelicanErrorRequiresAs guards the reason classifyTransferFailure uses
+// errors.As. If someone gives PelicanError an Is method to make the old
+// comparison work, the target stays the zero value and its ExitCode() is 0 --
+// the command would report success for a failed transfer.
+func TestPelicanErrorRequiresAs(t *testing.T) {
+	wrapped := errors.Wrap(error_codes.NewAuthorizationError(errors.New("Permission denied")), "failed download")
+
+	var peVal error_codes.PelicanError
+	require.False(t, errors.Is(wrapped, &peVal),
+		"errors.Is cannot recover a PelicanError; use errors.As")
+	assert.Equal(t, 0, peVal.ExitCode(),
+		"a zero-value PelicanError exits 0, which is why Is must not be made to match here")
+
+	var pePtr *error_codes.PelicanError
+	require.True(t, errors.As(wrapped, &pePtr))
+	assert.Equal(t, 7, pePtr.ExitCode())
+}
+
+// TestFatalErrorReachesUser covers the other half of a silent failure: with
+// Logging.LogLocation set, log output is redirected to the file, so a fatal
+// error reached neither the terminal nor -- because os.Exit runs no defers and
+// the async log writer never drained -- the log file itself.
+func TestFatalErrorReachesUser(t *testing.T) {
+	binaryPath := getPelicanBinary(t)
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "pelican.log")
+
+	// "object get" with a single argument is a usage failure: it exits through
+	// the same reporting path as a transfer failure without needing a network.
+	cmd := exec.Command(binaryPath, "object", "get", "onearg")
+	cmd.Env = append(os.Environ(),
+		"PELICAN_LOGGING_LOGLOCATION="+logFile,
+		"PELICAN_CONFIGDIR="+filepath.Join(tempDir, "config"),
+	)
+	stderr, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "expected a non-zero exit")
+	assert.NotEqual(t, 0, exitErr.ExitCode())
+
+	assert.Contains(t, string(stderr), "No Source or Destination",
+		"the reason for the exit must reach the terminal even when logs go to a file")
+
+	logData, readErr := os.ReadFile(logFile)
+	require.NoError(t, readErr, "the log file should exist")
+	assert.Contains(t, string(logData), "No Source or Destination",
+		"the log writer must drain before the process exits")
+}


### PR DESCRIPTION
Fixes #3700.

A download that hit a 403 printed nothing at all and exited 1. Reproduced with a simple case: one-argument `object get`, which exits through the same reporting path:

```
BEFORE:  $ pelican object get onearg    → exit 1, nothing on stderr, 0 hits in the log file
AFTER:   $ pelican object get onearg    → exit 1, message on stderr AND in the log file
```

Three separate defects stacked up to produce that silence. They map onto the three items in the issue.

### 1. `os.Exit` discarded the log tail

The async log writer batches for up to `Logging.Rotation.FlushInterval` (50ms), and `os.Exit` runs no defers, so the last flush interval of lines was dropped. That is why the log ended mid-transfer with no outputs.

`exitWithFlush` already existed for this but only `main.go` called it. The other **205 `os.Exit` calls across 18 files in `cmd/`** went straight to `os.Exit`.

These are fixed and I found a linter (`forbidigo`) that can flags these cases.  Here's an example linter error if someone tries to add an `os.Exit` call:

```
cmd/object_get.go:112:3: use of `os.Exit` forbidden because "os.Exit runs no defers, so the asynchronous log writer never drains and the line explaining the exit is lost..." (forbidigo)
```

### 2. Nothing reached stderr when `LogLocation` was set

File logging redirects everything, so the terminal got only the exit status. The new `reportError` mirrors the lines that explain a failing exit to stderr. This is done only at explicit CLI sites, respecting that `LogLocation` should be where logs mostly go. Verified there is no double-printing when logs are still buffered.

### 3. `errors.Is` could never match, so the exit code was always 1

`PelicanError` has no `Is` method, so `errors.Is(err, &pe)` against a freshly declared value fell back to pointer equality and was always false. Every classified failure exited 1 rather than the code in `docs/error_codes.yaml`.

Translated to `errors.As` since we need a copy of the error to get exit code.

### ⚠️ Behavior change

**Client exit codes change.** `object get` *intended* to return classified codes but never did (always returned exit code 1). It now returns those documented (the 403 case returns **7**, and a director 404 as **6**). I also extended classification to `ls`/`stat`/`put`/`copy`, which never had it.

No docs change as it was the specified behavior in the docs.  May be worthwhile for release notes.

### Bonus fix

Consolidating the eight object commands onto one classifier surfaced a pre-existing bug: `object copy` tested `client.ShouldRetry(err)`, where `err` was the nil rather than the transfer's own `result`.  So, `object copy` could *never* indicate a retry code (11).

### Testing

- Three new tests in `cmd/transfer_errors_test.go`: exit-code mapping per error class, the `Is`-vs-`As` guard, and an end-to-end subprocess test asserting a fatal error reaches both stderr and the log file.
