### PR TITLE
Bind Registration with Pelican User

### DIFF
--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -813,6 +813,12 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Server_HealthMonitoringPublic.GetName(), false)
 	// Server.NewUserDefaultScopes
 	v.SetDefault(param.Server_NewUserDefaultScopes.GetName(), []string{"web_ui.access"})
+	// Server.RegistrationCompletionLinkFile
+	{
+		val := "${ConfigBase}/server-registration-completion-link"
+		val = strings.ReplaceAll(val, "${ConfigBase}", v.GetString(param.ConfigBase.GetName()))
+		v.SetDefault(param.Server_RegistrationCompletionLinkFile.GetName(), val)
+	}
 	// Server.RegistrationRetryInterval
 	v.SetDefault(param.Server_RegistrationRetryInterval.GetName(), "10s")
 	// Server.SSRFProtection.Disabled
@@ -1238,6 +1244,14 @@ func ApplyDerivedDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 				val = strings.ReplaceAll(val, "${ConfigBase}", v.GetString(param.ConfigBase.GetName()))
 				v.SetDefault(param.Server_DbLocation.GetName(), val)
 			}
+		}
+	}
+	// Server.RegistrationCompletionLinkFile
+	if isDefaultSource(param.Server_RegistrationCompletionLinkFile.GetName()) {
+		{
+			val := "${ConfigBase}/server-registration-completion-link"
+			val = strings.ReplaceAll(val, "${ConfigBase}", v.GetString(param.ConfigBase.GetName()))
+			v.SetDefault(param.Server_RegistrationCompletionLinkFile.GetName(), val)
 		}
 	}
 	// Server.SessionSecretFile

--- a/database/collection.go
+++ b/database/collection.go
@@ -3,6 +3,7 @@ package database
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
@@ -470,12 +472,18 @@ type GroupMember struct {
 //     authenticated — we need a real user to transfer ownership to.
 //     Forced single-use: ownership transfer is by definition a
 //     one-shot operation.
+//   - InviteKindRegistrationOwnership: redeem-time, the *caller's* user
+//     becomes the owner of the registry registration named by
+//     RegistrationID (their Pelican User.ID is written into the
+//     registration's admin metadata). Caller must be authenticated.
+//     Forced single-use, mirroring collection-ownership invites.
 type InviteKind string
 
 const (
-	InviteKindGroup               InviteKind = "group"
-	InviteKindPassword            InviteKind = "password"
-	InviteKindCollectionOwnership InviteKind = "collection_ownership"
+	InviteKindGroup                 InviteKind = "group"
+	InviteKindPassword              InviteKind = "password"
+	InviteKindCollectionOwnership   InviteKind = "collection_ownership"
+	InviteKindRegistrationOwnership InviteKind = "registration_ownership"
 )
 
 // AuthMethod records how the *creator* of a record was authenticated at
@@ -544,7 +552,11 @@ type GroupInviteLink struct {
 	// names the collection whose ownership transfers to the redeemer.
 	// Empty for every other kind.
 	CollectionID string `gorm:"not null;default:''" json:"collectionId"`
-	HashedToken  string `gorm:"column:invite_token;not null;unique" json:"-"`
+	// RegistrationID is set when Kind == InviteKindRegistrationOwnership;
+	// names the registry registration whose ownership transfers to the
+	// redeemer. Zero for every other kind.
+	RegistrationID int    `gorm:"not null;default:0" json:"registrationId"`
+	HashedToken    string `gorm:"column:invite_token;not null;unique" json:"-"`
 	// TokenPrefix is the first few characters of the *plaintext* token,
 	// captured at mint time. It is NOT a credential — too narrow to brute
 	// force into the bcrypt hash — but is enough to label, sort, and
@@ -3061,6 +3073,135 @@ func RedeemCollectionOwnershipInviteLink(db *gorm.DB, plaintext string, redeemer
 		return "", "", err
 	}
 	return collectionID, previousOwnerID, nil
+}
+
+// CreateRegistrationOwnershipInviteLink mints a single-use invite that,
+// when redeemed by an authenticated user, transfers ownership of the
+// registry registration to that user. Unlike the collection variant,
+// the ownership gate (only the registration's current owner or a
+// registry admin may mint) is enforced by the caller: the registration
+// permission model lives in the registry package, which is the only
+// caller of this helper.
+//
+// Single-use is forced — ownership transfer is by definition a
+// one-shot operation.
+func CreateRegistrationOwnershipInviteLink(db *gorm.DB, registrationID int, createdByUserID string, expiresAt time.Time, authMethod AuthMethod, authMethodID string) (*GroupInviteLink, string, error) {
+	if registrationID <= 0 {
+		return nil, "", errors.New("registrationID is required")
+	}
+	return mintInviteLink(db, GroupInviteLink{
+		Kind:           InviteKindRegistrationOwnership,
+		RegistrationID: registrationID,
+		CreatedBy:      createdByUserID,
+		AuthMethod:     authMethod,
+		AuthMethodID:   authMethodID,
+		ExpiresAt:      expiresAt,
+		IsSingleUse:    true,
+	})
+}
+
+// RedeemRegistrationOwnershipInviteLink consumes a plaintext ownership
+// invite and records the redeemer's Pelican User.ID as the owner of the
+// registry registration. The link is marked redeemed in the same
+// transaction so subsequent redemption attempts fail.
+//
+// Returns (registrationID, registrationPrefix, error); the prefix lets
+// the redemption page tell the user what they now own.
+func RedeemRegistrationOwnershipInviteLink(db *gorm.DB, plaintext string, redeemerUserID string) (int, string, error) {
+	if redeemerUserID == "" {
+		return 0, "", errors.New("redeemer user ID is required")
+	}
+	var registrationID int
+	var registrationPrefix string
+	err := db.Transaction(func(tx *gorm.DB) error {
+		var links []GroupInviteLink
+		if err := tx.Where("revoked = 0 AND expires_at > ? AND kind = ?", time.Now(), InviteKindRegistrationOwnership).Find(&links).Error; err != nil {
+			return err
+		}
+		var link *GroupInviteLink
+		for i := range links {
+			if err := bcrypt.CompareHashAndPassword([]byte(links[i].HashedToken), []byte(plaintext)); err == nil {
+				link = &links[i]
+				break
+			}
+		}
+		if link == nil {
+			return gorm.ErrRecordNotFound
+		}
+		// Single-use is the only supported mode, but check defensively
+		// in case a future schema relaxes that constraint.
+		if link.IsSingleUse && link.RedeemedBy != "" {
+			return errors.New("invite link has already been redeemed")
+		}
+		// The registration must still exist and the redeemer must be a
+		// real, active user.
+		var reg server_structs.Registration
+		if err := tx.First(&reg, "id = ?", link.RegistrationID).Error; err != nil {
+			return err
+		}
+		var redeemer User
+		if err := tx.First(&redeemer, "id = ?", redeemerUserID).Error; err != nil {
+			return err
+		}
+		if redeemer.Status != UserStatusActive {
+			return errors.New("redeemer's account is not active")
+		}
+		registrationID = reg.ID
+		registrationPrefix = reg.Prefix
+
+		// Claim the link FIRST with a race-safe conditional update, the
+		// same guard the other redeem paths use, so two concurrent
+		// redemptions can't both perform the transfer.
+		now := time.Now()
+		claim := tx.Model(&GroupInviteLink{}).
+			Where("id = ? AND redeemed_by = ''", link.ID).
+			Updates(map[string]interface{}{
+				"redeemed_by": redeemer.ID,
+				"redeemed_at": &now,
+			})
+		if claim.Error != nil {
+			return claim.Error
+		}
+		if claim.RowsAffected == 0 {
+			return errors.New("invite link has already been redeemed")
+		}
+
+		// The owner lives inside the JSON-serialized admin metadata, so
+		// transfer via read-modify-write within this transaction.
+		reg.AdminMetadata.UserID = redeemer.ID
+		reg.AdminMetadata.UpdatedAt = now
+		adminMetadataBytes, err := json.Marshal(reg.AdminMetadata)
+		if err != nil {
+			return err
+		}
+		if err := tx.Model(&server_structs.Registration{}).
+			Where("id = ?", reg.ID).
+			Update("admin_metadata", string(adminMetadataBytes)).Error; err != nil {
+			return err
+		}
+		// A successful transfer invalidates every other outstanding invite
+		// for this registration: they were minted under the previous owner's
+		// authority, which the transfer just ended.
+		return RevokeRegistrationOwnershipInviteLinks(tx, reg.ID)
+	})
+	if err != nil {
+		return 0, "", err
+	}
+	return registrationID, registrationPrefix, nil
+}
+
+// RevokeRegistrationOwnershipInviteLinks revokes every outstanding
+// (unredeemed, unrevoked) ownership-transfer invite for the given
+// registration. Call it whenever the registration's owner changes (a claim
+// or an invite redemption) so links minted under the previous owner's
+// authority cannot transfer the registration out from under the new owner.
+// Accepts a transaction so callers can revoke atomically with the owner
+// write.
+func RevokeRegistrationOwnershipInviteLinks(db *gorm.DB, registrationID int) error {
+	return db.Model(&GroupInviteLink{}).
+		Where("kind = ? AND registration_id = ? AND redeemed_by = '' AND revoked = 0",
+			InviteKindRegistrationOwnership, registrationID).
+		Update("revoked", true).Error
 }
 
 // mintInviteLink fills in the bookkeeping (id, token, hash, prefix) and

--- a/database/registration_invite_test.go
+++ b/database/registration_invite_test.go
@@ -1,0 +1,161 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// registrationInviteTestDB extends the shared collection test DB with the
+// registrations table the ownership-transfer helpers operate on.
+func registrationInviteTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := setupCollectionTestDB(t)
+	require.NoError(t, db.AutoMigrate(&server_structs.Registration{}))
+	return db
+}
+
+func registrationInviteTestRegistration(t *testing.T, db *gorm.DB, owner string) int {
+	t.Helper()
+	reg := server_structs.Registration{
+		Prefix: "/origins/example.org",
+		Pubkey: "mock-pubkey",
+		AdminMetadata: server_structs.AdminMetadata{
+			UserID:   owner,
+			SiteName: "example-site",
+			Status:   server_structs.RegApproved,
+		},
+	}
+	require.NoError(t, db.Create(&reg).Error)
+	return reg.ID
+}
+
+func TestRegistrationOwnershipInviteLink(t *testing.T) {
+	t.Run("mint-and-redeem-transfers-owner", func(t *testing.T) {
+		db := registrationInviteTestDB(t)
+		regID := registrationInviteTestRegistration(t, db, "u-old-owner")
+		redeemer, err := CreateLocalUser(db, "bob", "Bob", "https://local", CreatorSelf())
+		require.NoError(t, err)
+
+		link, plaintext, err := CreateRegistrationOwnershipInviteLink(
+			db, regID, "u-old-owner", time.Now().Add(time.Hour), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, InviteKindRegistrationOwnership, link.Kind)
+		assert.Equal(t, regID, link.RegistrationID)
+		assert.True(t, link.IsSingleUse, "ownership transfer must be single-use")
+
+		gotID, gotPrefix, err := RedeemRegistrationOwnershipInviteLink(db, plaintext, redeemer.ID)
+		require.NoError(t, err)
+		assert.Equal(t, regID, gotID)
+		assert.Equal(t, "/origins/example.org", gotPrefix)
+
+		var reg server_structs.Registration
+		require.NoError(t, db.First(&reg, "id = ?", regID).Error)
+		assert.Equal(t, redeemer.ID, reg.AdminMetadata.UserID,
+			"the redeemer's Pelican user ID must be recorded as the owner")
+		// Everything else in the admin metadata survives the transfer
+		assert.Equal(t, "example-site", reg.AdminMetadata.SiteName)
+		assert.Equal(t, server_structs.RegApproved, reg.AdminMetadata.Status)
+	})
+
+	t.Run("second-redemption-fails", func(t *testing.T) {
+		db := registrationInviteTestDB(t)
+		regID := registrationInviteTestRegistration(t, db, "u-old-owner")
+		redeemer1, err := CreateLocalUser(db, "bob", "Bob", "https://local", CreatorSelf())
+		require.NoError(t, err)
+		redeemer2, err := CreateLocalUser(db, "carol", "Carol", "https://local", CreatorSelf())
+		require.NoError(t, err)
+
+		_, plaintext, err := CreateRegistrationOwnershipInviteLink(
+			db, regID, "u-old-owner", time.Now().Add(time.Hour), "", "")
+		require.NoError(t, err)
+
+		_, _, err = RedeemRegistrationOwnershipInviteLink(db, plaintext, redeemer1.ID)
+		require.NoError(t, err)
+		_, _, err = RedeemRegistrationOwnershipInviteLink(db, plaintext, redeemer2.ID)
+		assert.Error(t, err, "a single-use link must not transfer ownership twice")
+
+		var reg server_structs.Registration
+		require.NoError(t, db.First(&reg, "id = ?", regID).Error)
+		assert.Equal(t, redeemer1.ID, reg.AdminMetadata.UserID)
+	})
+
+	t.Run("expired-link-fails", func(t *testing.T) {
+		db := registrationInviteTestDB(t)
+		regID := registrationInviteTestRegistration(t, db, "u-old-owner")
+		redeemer, err := CreateLocalUser(db, "bob", "Bob", "https://local", CreatorSelf())
+		require.NoError(t, err)
+
+		_, plaintext, err := CreateRegistrationOwnershipInviteLink(
+			db, regID, "u-old-owner", time.Now().Add(-time.Minute), "", "")
+		require.NoError(t, err)
+
+		_, _, err = RedeemRegistrationOwnershipInviteLink(db, plaintext, redeemer.ID)
+		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	})
+
+	t.Run("rejects-invalid-registration-id", func(t *testing.T) {
+		db := registrationInviteTestDB(t)
+		_, _, err := CreateRegistrationOwnershipInviteLink(
+			db, 0, "u-creator", time.Now().Add(time.Hour), "", "")
+		assert.Error(t, err)
+	})
+
+	t.Run("owner-change-revokes-other-outstanding-invites", func(t *testing.T) {
+		db := registrationInviteTestDB(t)
+		regID := registrationInviteTestRegistration(t, db, "u-old-owner")
+		redeemer, err := CreateLocalUser(db, "bob", "Bob", "https://local", CreatorSelf())
+		require.NoError(t, err)
+		rival, err := CreateLocalUser(db, "carol", "Carol", "https://local", CreatorSelf())
+		require.NoError(t, err)
+
+		_, plaintext1, err := CreateRegistrationOwnershipInviteLink(
+			db, regID, "u-old-owner", time.Now().Add(time.Hour), "", "")
+		require.NoError(t, err)
+		link2, plaintext2, err := CreateRegistrationOwnershipInviteLink(
+			db, regID, "u-old-owner", time.Now().Add(time.Hour), "", "")
+		require.NoError(t, err)
+
+		// The first redemption transfers ownership; the sibling invite was
+		// minted under the previous owner's authority and must die with it.
+		_, _, err = RedeemRegistrationOwnershipInviteLink(db, plaintext1, redeemer.ID)
+		require.NoError(t, err)
+
+		var sibling GroupInviteLink
+		require.NoError(t, db.First(&sibling, "id = ?", link2.ID).Error)
+		assert.True(t, sibling.Revoked,
+			"outstanding invites must be revoked when the owner changes")
+
+		_, _, err = RedeemRegistrationOwnershipInviteLink(db, plaintext2, rival.ID)
+		assert.ErrorIs(t, err, gorm.ErrRecordNotFound,
+			"a revoked invite must not transfer ownership")
+
+		var reg server_structs.Registration
+		require.NoError(t, db.First(&reg, "id = ?", regID).Error)
+		assert.Equal(t, redeemer.ID, reg.AdminMetadata.UserID,
+			"ownership must stay with the first redeemer")
+	})
+}

--- a/database/registration_owner_migration.go
+++ b/database/registration_owner_migration.go
@@ -1,0 +1,154 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package database
+
+import (
+	"database/sql"
+	"encoding/json"
+	"regexp"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// This file serves as the db migration for v26.0 and could be removed later.
+
+// cilogonSubjectRegexp matches the owner encoding the registry used before the
+// 7.27 user model: the raw CILogon OIDC `sub` claim of the user who registered,
+// e.g. http://cilogon.org/serverA/users/12345.
+var cilogonSubjectRegexp = regexp.MustCompile(`^https?://cilogon\.org/server[A-Za-z0-9]+/users/[0-9]+$`)
+
+// migrateLegacyRegistrationOwners re-homes registrations whose
+// admin_metadata.user_id still holds a raw CILogon subject onto the Pelican
+// user ID of the account carrying that subject, so the ownership checks
+// (which compare Pelican user IDs only) recognise the original registrant.
+//
+// Only registrations whose owner value looks like a CILogon subject are
+// considered; rows with an empty owner, a Pelican user ID, or any other
+// value are left untouched (those are handled through other paths, e.g.
+// self claiming link or an admin-minted ownership-transfer invite). A
+// subject is only resolved when exactly one live user carries it; an
+// ambiguous subject present under several issuers is skipped with a warning.
+func migrateLegacyRegistrationOwners(db *gorm.DB) error {
+	type candidate struct {
+		id     int
+		prefix string
+		sub    string
+	}
+
+	// Read the raw JSON: legacy rows may carry an empty or malformed
+	// admin_metadata column that the GORM JSON serializer would reject.
+	var candidates []candidate
+	subjects := make(map[string]struct{})
+	if err := func() error {
+		rows, err := db.Raw("SELECT id, prefix, admin_metadata FROM registrations").Rows()
+		if err != nil {
+			return errors.Wrap(err, "failed to list registrations")
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				id     int
+				prefix string
+				meta   sql.NullString
+			)
+			if err := rows.Scan(&id, &prefix, &meta); err != nil {
+				return errors.Wrap(err, "failed to scan registration row")
+			}
+			if !meta.Valid || meta.String == "" {
+				continue
+			}
+			var parsed struct {
+				UserID string `json:"user_id"`
+			}
+			if err := json.Unmarshal([]byte(meta.String), &parsed); err != nil {
+				log.Debugf("Skipping registration %d (%s): admin_metadata is not valid JSON: %v", id, prefix, err)
+				continue
+			}
+			if parsed.UserID == "" || !cilogonSubjectRegexp.MatchString(parsed.UserID) {
+				continue
+			}
+			candidates = append(candidates, candidate{id: id, prefix: prefix, sub: parsed.UserID})
+			subjects[parsed.UserID] = struct{}{}
+		}
+		return rows.Err()
+	}(); err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		log.Debug("No registrations owned by a legacy CILogon subject; nothing to migrate")
+		return nil
+	}
+
+	// Resolve subjects to Pelican user IDs. The users table is unique on
+	// (sub, issuer), so one subject can exist under several issuers; such
+	// subjects cannot be attributed to a single account and are skipped.
+	// Soft-deleted users are excluded by GORM automatically.
+	subjectList := make([]string, 0, len(subjects))
+	for sub := range subjects {
+		subjectList = append(subjectList, sub)
+	}
+	var users []User
+	if err := db.Select("id", "sub", "issuer").Where("sub IN ?", subjectList).Find(&users).Error; err != nil {
+		return errors.Wrap(err, "failed to look up users by subject")
+	}
+	subToUserID := make(map[string]string, len(users))
+	ambiguous := make(map[string]bool)
+	for _, u := range users {
+		if _, seen := subToUserID[u.Sub]; seen {
+			ambiguous[u.Sub] = true
+			continue
+		}
+		subToUserID[u.Sub] = u.ID
+	}
+
+	rewritten, unresolved, skippedAmbiguous := 0, 0, 0
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		for _, c := range candidates {
+			if ambiguous[c.sub] {
+				skippedAmbiguous++
+				log.Warnf("Not re-homing registration %d (%s): legacy owner %s matches more than one user account", c.id, c.prefix, c.sub)
+				continue
+			}
+			userID, ok := subToUserID[c.sub]
+			if !ok {
+				unresolved++
+				continue
+			}
+			// json_set rewrites only the user_id key and leaves the rest of the
+			// stored metadata byte-for-byte as it was.
+			if err := tx.Exec(
+				"UPDATE registrations SET admin_metadata = json_set(admin_metadata, '$.user_id', ?) WHERE id = ?",
+				userID, c.id,
+			).Error; err != nil {
+				return errors.Wrapf(err, "failed to re-home registration %d (%s)", c.id, c.prefix)
+			}
+			rewritten++
+			log.Infof("Re-homed registration %d (%s) from legacy owner %s to Pelican user %s", c.id, c.prefix, c.sub, userID)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	log.Infof("Legacy registration owner migration: %d re-homed, %d waiting for the owner's first login, %d ambiguous",
+		rewritten, unresolved, skippedAmbiguous)
+	return nil
+}

--- a/database/server.go
+++ b/database/server.go
@@ -145,6 +145,11 @@ func InitServerDatabase(serverType server_structs.ServerType) error {
 			log.Errorf("Failed to populate the data for the new server tables: %v", err)
 			return errors.Wrap(err, "server data migration failed")
 		}
+
+		// Migrate registrations owned by a CILogon subject to the Pelican user id carrying that subject
+		if err := migrateLegacyRegistrationOwners(ServerDatabase); err != nil {
+			log.Warnf("Legacy registration owner migration failed: %v", err)
+		}
 	}
 
 	return nil

--- a/database/universal_migrations/20260704120000_invite_links_registration_ownership.sql
+++ b/database/universal_migrations/20260704120000_invite_links_registration_ownership.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- New invite-link kind: 'registration_ownership'. The link, when
+-- redeemed by an authenticated user, transfers ownership of a registry
+-- registration (registrations.admin_metadata user_id) to the redeemer.
+-- Single-use is forced at the application layer, mirroring
+-- collection-ownership invites.
+--
+-- RegistrationID parallels the existing GroupID / TargetUserID /
+-- CollectionID pattern: per-row, defaulted to 0 so older rows pass the
+-- NOT NULL constraint without a backfill. (Registration IDs are the
+-- integer primary keys of the registrations table.)
+ALTER TABLE group_invite_links
+  ADD COLUMN registration_id INTEGER NOT NULL DEFAULT 0;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- SQLite cannot DROP COLUMN cleanly; the down migration is a no-op.
+-- +goose StatementEnd

--- a/docs/app/federating-your-data/_meta.js
+++ b/docs/app/federating-your-data/_meta.js
@@ -1,5 +1,6 @@
 export default {
     "choosing-namespaces": "Choosing a Namespace Prefix",
+    "registration": "Service Registration & Ownership",
     "origin": "Serving an Origin",
     "s3-backend": "S3 Backend",
     "globus-backend": "Globus Backend",

--- a/docs/app/federating-your-data/origin/page.mdx
+++ b/docs/app/federating-your-data/origin/page.mdx
@@ -456,6 +456,7 @@ This asserts your ownership over the namespace and gives you the ability to furt
 For more information about how to choose these prefixes, see [Choosing a Namespace Prefix](./choosing-namespaces.mdx)
 
 Generally this process is a pre-requisite to setting up an functional Origin, but it's not included in this page's "Before Starting" section because Origins attempt to do this automatically on server startup.
+For how that automatic registration works (including claiming the registration as your own and managing it afterwards), see [Service Registration & Ownership](./registration.mdx).
 However, there are some cases where you may not wish to rely on this automatic feature.
 These may include:
 - Your federation requires namespace registration approval and you want to complete this ahead of time

--- a/docs/app/federating-your-data/registration/page.mdx
+++ b/docs/app/federating-your-data/registration/page.mdx
@@ -1,0 +1,89 @@
+import { Callout } from 'nextra/components'
+
+# Service Registration & Ownership
+
+Every Origin, Cache, and namespace prefix in a federation exists as a **registration** in the federation's [***Registry***](../about-pelican/core-concepts.mdx#registry-service).
+
+Registrations follow a self-service workflow:
+1. Your service registers itself automatically as `Incomplete`.
+2. You **claim** the registration through a service-provided link.
+3. You submit a completed registration form for administrator review.
+4. Once approved, you can manage, transfer, or update the registration.
+
+For guidance on choosing a prefix, see [Choosing a Namespace Prefix](./choosing-namespaces.mdx).
+To register a prefix manually in advance, see [Federation Namespace Prefix Registration](./origin.mdx#federation-namespace-prefix-registration).
+
+## Registration Lifecycle
+
+| Status | Meaning |
+| :--- | :--- |
+| `Incomplete` | Auto-registered by the service. Unowned and awaiting form completion. |
+| `Pending` | Claimed by an owner with a submitted form. Awaiting administrator review. |
+| `Approved` | Granted federation access. |
+| `Denied` | Turned down by an administrator. Editable and resubmittable for review. |
+
+* **Transition Rules:** Claiming and submitting an `Incomplete` registration moves it to `Pending`. An administrator then moves it to `Approved` or `Denied`.
+* **Re-submitting:** Denial is non-final. Editing and resubmitting a `Denied` registration returns it to `Pending`.
+* **Trust Boundary:** Approval is the primary trust boundary. The Director only routes traffic to `Approved` services, and once approved, core properties can only be altered by an administrator.
+
+<Callout type="info">
+Only registrations created by Pelican 26.0+ services start as `Incomplete`. Existing federation registrations retain their current status and meaning.
+</Callout>
+
+## How Services Register
+
+### 1. Automatic Registration
+When an Origin or Cache starts up, it automatically registers with the federation's Registry by proving ownership of its issuer keypair.
+It submits its public key, namespace prefix(es), and site name, entering the system as `Incomplete`.
+
+### 2. Finding the Registration Link
+While a registration remains incomplete, the service generates a **registration completion link** (valid for 15 minutes and refreshed every 10 minutes). Access this link through:
+
+* **Service Logs / stdout:** Indicated by `Complete server registration at <link> (expire at <local time>)`.
+* **Link File:** Output to the path defined in [`Server.RegistrationCompletionLinkFile`](../parameters.mdx#Server-RegistrationCompletionLinkFile) (one line per prefix) for headless or automated setups.
+The file is removed once all registrations are complete.
+* **Origin Admin UI:** Displayed under the **Data Exports** table for each prefix.
+
+### 3. Claiming Ownership
+1. Open the completion link.
+2. Log in through the Registry's authentication flow (e.g., CILogon) if prompted.
+3. Review the registration details on the **claim page** and click **Accept**.
+
+Upon acceptance, the Registry verifies the link's token against the service's public key and assigns ownership to your **Pelican user account**. The link then expires and is removed.
+
+> **Rules & Constraints:**
+> * Only **unowned** registrations can be claimed.
+> * Unowned registrations can be claimed in any status (including registrations approved prior to ownership enforcement).
+> * Ownership requires an authenticated Pelican user account; anonymous or token-only access is not permitted.
+
+### 4. Submitting Details
+Once claimed, you will be directed to the registration form:
+1. Complete all required federation fields (e.g., institution, description, custom fields).
+2. Confirm the security contact (defaults to your account).
+3. Submit the form to transition status to `Pending` (displayed to admins as "Pending (Ready to review)").
+
+*Note: Your service does not require a restart during this process. It will automatically detect approval via Registry polling and go live.*
+
+## Post-Registration Management
+
+As a registration owner, you can manage your resource through the Registry UI:
+
+* **Resubmit Rejected Entries:** Edit a `Denied` registration and resubmit it to return it to the `Pending` queue.
+* **Transfer Ownership:** Generate a single-use, expiring invite link from the registration's card. Once a colleague logs into their Pelican account and redeems the link, ownership is transferred to them.
+
+## Upgrading to Pelican 26.0+
+
+In Pelican 26.0+, ownership is bound to your Registry **User ID** rather than login usernames or identity strings (e.g., CILogon sub).
+
+* **Unowned Legacy Registrations:** Registrations created before Pelican 26.0 can be claimed using a completion link once running 26.0+, or via the Origin Web UI on any version.
+* **Legacy Ownership Strings:** Registrations with older owner strings are automatically migrated to Pelican User IDs upon upgrading the Registry to 26.0 without breaking backwards compatibility.
+* **Loss of Admin Access:** If you lose access to your Pelican service following an upgrade, request an ownership-transfer link from a federation administrator to re-bind the service to your account.
+
+## For Federation Administrators
+
+Administrators manage registrations via the Registry web UI (see [Serving a Pelican Registry](../operating-a-federation/registry.mdx)):
+
+* **Review Queue Priority:** Items marked `Pending (Ready to review)` appear at the top of the queue. `Incomplete` registrations are grouped separately as they do not yet require review.
+* **Editing & Decisions:** You may edit registration fields ("correct") prior to approving or denying a submission.
+* **Manual Overrides:** You can directly approve an `Incomplete` registration (useful for legacy services where operators cannot access claim links).
+* **Transfer Invites:** You can generate an ownership-transfer link for **any** registration to help reassign legacy entries to active Pelican user accounts.

--- a/docs/app/operating-a-federation/registry/page.mdx
+++ b/docs/app/operating-a-federation/registry/page.mdx
@@ -74,6 +74,7 @@ Once you finish the initialization, you should be able to see the following page
 <ExportedImage width={1000} height={1000} src={"/pelican/registry-admin.png"} alt={"Image registry home page in public view"} />
 
 You may view and manage namespaces registered in your federation. Pending registrations are shown as the first list and you can click each namespace strip for more detailed information. You can click the check button to approve a namespace registration or the cross button to deny the registration. As an admin user, you can also edit the registration by clicking the pencil icon.
+For the full registration lifecycle — how services auto-register as `Incomplete`, and how operators claim and own their registrations — see [Service Registration & Ownership](../federating-your-data/registration.mdx).
 
 For approved namespaces, you can download the public key associated with the namespace by clicking the downward-arrow button.
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4367,6 +4367,17 @@ type: duration
 default: 10s
 components: ["cache", "origin"]
 ---
+name: Server.RegistrationCompletionLinkFile
+description: |+
+  While any of this server's registrations at the federation registry is incomplete, the
+  "complete server registration" request link (carrying a fresh short-lived access token)
+  is re-written to this file on every registration completeness poll cycle and echoed to
+  the server's logs. The file is removed once no incomplete registration remains.
+  Set to an empty string to disable writing the file; the link is then only logged.
+type: filename
+default: ${ConfigBase}/server-registration-completion-link
+components: ["cache", "origin"]
+---
 name: Server.UILoginRateLimit
 description: |+
   The maximum number of requests a user can be made under the same IP address per second against the login endpoint

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -26,6 +26,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -287,6 +291,122 @@ func registerNamespaceImpl(key jwk.Key, prefix string, siteName string, registra
 	return nil
 }
 
+// The registration edit token attached to the completion link is valid for
+// origin.RegEditTokenLifetime (15 minutes); re-write the link (with a fresh
+// token) at a shorter interval so the most recent link is always usable.
+const regCompletionLinkInterval = 10 * time.Minute
+
+// Request-link lines for this server's incomplete registrations, one per
+// prefix, mirrored into Server.RegistrationCompletionLinkFile.
+var (
+	regCompletionLinksMutex sync.Mutex
+	regCompletionLinks      = make(map[string]string)
+)
+
+// updateRegCompletionLinkFile records (line != "") or clears (line == "") the
+// request-link line for the given prefix, then re-writes the registration
+// completion link file so it always holds the current set of links. The file
+// is removed once no incomplete registration remains. It returns the file's
+// new contents along with its path ("" when the file is disabled).
+func updateRegCompletionLinkFile(prefix string, line string) (contents string, path string, err error) {
+	regCompletionLinksMutex.Lock()
+	defer regCompletionLinksMutex.Unlock()
+	if line == "" {
+		delete(regCompletionLinks, prefix)
+	} else {
+		regCompletionLinks[prefix] = line
+	}
+	prefixes := make([]string, 0, len(regCompletionLinks))
+	for p := range regCompletionLinks {
+		prefixes = append(prefixes, p)
+	}
+	sort.Strings(prefixes)
+	builder := strings.Builder{}
+	for _, p := range prefixes {
+		builder.WriteString(regCompletionLinks[p])
+		builder.WriteString("\n")
+	}
+	contents = builder.String()
+	path = param.Server_RegistrationCompletionLinkFile.GetString()
+	if path == "" {
+		return
+	}
+	if contents == "" {
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+			err = rmErr
+		}
+		return
+	}
+	err = os.WriteFile(path, []byte(contents), 0600)
+	return
+}
+
+// watchRegistrationCompletion polls the registry for the registration
+// completeness of the given prefix. While the registration is incomplete, it
+// funnels the "request link" — the registry edit URL plus a fresh short-lived
+// access token minted with this server's issuer key — into the registration
+// completion link file and re-writes the file on each poll cycle, then prints
+// the file to the server's log (and hence stdout) right away, so the link is
+// always fresh. The loop ends once the registration is complete, the registry
+// doesn't support completeness checks, or the context is done.
+func watchRegistrationCompletion(ctx context.Context, egrp *errgroup.Group, prefix string) {
+	egrp.Go(func() error {
+		ticker := time.NewTicker(regCompletionLinkInterval)
+		defer ticker.Stop()
+		for {
+			res, err := origin.FetchRegStatus([]string{prefix})
+			if errors.Is(err, origin.RegistryNotImplErr) {
+				log.Debugf("The registry doesn't support registration completeness checks; no completion link will be logged for %s", prefix)
+				return nil
+			} else if err != nil {
+				log.Warningf("Failed to check registration completeness for %s: %v", prefix, err)
+			} else if result, ok := res.Results[prefix]; !ok {
+				log.Warningf("Registry response does not contain the registration status for %s", prefix)
+			} else if result.Completed {
+				log.Infof("Registration for %s is complete", prefix)
+				if _, path, wErr := updateRegCompletionLinkFile(prefix, ""); wErr != nil {
+					log.Warningf("Failed to update the registration completion link file %s: %v", path, wErr)
+				}
+				return nil
+			} else if result.EditUrl != "" {
+				link := result.EditUrl
+				line := ""
+				if accessToken, tErr := origin.MintRegistrationEditToken(ctx); tErr != nil {
+					log.Warningf("Failed to mint an access token for the registration completion link for %s: %v", prefix, tErr)
+					line = fmt.Sprintf("Complete server registration at %s", link)
+				} else {
+					expiry := time.Now().Add(origin.RegEditTokenLifetime)
+					if parsed, pErr := url.Parse(link); pErr == nil {
+						q := parsed.Query()
+						q.Set("access_token", accessToken)
+						parsed.RawQuery = q.Encode()
+						link = parsed.String()
+					}
+					line = fmt.Sprintf("Complete server registration at %s (expire at %s)", link, expiry.Format(time.RFC1123))
+				}
+				contents, path, wErr := updateRegCompletionLinkFile(prefix, line)
+				if wErr != nil {
+					log.Warningf("Failed to write the registration completion link file %s: %v", path, wErr)
+				}
+				if msg := strings.TrimSpace(result.Msg); msg != "" {
+					log.Warningf("Registration for %s is incomplete: %s", prefix, msg)
+				}
+				dest := "the log"
+				if path != "" {
+					dest = path
+				}
+				log.Errorf("Server registration is incomplete; open the link below in a browser and log in to the registry to complete it (a fresh link is written to %s every %s):\n%s",
+					dest, regCompletionLinkInterval, strings.TrimRight(contents, "\n"))
+			}
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	})
+}
+
 // Register the namespace. If failed, retry every 10s (default)
 func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefix string) error {
 	retryInterval := param.Server_RegistrationRetryInterval.GetDuration()
@@ -318,10 +438,12 @@ func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefi
 		if err := origin.FetchAndSetRegStatus(prefix); err != nil {
 			return errors.Wrapf(err, "failed to fetch registration status for the prefix %s", prefix)
 		}
+		watchRegistrationCompletion(ctx, egrp, prefix)
 		return nil
 	}
 
 	if err = registerNamespaceImpl(key, prefix, siteName, url); err == nil {
+		watchRegistrationCompletion(ctx, egrp, prefix)
 		return nil
 	}
 	log.Errorf("Failed to register with namespace service: %v; will automatically retry in 10 seconds\n", err)
@@ -338,6 +460,7 @@ func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefi
 					if err := origin.FetchAndSetRegStatus(prefix); err != nil {
 						log.Errorf("failed to fetch registration status for the prefix %s: %v", prefix, err)
 					}
+					watchRegistrationCompletion(ctx, egrp, prefix)
 					return nil
 				}
 				log.Errorf("Failed to register with namespace service: %v; will automatically retry in 10 seconds\n", err)

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -531,3 +531,77 @@ func TestReconcileKeysWhenAlreadyRegistered(t *testing.T) {
 	sort.Strings(expected)
 	require.Equal(t, expected, fetchRegistryKids(t, svr.URL, prefix))
 }
+
+func TestUpdateRegCompletionLinkFile(t *testing.T) {
+	t.Cleanup(func() {
+		regCompletionLinksMutex.Lock()
+		regCompletionLinks = make(map[string]string)
+		regCompletionLinksMutex.Unlock()
+		server_utils.ResetTestState()
+	})
+	server_utils.ResetTestState()
+	// Earlier tests in this package perform real registrations that stash
+	// their completion link in the package-global map; start from a clean
+	// slate so this test asserts only on its own entries.
+	regCompletionLinksMutex.Lock()
+	regCompletionLinks = make(map[string]string)
+	regCompletionLinksMutex.Unlock()
+
+	linkFile := filepath.Join(t.TempDir(), "completion-link")
+	require.NoError(t, param.Server_RegistrationCompletionLinkFile.Set(linkFile))
+
+	// Adding a line writes the file and returns its contents
+	lineFoo := "Complete server registration at https://registry.example/view/registry/claim/?id=1 (expire at Mon, 01 Jan 2026 00:00:00 UTC)"
+	contents, path, err := updateRegCompletionLinkFile("/foo", lineFoo)
+	require.NoError(t, err)
+	assert.Equal(t, linkFile, path)
+	assert.Equal(t, lineFoo+"\n", contents)
+	onDisk, err := os.ReadFile(linkFile)
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(onDisk))
+
+	// A second prefix appends a line; lines are ordered by prefix
+	lineBar := "Complete server registration at https://registry.example/view/registry/claim/?id=2 (expire at Mon, 01 Jan 2026 00:00:00 UTC)"
+	contents, _, err = updateRegCompletionLinkFile("/bar", lineBar)
+	require.NoError(t, err)
+	assert.Equal(t, lineBar+"\n"+lineFoo+"\n", contents)
+	onDisk, err = os.ReadFile(linkFile)
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(onDisk))
+
+	// Re-writing a prefix replaces its line rather than appending
+	lineFoo2 := "Complete server registration at https://registry.example/view/registry/claim/?id=1 (expire at Mon, 01 Jan 2026 00:15:00 UTC)"
+	contents, _, err = updateRegCompletionLinkFile("/foo", lineFoo2)
+	require.NoError(t, err)
+	assert.Equal(t, lineBar+"\n"+lineFoo2+"\n", contents)
+
+	// Clearing one prefix leaves the other's line in place
+	contents, _, err = updateRegCompletionLinkFile("/bar", "")
+	require.NoError(t, err)
+	assert.Equal(t, lineFoo2+"\n", contents)
+	onDisk, err = os.ReadFile(linkFile)
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(onDisk))
+
+	// Clearing the last prefix removes the file
+	contents, _, err = updateRegCompletionLinkFile("/foo", "")
+	require.NoError(t, err)
+	assert.Equal(t, "", contents)
+	_, err = os.Stat(linkFile)
+	assert.True(t, os.IsNotExist(err))
+
+	// Clearing when the file is already absent is not an error
+	_, _, err = updateRegCompletionLinkFile("/foo", "")
+	require.NoError(t, err)
+
+	// An empty path disables the file but still returns the contents for logging
+	require.NoError(t, param.Server_RegistrationCompletionLinkFile.Set(""))
+	contents, path, err = updateRegCompletionLinkFile("/foo", lineFoo)
+	require.NoError(t, err)
+	assert.Equal(t, "", path)
+	assert.Equal(t, lineFoo+"\n", contents)
+	_, err = os.Stat(linkFile)
+	assert.True(t, os.IsNotExist(err))
+	_, _, err = updateRegCompletionLinkFile("/foo", "")
+	require.NoError(t, err)
+}

--- a/origin/exports.go
+++ b/origin/exports.go
@@ -3,7 +3,6 @@ package origin
 import (
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
@@ -12,8 +11,6 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
-	"github.com/pelicanplatform/pelican/token"
-	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
 type (
@@ -116,28 +113,7 @@ func handleExports(ctx *gin.Context) {
 	// Create token for accessing registry edit page. A standalone origin has no
 	// registry, hence no edit URLs to decorate and no audience to mint against.
 	if !standalone {
-		issuerUrl, err := config.GetServerIssuerURL()
-		if err != nil {
-			log.Errorf("Failed to get server issuer url %v", err)
-			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Server encountered error when getting server issuer url " + err.Error()})
-			return
-		}
-		fed, err := config.GetFederation(ctx)
-		if err != nil {
-			log.Error("handleExports: failed to get federaion:", err)
-			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-				Status: server_structs.RespFailed,
-				Msg:    "Server error when getting federation information: " + err.Error(),
-			})
-			return
-		}
-		tc := token.NewWLCGToken()
-		tc.Issuer = issuerUrl
-		tc.Lifetime = 15 * time.Minute
-		tc.Subject = issuerUrl
-		tc.AddScopes(token_scopes.Registry_EditRegistration)
-		tc.AddAudiences(fed.RegistryEndpoint)
-		token, err := tc.CreateToken()
+		token, err := MintRegistrationEditToken(ctx)
 		if err != nil {
 			log.Errorf("Failed to create access token for editing registration %v", err)
 			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Server encountered error when creating token for access registry edit page " + err.Error()})

--- a/origin/reg_status.go
+++ b/origin/reg_status.go
@@ -35,6 +35,8 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
 type (
@@ -82,6 +84,33 @@ const (
 
 func SetNamespacesStatus(key string, val RegistrationStatus, ttl time.Duration) {
 	registrationsStatus.Set(key, val, ttl)
+}
+
+// RegEditTokenLifetime is the lifetime of the registration edit tokens
+// minted by MintRegistrationEditToken.
+const RegEditTokenLifetime = 15 * time.Minute
+
+// MintRegistrationEditToken creates a short-lived (RegEditTokenLifetime)
+// token, signed with this server's issuer key, that authorizes editing this
+// server's registration(s) at the registry. The registry verifies the token
+// against the public key stored with the registration, so it only works for
+// registrations created with this server's keypair.
+func MintRegistrationEditToken(ctx context.Context) (string, error) {
+	issuerUrl, err := config.GetServerIssuerURL()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get server issuer URL")
+	}
+	fed, err := config.GetFederation(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get federation information")
+	}
+	tc := token.NewWLCGToken()
+	tc.Issuer = issuerUrl
+	tc.Lifetime = RegEditTokenLifetime
+	tc.Subject = issuerUrl
+	tc.AddScopes(token_scopes.Registry_EditRegistration)
+	tc.AddAudiences(fed.RegistryEndpoint)
+	return tc.CreateToken()
 }
 
 // Fetch the registration status for an array of namespace prefixes

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -528,6 +528,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Server.IssuerUrl": false,
 	"Server.Modules": false,
 	"Server.NewUserDefaultScopes": false,
+	"Server.RegistrationCompletionLinkFile": false,
 	"Server.RegistrationRetryInterval": false,
 	"Server.SSRFProtection.AllowedCIDRs": false,
 	"Server.SSRFProtection.BlockedCIDRs": false,
@@ -815,6 +816,7 @@ var stringAccessors = map[string]func(*Config) string{
 	"Server.IssuerHostname": func(c *Config) string { return c.Server.IssuerHostname },
 	"Server.IssuerJwks": func(c *Config) string { return c.Server.IssuerJwks },
 	"Server.IssuerUrl": func(c *Config) string { return c.Server.IssuerUrl },
+	"Server.RegistrationCompletionLinkFile": func(c *Config) string { return c.Server.RegistrationCompletionLinkFile },
 	"Server.SessionSecretFile": func(c *Config) string { return c.Server.SessionSecretFile },
 	"Server.TLSCACertificateDirectory": func(c *Config) string { return c.Server.TLSCACertificateDirectory },
 	"Server.TLSCACertificateFile": func(c *Config) string { return c.Server.TLSCACertificateFile },
@@ -1836,6 +1838,7 @@ var allParameterNames = []string{
 	"Server.IssuerUrl",
 	"Server.Modules",
 	"Server.NewUserDefaultScopes",
+	"Server.RegistrationCompletionLinkFile",
 	"Server.RegistrationRetryInterval",
 	"Server.SSRFProtection.AllowedCIDRs",
 	"Server.SSRFProtection.BlockedCIDRs",
@@ -2096,6 +2099,7 @@ var (
 	Server_IssuerHostname = StringParam{"Server.IssuerHostname"}
 	Server_IssuerJwks = StringParam{"Server.IssuerJwks"}
 	Server_IssuerUrl = StringParam{"Server.IssuerUrl"}
+	Server_RegistrationCompletionLinkFile = StringParam{"Server.RegistrationCompletionLinkFile"}
 	Server_SessionSecretFile = StringParam{"Server.SessionSecretFile"}
 	Server_TLSCACertificateDirectory = StringParam{"Server.TLSCACertificateDirectory"}
 	Server_TLSCACertificateFile = StringParam{"Server.TLSCACertificateFile"}
@@ -2649,6 +2653,7 @@ func init() {
 		"Server.IssuerHostname": Server_IssuerHostname,
 		"Server.IssuerJwks": Server_IssuerJwks,
 		"Server.IssuerUrl": Server_IssuerUrl,
+		"Server.RegistrationCompletionLinkFile": Server_RegistrationCompletionLinkFile,
 		"Server.SessionSecretFile": Server_SessionSecretFile,
 		"Server.TLSCACertificateDirectory": Server_TLSCACertificateDirectory,
 		"Server.TLSCACertificateFile": Server_TLSCACertificateFile,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -508,6 +508,7 @@ type Config struct {
 		IssuerUrl string `mapstructure:"issuerurl" yaml:"IssuerUrl"`
 		Modules []string `mapstructure:"modules" yaml:"Modules"`
 		NewUserDefaultScopes []string `mapstructure:"newuserdefaultscopes" yaml:"NewUserDefaultScopes"`
+		RegistrationCompletionLinkFile string `mapstructure:"registrationcompletionlinkfile" yaml:"RegistrationCompletionLinkFile"`
 		RegistrationRetryInterval time.Duration `mapstructure:"registrationretryinterval" yaml:"RegistrationRetryInterval"`
 		SSRFProtection struct {
 			AllowedCIDRs []string `mapstructure:"allowedcidrs" yaml:"AllowedCIDRs"`
@@ -1097,6 +1098,7 @@ type configWithType struct {
 		IssuerUrl struct { Type string; Value string }
 		Modules struct { Type string; Value []string }
 		NewUserDefaultScopes struct { Type string; Value []string }
+		RegistrationCompletionLinkFile struct { Type string; Value string }
 		RegistrationRetryInterval struct { Type string; Value time.Duration }
 		SSRFProtection struct {
 			AllowedCIDRs struct { Type string; Value []string }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1202,7 +1202,11 @@ func checkStatusHandler(ctx *gin.Context) {
 				Msg:    "Server error when getting federation information: " + err.Error(),
 			})
 		}
-		if server_structs.IsCacheNS(prefix) {
+		if ns.AdminMetadata.UserID == "" {
+			// Unowned registrations go through the claim page first, which
+			// binds the registration to the logged-in user before editing.
+			complete.EditUrl = fmt.Sprintf("%s/view/registry/claim/?id=%d", fed.RegistryEndpoint, ns.ID)
+		} else if server_structs.IsCacheNS(prefix) {
 			complete.EditUrl = fmt.Sprintf("%s/view/registry/cache/edit/?id=%d", fed.RegistryEndpoint, ns.ID)
 		} else if server_structs.IsOriginNS(prefix) {
 			complete.EditUrl = fmt.Sprintf("%s/view/registry/origin/edit/?id=%d", fed.RegistryEndpoint, ns.ID)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -435,8 +435,10 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 		}
 	}
 
-	// Overwrite status to Pending to filter malicious request
-	ns.AdminMetadata.Status = server_structs.RegPending
+	// Registrations coming through the automated flow/CLI carry only the basic info;
+	// the additional fields (institution, etc.) hasn't been filled in yet, so they
+	// start as Incomplete. Submitting the web form promotes them to Pending.
+	ns.AdminMetadata.Status = server_structs.RegIncomplete
 
 	if server_structs.IsServerPrefix(data.Prefix) {
 		if ns.CustomFields == nil {

--- a/registry/registry_api.go
+++ b/registry/registry_api.go
@@ -121,6 +121,13 @@ func LaunchRegistryMetrics(ctx context.Context, egrp *errgroup.Group) {
 					continue
 				}
 				metrics.PelicanRegistryFederationNamespaces.WithLabelValues(server_structs.RegPending.LowerString()).Set(float64(numPending))
+
+				numIncomplete, err := getCountofFederationNamespacesByStatus(server_structs.RegIncomplete)
+				if err != nil {
+					log.Warningln("Failed to update namespace metric for incomplete namespaces.", err.Error())
+					continue
+				}
+				metrics.PelicanRegistryFederationNamespaces.WithLabelValues(server_structs.RegIncomplete.LowerString()).Set(float64(numIncomplete))
 			}
 		}
 	})

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -153,7 +153,9 @@ func registrationExistsById(id int) (bool, error) {
 	}
 }
 
-func registrationBelongsToUserId(id int, userId string) (bool, error) {
+// registrationBelongsToUser reports whether the registration's recorded owner
+// matches the caller's Pelican user ID. An anonymous caller (empty userId) owns nothing.
+func registrationBelongsToUser(id int, userId string) (bool, error) {
 	var result server_structs.Registration
 	err := database.ServerDatabase.First(&result, "id = ?", id).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -161,7 +163,47 @@ func registrationBelongsToUserId(id int, userId string) (bool, error) {
 	} else if err != nil {
 		return false, errors.Wrap(err, "error retrieving registration")
 	}
-	return result.AdminMetadata.UserID == userId, nil
+	return userId != "" && result.AdminMetadata.UserID == userId, nil
+}
+
+// errRegistrationAlreadyOwned reports that a claim repeated or lost a race:
+// the registration already carries a non-empty owner. Handlers translate it
+// to an HTTP conflict (or forbidden, on the tokenized-edit leg).
+var errRegistrationAlreadyOwned = errors.New("registration already has an owner")
+
+// errRegistrationNotFound is the typed not-found error for registration
+// lookups so handlers can map it to a 404 without string matching.
+var errRegistrationNotFound = errors.New("registration not found in database")
+
+// claimRegistration atomically binds an unowned registration to owner (a
+// Pelican user ID). It is the only place ownership is written. Generic updates
+// never touch ownership (updateRegistration carries the stored owner forward).
+func claimRegistration(id int, owner string) error {
+	if owner == "" {
+		return errors.New("cannot claim a registration for an empty owner")
+	}
+	return database.ServerDatabase.Transaction(func(tx *gorm.DB) error {
+		// Re-checked the owner is empty inside the transaction, so two concurrent
+		// claims cannot both succeed (SQLite serializes the write; the loser sees
+		// the committed owner or fails to commit, but not a silent overwrite).
+		ns := server_structs.Registration{}
+		if err := tx.First(&ns, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errors.Wrapf(errRegistrationNotFound, "registration with id %d", id)
+			}
+			return errors.Wrap(err, "error retrieving registration")
+		}
+		if ns.AdminMetadata.UserID != "" {
+			return errRegistrationAlreadyOwned
+		}
+		ns.AdminMetadata.UserID = owner
+		ns.AdminMetadata.UpdatedAt = time.Now()
+		adminMetadataByte, err := json.Marshal(ns.AdminMetadata)
+		if err != nil {
+			return errors.Wrap(err, "Error marshaling admin metadata")
+		}
+		return tx.Model(&server_structs.Registration{}).Where("id = ?", id).Update("admin_metadata", string(adminMetadataByte)).Error
+	})
 }
 
 func getRegistrationJwksById(id int) (jwk.Set, error) {
@@ -357,14 +399,25 @@ func listServers() ([]server_structs.ServerRegistration, error) {
 	return results, nil
 }
 
+// getRegistrationById is used by read-only callers
 func getRegistrationById(id int) (*server_structs.Registration, error) {
+	return getRegistrationByIdTx(database.ServerDatabase, id)
+}
+
+// getRegistrationByIdTx is used by anything that writes back fields
+// derived from the read (updateRegistration, updateRegistrationStatusById)
+// through their own write transaction: an outside read lets a concurrent
+// admin_metadata writer (claimRegistration, an ownership-transfer
+// redemption) commit between the read and the write and be silently
+// overwritten with the stale pinned values.
+func getRegistrationByIdTx(db *gorm.DB, id int) (*server_structs.Registration, error) {
 	if id < 1 {
 		return nil, errors.New("Invalid id. id must be a positive number")
 	}
 	ns := server_structs.Registration{}
-	err := database.ServerDatabase.Last(&ns, id).Error
+	err := db.Last(&ns, id).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, errors.Errorf("registration with id %d not found in database", id)
+		return nil, errors.Wrapf(errRegistrationNotFound, "registration with id %d", id)
 	} else if err != nil {
 		return nil, errors.Wrap(err, "error retrieving pubkey")
 	}
@@ -847,34 +900,45 @@ func reapOrphanedPendingNamespaces(staleServers []serverIdentity) error {
 }
 
 func updateRegistration(ns *server_structs.Registration) error {
-	existingNs, err := getRegistrationById(ns.ID)
-	if err != nil || existingNs == nil {
-		return errors.Wrap(err, "Failed to get registration")
-	}
-	if ns.Prefix == "" {
-		ns.Prefix = existingNs.Prefix
-	}
-	if ns.Pubkey == "" {
-		ns.Pubkey = existingNs.Pubkey
-	}
-	// We intentionally exclude updating "identity" as this should only be updated
-	// when user registered through Pelican client with identity
-	ns.Identity = existingNs.Identity
-
-	existingNsAdmin := existingNs.AdminMetadata
-	// We prevent the following fields from being modified by the user for now.
-	// They are meant for "internal" use only.
-	// We also don't allow changing Status other than explicitly
-	// call updateRegistrationStatusById
-	ns.AdminMetadata.CreatedAt = existingNsAdmin.CreatedAt
-	ns.AdminMetadata.Status = existingNsAdmin.Status
-	ns.AdminMetadata.ApprovedAt = existingNsAdmin.ApprovedAt
-	ns.AdminMetadata.ApproverID = existingNsAdmin.ApproverID
-	ns.AdminMetadata.UpdatedAt = time.Now()
-
 	// Wrap all database operations in a transaction
 	// If any operation fails, all changes are reverted. No partial records left.
+	// The read of the stored row happens INSIDE the transaction: the pinned
+	// fields below (ownership especially) must come from the row this
+	// transaction replaces, or a concurrent claim/ownership transfer that
+	// commits between an outside read and the Save would be silently
+	// reverted.
 	return database.ServerDatabase.Transaction(func(tx *gorm.DB) error {
+		existingNs, err := getRegistrationByIdTx(tx, ns.ID)
+		if err != nil || existingNs == nil {
+			return errors.Wrap(err, "Failed to get registration")
+		}
+		if ns.Prefix == "" {
+			ns.Prefix = existingNs.Prefix
+		}
+		if ns.Pubkey == "" {
+			ns.Pubkey = existingNs.Pubkey
+		}
+		// We intentionally exclude updating "identity" as this should only be updated
+		// when user registered through Pelican client with identity
+		ns.Identity = existingNs.Identity
+
+		existingNsAdmin := existingNs.AdminMetadata
+		// We prevent the following fields from being modified by the user for now.
+		// They are meant for "internal" use only.
+		// We also don't allow changing Status other than explicitly
+		// call updateRegistrationStatusById
+		ns.AdminMetadata.CreatedAt = existingNsAdmin.CreatedAt
+		ns.AdminMetadata.Status = existingNsAdmin.Status
+		ns.AdminMetadata.ApprovedAt = existingNsAdmin.ApprovedAt
+		ns.AdminMetadata.ApproverID = existingNsAdmin.ApproverID
+		// Ownership is likewise internal: the owner is written only through
+		// claimRegistration (or the create path stamping the session's user
+		// ID), never from a request body — otherwise an owner or admin PUT
+		// could clear or reassign the owner and re-open the registration for
+		// claiming by any key holder.
+		ns.AdminMetadata.UserID = existingNsAdmin.UserID
+		ns.AdminMetadata.UpdatedAt = time.Now()
+
 		// Update the registration first
 		if err := tx.Save(ns).Error; err != nil {
 			return errors.Wrapf(err, "failed to update registration: %s", ns.AdminMetadata.SiteName)
@@ -907,27 +971,32 @@ func updateRegistration(ns *server_structs.Registration) error {
 }
 
 func updateRegistrationStatusById(id int, status server_structs.RegistrationStatus, approverId string) error {
-	ns, err := getRegistrationById(id)
-	if err != nil {
-		return errors.Wrap(err, "Error getting registration by id")
-	}
-
-	ns.AdminMetadata.Status = status
-	ns.AdminMetadata.UpdatedAt = time.Now()
-	if status == server_structs.RegApproved {
-		if approverId == "" {
-			return errors.New("approverId can't be empty to approve")
+	// Read-modify-write of the admin_metadata JSON column: the read must
+	// happen inside the write transaction (see getRegistrationByIdTx) or a
+	// concurrent owner write would be reverted by this stale marshal.
+	return database.ServerDatabase.Transaction(func(tx *gorm.DB) error {
+		ns, err := getRegistrationByIdTx(tx, id)
+		if err != nil {
+			return errors.Wrap(err, "Error getting registration by id")
 		}
-		ns.AdminMetadata.ApproverID = approverId
-		ns.AdminMetadata.ApprovedAt = time.Now()
-	}
 
-	adminMetadataByte, err := json.Marshal(ns.AdminMetadata)
-	if err != nil {
-		return errors.Wrap(err, "Error marshaling admin metadata")
-	}
+		ns.AdminMetadata.Status = status
+		ns.AdminMetadata.UpdatedAt = time.Now()
+		if status == server_structs.RegApproved {
+			if approverId == "" {
+				return errors.New("approverId can't be empty to approve")
+			}
+			ns.AdminMetadata.ApproverID = approverId
+			ns.AdminMetadata.ApprovedAt = time.Now()
+		}
 
-	return database.ServerDatabase.Model(ns).Where("id = ?", id).Update("admin_metadata", string(adminMetadataByte)).Error
+		adminMetadataByte, err := json.Marshal(ns.AdminMetadata)
+		if err != nil {
+			return errors.Wrap(err, "Error marshaling admin metadata")
+		}
+
+		return tx.Model(ns).Where("id = ?", id).Update("admin_metadata", string(adminMetadataByte)).Error
+	})
 }
 
 func setRegistrationPubKey(prefix string, pubkeyDbString string) error {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -730,9 +730,10 @@ func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDelet
 			continue
 		}
 
+		// Incomplete counts the same as Pending here: both mean unreviewed registration
 		allPending := true
 		for _, reg := range srv.Registration {
-			if reg.AdminMetadata.Status != server_structs.RegPending {
+			if reg.AdminMetadata.Status != server_structs.RegPending && reg.AdminMetadata.Status != server_structs.RegIncomplete {
 				allPending = false
 				break
 			}
@@ -831,7 +832,7 @@ func reapOrphanedPendingNamespaces(staleServers []serverIdentity) error {
 	}
 
 	for _, ns := range candidates {
-		if ns.AdminMetadata.Status != server_structs.RegPending {
+		if ns.AdminMetadata.Status != server_structs.RegPending && ns.AdminMetadata.Status != server_structs.RegIncomplete {
 			continue
 		}
 		// Deletions are best-effort: a failure on one namespace is logged and the rest continue.

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -176,8 +176,9 @@ var errRegistrationAlreadyOwned = errors.New("registration already has an owner"
 var errRegistrationNotFound = errors.New("registration not found in database")
 
 // claimRegistration atomically binds an unowned registration to owner (a
-// Pelican user ID). It is the only place ownership is written. Generic updates
-// never touch ownership (updateRegistration carries the stored owner forward).
+// Pelican user ID). Ownership is written in two places: here and in an
+// ownership-transfer invite redemption. Generic updates never touch
+// ownership (updateRegistration carries the stored owner forward).
 func claimRegistration(id int, owner string) error {
 	if owner == "" {
 		return errors.New("cannot claim a registration for an empty owner")
@@ -202,7 +203,13 @@ func claimRegistration(id int, owner string) error {
 		if err != nil {
 			return errors.Wrap(err, "Error marshaling admin metadata")
 		}
-		return tx.Model(&server_structs.Registration{}).Where("id = ?", id).Update("admin_metadata", string(adminMetadataByte)).Error
+		if err := tx.Model(&server_structs.Registration{}).Where("id = ?", id).Update("admin_metadata", string(adminMetadataByte)).Error; err != nil {
+			return err
+		}
+		// A change of owner invalidates any outstanding ownership-transfer
+		// invites (e.g. minted by an admin while the registration was
+		// unowned): they were issued under authority that no longer holds.
+		return database.RevokeRegistrationOwnershipInviteLinks(tx, id)
 	})
 }
 
@@ -932,10 +939,11 @@ func updateRegistration(ns *server_structs.Registration) error {
 		ns.AdminMetadata.ApprovedAt = existingNsAdmin.ApprovedAt
 		ns.AdminMetadata.ApproverID = existingNsAdmin.ApproverID
 		// Ownership is likewise internal: the owner is written only through
-		// claimRegistration (or the create path stamping the session's user
-		// ID), never from a request body — otherwise an owner or admin PUT
-		// could clear or reassign the owner and re-open the registration for
-		// claiming by any key holder.
+		// claimRegistration, an ownership-transfer invite redemption
+		// (database.RedeemRegistrationOwnershipInviteLink), or the create
+		// path stamping the session's user ID — never from a request body —
+		// otherwise an owner or admin PUT could clear or reassign the owner
+		// and re-open the registration for claiming by any key holder.
 		ns.AdminMetadata.UserID = existingNsAdmin.UserID
 		ns.AdminMetadata.UpdatedAt = time.Now()
 

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -962,3 +962,58 @@ func TestGetTopoPrefixString(t *testing.T) {
 		assert.Equal(t, "/foo, /bar, /barz", re)
 	})
 }
+
+// TestClaimRegistration pins the contract of the one place ownership is
+// written: only unowned rows can be claimed, only for a non-empty owner, and
+// a repeated claim conflicts instead of silently overwriting the first owner.
+func TestClaimRegistration(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	insertUnowned := func(t *testing.T) int {
+		require.NoError(t, insertMockDBData([]server_structs.Registration{{Prefix: "/foo", Pubkey: "mock-key"}}))
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+		return id
+	}
+
+	t.Run("empty-owner-is-refused", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		id := insertUnowned(t)
+
+		require.Error(t, claimRegistration(id, ""))
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "", got.AdminMetadata.UserID, "a refused claim must not write an owner")
+	})
+
+	t.Run("unowned-row-is-claimed", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		id := insertUnowned(t)
+
+		require.NoError(t, claimRegistration(id, "u-owner-id"))
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-owner-id", got.AdminMetadata.UserID)
+	})
+
+	t.Run("second-claim-conflicts-and-does-not-overwrite", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		id := insertUnowned(t)
+
+		require.NoError(t, claimRegistration(id, "u-first-id"))
+		require.ErrorIs(t, claimRegistration(id, "u-second-id"), errRegistrationAlreadyOwned)
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-first-id", got.AdminMetadata.UserID, "the losing claim must not overwrite the first owner")
+	})
+
+	t.Run("missing-registration", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		require.ErrorIs(t, claimRegistration(404404, "u-owner-id"), errRegistrationNotFound)
+	})
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -290,7 +290,9 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 		result, ok := resStruct.Results["/incomplete-prefix"]
 		require.True(t, ok)
 		assert.False(t, result.Completed)
-		assert.Contains(t, result.EditUrl, "https://registry.org/view/registry/namespace/edit/?id=")
+		// The registration has no owner (empty UserID), so the link points to
+		// the claim page instead of the edit page
+		assert.Contains(t, result.EditUrl, "https://registry.org/view/registry/claim/?id=")
 		assert.Contains(t, result.Msg, "Incomplete registration:")
 	})
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -310,7 +310,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 					"/complete-prefix",
 					mockJWKS,
 					"",
-					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution"},
+					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution", Description: "mock description"},
 				),
 			},
 		)
@@ -355,19 +355,19 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 					"/complete-prefix-1",
 					mockJWKS,
 					"",
-					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution"},
+					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution", Description: "mock description"},
 				),
 				mockNamespace(
 					"/complete-prefix-2",
 					mockJWKS,
 					"",
-					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution"},
+					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution", Description: "mock description"},
 				),
 				mockNamespace(
 					"/foo/bar",
 					mockJWKS,
 					"",
-					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution"},
+					server_structs.AdminMetadata{UserID: "fake-user-id", Institution: "mock-institution", Description: "mock description"},
 				),
 			},
 		)

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -173,10 +173,11 @@ func populateRegistrationFields(prefix string, data interface{}) []registrationF
 
 		if field.Type == reflect.TypeOf(server_structs.RegistrationStatus("")) {
 			regField.Type = Enum
-			options := make([]registrationFieldOption, 3)
-			options[0] = registrationFieldOption{Name: server_structs.RegPending.String(), ID: server_structs.RegPending.LowerString()}
-			options[1] = registrationFieldOption{Name: server_structs.RegApproved.String(), ID: server_structs.RegApproved.LowerString()}
-			options[2] = registrationFieldOption{Name: server_structs.RegDenied.String(), ID: server_structs.RegDenied.LowerString()}
+			options := make([]registrationFieldOption, 4)
+			options[0] = registrationFieldOption{Name: server_structs.RegIncomplete.String(), ID: server_structs.RegIncomplete.LowerString()}
+			options[1] = registrationFieldOption{Name: server_structs.RegPending.String(), ID: server_structs.RegPending.LowerString()}
+			options[2] = registrationFieldOption{Name: server_structs.RegApproved.String(), ID: server_structs.RegApproved.LowerString()}
+			options[3] = registrationFieldOption{Name: server_structs.RegDenied.String(), ID: server_structs.RegDenied.LowerString()}
 			regField.Options = options
 			fields = append(fields, regField)
 		} else {
@@ -250,7 +251,7 @@ func listNamespaces(ctx *gin.Context) {
 			} else {
 				ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,
-					Msg:    fmt.Sprintf("Invalid query parameters %s: status must be one of  'Pending', 'Approved', 'Denied', 'Unknown'", queryParams.Status)})
+					Msg:    fmt.Sprintf("Invalid query parameters %s: status must be one of 'Incomplete', 'Pending', 'Approved', 'Denied', 'Unknown'", queryParams.Status)})
 			}
 		}
 	} else {
@@ -298,7 +299,7 @@ func listNamespacesForUser(ctx *gin.Context) {
 		} else {
 			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
-				Msg:    fmt.Sprintf("Invalid query parameters %s: status must be one of 'Pending', 'Approved', 'Denied', 'Unknown'", queryParams.Status)})
+				Msg:    fmt.Sprintf("Invalid query parameters %s: status must be one of 'Incomplete', 'Pending', 'Approved', 'Denied', 'Unknown'", queryParams.Status)})
 		}
 	}
 
@@ -545,6 +546,16 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 			return
 		}
 
+		existingNs, err := getRegistrationById(ns.ID)
+		if err != nil {
+			log.Error("Error checking namespace status: ", err)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Error checking namespace status"})
+			return
+		}
+		existingStatus := existingNs.AdminMetadata.Status
+
 		// Then check if the user has privilege to update
 		belongsTo := false
 
@@ -569,14 +580,6 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 						Msg:    "You do not have permissions to access this namespace registration. Check the id or if you own the namespace"})
 					return
 				}
-			}
-			existingNs, err := getRegistrationById(ns.ID)
-			if err != nil {
-				log.Error("Error loading existing registration: ", err)
-				ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-					Status: server_structs.RespFailed,
-					Msg:    "Error loading existing registration"})
-				return
 			}
 			if existingNs.AdminMetadata.Status == server_structs.RegApproved {
 				log.Errorf("User '%s' is trying to modify approved namespace registration with id=%d", user, ns.ID)
@@ -659,6 +662,21 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 				Status: server_structs.RespFailed,
 				Msg:    "Fail to update namespace"})
 			return
+		}
+
+		// A fully-valid submission moves an auto-registered (Incomplete)
+		// registration into the admin review queue. Partially-filled updates
+		// (e.g. an admin correcting an unclaimed registration) keep it Incomplete.
+		if existingStatus == server_structs.RegIncomplete {
+			if verr := config.GetValidate().Struct(ns); verr == nil {
+				if serr := updateRegistrationStatusById(ns.ID, server_structs.RegPending, ""); serr != nil {
+					log.Errorf("Failed to promote registration %d from Incomplete to Pending: %v", ns.ID, serr)
+					ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+						Status: server_structs.RespFailed,
+						Msg:    "Registration was updated but could not be submitted for review"})
+					return
+				}
+			}
 		}
 	}
 }

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -277,6 +277,7 @@ func listNamespaces(ctx *gin.Context) {
 // GET /namespaces/user
 func listNamespacesForUser(ctx *gin.Context) {
 	user := ctx.GetString("User")
+	userId := ctx.GetString("UserId")
 	if user == "" {
 		ctx.JSON(http.StatusUnauthorized, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -291,7 +292,11 @@ func listNamespacesForUser(ctx *gin.Context) {
 		return
 	}
 
-	filterNs := server_structs.Registration{AdminMetadata: server_structs.AdminMetadata{UserID: user}}
+	filterNs := server_structs.Registration{AdminMetadata: server_structs.AdminMetadata{UserID: userId}}
+	// A session without User ID (e.g. the CLI admin token) fallbacks to use "user" to build filter.
+	if userId == "" {
+		filterNs = server_structs.Registration{AdminMetadata: server_structs.AdminMetadata{UserID: user}}
+	}
 
 	if queryParams.Status != "" {
 		if server_structs.IsValidRegStatus(queryParams.Status) {
@@ -305,7 +310,7 @@ func listNamespacesForUser(ctx *gin.Context) {
 
 	namespaces, err := getRegistrationsByFilter(filterNs, "", false)
 	if err != nil {
-		log.Error("Error getting namespaces for user ", user)
+		log.Error("Error getting namespaces for user ID ", userId)
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Error getting namespaces by user ID"})
@@ -389,7 +394,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		return
 	}
 	if !isUpdate { // create
-		ns.AdminMetadata.UserID = user
+		ns.AdminMetadata.UserID = userId
 	}
 	// Assign ID from path param because the request data doesn't have ID set
 	ns.ID = id
@@ -556,11 +561,16 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		}
 		existingStatus := existingNs.AdminMetadata.Status
 
+		// Ownership can never be set or changed through the request body.
+		// The tokenized-claim leg below overrides this for the one transition
+		// it explicitly authorizes: unowned -> caller via claimRegistration.
+		ns.AdminMetadata.UserID = existingNs.AdminMetadata.UserID
+
 		// Then check if the user has privilege to update
 		belongsTo := false
 
 		if !isAdmin { // Not admin, need to check if the namespace belongs to the user
-			belongsTo, err = registrationBelongsToUserId(ns.ID, user)
+			belongsTo, err = registrationBelongsToUser(ns.ID, userId)
 			if err != nil {
 				log.Error("Error checking if namespace belongs to the user: ", err)
 				ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
@@ -627,7 +637,35 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 
 				// Proof of possession succeeded on an unowned registration: the
 				// key-holder claims it. The request-body user_id is ignored.
-				ns.AdminMetadata.UserID = user
+				if userId == "" {
+					ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
+						Status: server_structs.RespFailed,
+						Msg:    "Claiming a registration requires a session with a Pelican user ID; log in through the web interface"})
+					return
+				}
+				// Bind ownership through the guarded claim primitive claimRegistration() before
+				// applying the field edits in updateRegistration(), because the latter deliberately
+				// never writes ownership. Claim-first ordering keeps the failure mode benign: an
+				// owned row with unsaved fields the caller can retry as owner, rather than an
+				// unowned row with request-provided fields.
+				if err := claimRegistration(ns.ID, userId); err != nil {
+					if errors.Is(err, errRegistrationAlreadyOwned) {
+						// Lost a race with a concurrent claim of the same registration
+						log.Errorf("User %q (ID %q) lost a concurrent claim of namespace %q (ID %d)", user, userId, existingNs.Prefix, ns.ID)
+						ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
+							Status: server_structs.RespFailed,
+							Msg:    "You do not have permission to modify a registration that already belongs to another user"})
+						return
+					}
+					log.Errorf("Failed to claim registration %d for user %q (ID %q): %v", ns.ID, user, userId, err)
+					ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+						Status: server_structs.RespFailed,
+						Msg:    "Failed to claim the registration"})
+					return
+				}
+				// In-memory only, so the required-field validation below sees
+				// the owner claimRegistration just recorded.
+				ns.AdminMetadata.UserID = userId
 			}
 		}
 
@@ -730,7 +768,7 @@ func getNamespace(ctx *gin.Context) {
 	belongsTo := false
 
 	if !isAdmin { // Not admin, need to check if the namespace belongs to the user
-		belongsTo, err = registrationBelongsToUserId(id, user)
+		belongsTo, err = registrationBelongsToUser(id, userId)
 		if err != nil {
 			log.Error("Error checking if namespace belongs to the user: ", err)
 			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
@@ -787,6 +825,123 @@ func getNamespace(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, ns)
+}
+
+// Claim an unowned registration: after verifying the access token minted by
+// the registering server against the registration's public key, bind the
+// registration to the logged-in user. The stable Pelican user ID is recorded
+// as the owner; a session without one is refused (403). Re-claiming a
+// registration the caller already owns succeeds idempotently.
+//
+// POST /namespaces/:id/claim?access_token=<token>
+func claimNamespace(ctx *gin.Context) {
+	accessToken := ctx.Query("access_token")
+	user, userId, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		log.Error("Failed to get user groups: ", err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user groups"})
+		return
+	}
+	if user == "" {
+		ctx.JSON(http.StatusUnauthorized, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "You need to login to perform this action"})
+		return
+	}
+	// The owner is recorded as the immutable Pelican user ID; a session
+	// without one (e.g. the CLI admin token) cannot take ownership.
+	if userId == "" {
+		ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Claiming a registration requires a session with a Pelican user ID; log in through the web interface"})
+		return
+	}
+	idStr := ctx.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil || id <= 0 {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Invalid ID format. ID must a positive integer"})
+		return
+	}
+	if accessToken == "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "An access_token generated by the registered server is required to claim a registration"})
+		return
+	}
+	ns, err := getRegistrationById(id)
+	if err != nil {
+		if errors.Is(err, errRegistrationNotFound) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Namespace not found"})
+			return
+		}
+		log.Error("Error getting namespace: ", err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Error getting namespace"})
+		return
+	}
+	if ns.AdminMetadata.UserID != "" {
+		if ns.AdminMetadata.UserID == userId {
+			// Idempotent: the caller already owns this registration
+			ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
+				Status: server_structs.RespOK,
+				Msg:    "success",
+			})
+			return
+		}
+		ctx.JSON(http.StatusConflict, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "This registration has already been claimed. Contact the current owner or a federation administrator to transfer it"})
+		return
+	}
+
+	// Possession of a token signed by the registration's private key is the
+	// proof that the caller operates the registered server.
+	jwks, err := jwk.Parse([]byte(ns.Pubkey))
+	if err != nil {
+		log.Errorf("Error parsing the public key of the namespace %s with ID %d: %v", ns.Prefix, ns.ID, err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Error parsing the public key of the namespace %s with ID %d: %v", ns.Prefix, ns.ID, err),
+		})
+		return
+	}
+	scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Registry_EditRegistration}, false)
+	if _, err := token.VerifyWithKeyset(accessToken, jwks, jwt.WithValidator(scopeValidator)); err != nil {
+		log.Errorf("Failed to verify access token to claim namespace %q (ID %d) by user %q: %v", ns.Prefix, ns.ID, user, err)
+		ctx.JSON(http.StatusForbidden,
+			server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprint("Invalid access token: ", err),
+			})
+		return
+	}
+
+	if err := claimRegistration(id, userId); err != nil {
+		if errors.Is(err, errRegistrationAlreadyOwned) {
+			// Lost a race with a concurrent claim between the pre-check
+			// above and the guarded write.
+			ctx.JSON(http.StatusConflict, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "This registration has already been claimed. Contact the current owner or a federation administrator to transfer it"})
+			return
+		}
+		log.Errorf("Failed to set the owner of registration %d to %s: %v", id, userId, err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to claim the registration"})
+		return
+	}
+	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
+		Status: server_structs.RespOK,
+		Msg:    "success",
+	})
 }
 
 func updateNamespaceStatus(ctx *gin.Context, status server_structs.RegistrationStatus) {
@@ -1057,6 +1212,7 @@ func RegisterRegistryWebAPI(router *gin.RouterGroup) error {
 		})
 		registryWebAPI.DELETE("/namespaces/:id", web_ui.AuthHandler, web_ui.AdminAuthHandler, deleteNamespace)
 		registryWebAPI.GET("/namespaces/:id/pubkey", getNamespaceJWKS)
+		registryWebAPI.POST("/namespaces/:id/claim", web_ui.AuthHandler, claimNamespace)
 		registryWebAPI.PATCH("/namespaces/:id/approve", web_ui.AuthHandler, web_ui.AdminAuthHandler, func(ctx *gin.Context) {
 			updateNamespaceStatus(ctx, server_structs.RegApproved)
 		})

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -706,10 +706,13 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		// A fully-valid submission moves an auto-registered (Incomplete)
 		// registration into the admin review queue. Partially-filled updates
 		// (e.g. an admin correcting an unclaimed registration) keep it Incomplete.
-		if existingStatus == server_structs.RegIncomplete {
+		// Denial is likewise not final: editing a Denied registration (e.g. to
+		// fix the problem that led to the denial) resubmits it as Pending for
+		// another round of review.
+		if existingStatus == server_structs.RegIncomplete || existingStatus == server_structs.RegDenied {
 			if verr := config.GetValidate().Struct(ns); verr == nil {
 				if serr := updateRegistrationStatusById(ns.ID, server_structs.RegPending, ""); serr != nil {
-					log.Errorf("Failed to promote registration %d from Incomplete to Pending: %v", ns.ID, serr)
+					log.Errorf("Failed to promote registration %d from %s to Pending: %v", ns.ID, existingStatus, serr)
 					ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 						Status: server_structs.RespFailed,
 						Msg:    "Registration was updated but could not be submitted for review"})

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -36,6 +36,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token"
@@ -944,6 +945,145 @@ func claimNamespace(ctx *gin.Context) {
 	})
 }
 
+// createRegistrationOwnershipInviteReq is the body for
+// POST /namespaces/:id/ownership-invites. ExpiresIn is a Go duration
+// string; absent or empty defaults to 7 days. The link is always
+// single-use — ownership transfer is a one-shot operation.
+type createRegistrationOwnershipInviteReq struct {
+	ExpiresIn string `json:"expiresIn,omitempty"`
+}
+
+// createRegistrationOwnershipInviteRes mirrors the collection-ownership
+// invite response shape so the frontend's link displayer can consume it
+// without a kind-specific adapter.
+type createRegistrationOwnershipInviteRes struct {
+	ID          string    `json:"id"`
+	InviteToken string    `json:"inviteToken"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+	IsSingleUse bool      `json:"isSingleUse"`
+}
+
+// maxOwnershipInviteExpiry caps how long an ownership-transfer invite stays
+// redeemable, keeping it from becoming effectively permanent.
+const maxOwnershipInviteExpiry = 30 * 24 * time.Hour
+
+// Mint a single-use invite that, when redeemed by an authenticated user,
+// transfers ownership of the registration to that user. Only the current
+// owner or a registry admin may mint one.
+//
+// POST /namespaces/:id/ownership-invites
+func createRegistrationOwnershipInvite(ctx *gin.Context) {
+	user, userId, groups, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		log.Error("Failed to get user groups: ", err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user groups"})
+		return
+	}
+	if user == "" {
+		ctx.JSON(http.StatusUnauthorized, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "You need to login to perform this action"})
+		return
+	}
+	idStr := ctx.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil || id <= 0 {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Invalid ID format. ID must a positive integer"})
+		return
+	}
+	exists, err := registrationExistsById(id)
+	if err != nil {
+		log.Error("Error checking if namespace exists: ", err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Error checking if namespace exists"})
+		return
+	}
+	if !exists {
+		ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Namespace not found"})
+		return
+	}
+
+	identity := web_ui.UserIdentity{
+		Username: user,
+		ID:       userId,
+		Groups:   groups,
+		Sub:      ctx.GetString("OIDCSub"),
+	}
+	isAdmin, _ := web_ui.CheckAdmin(identity)
+	if !isAdmin {
+		belongsTo, err := registrationBelongsToUser(id, userId)
+		if err != nil {
+			log.Error("Error checking if namespace belongs to the user: ", err)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Error checking if namespace belongs to the user"})
+			return
+		}
+		if !belongsTo {
+			ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Only the owner of a registration or an admin can transfer its ownership"})
+			return
+		}
+	}
+
+	req := createRegistrationOwnershipInviteReq{}
+	if ctx.Request.ContentLength > 0 {
+		if err := ctx.ShouldBindJSON(&req); err != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Invalid request body: " + err.Error()})
+			return
+		}
+	}
+	expiry := 7 * 24 * time.Hour
+	if req.ExpiresIn != "" {
+		d, parseErr := time.ParseDuration(req.ExpiresIn)
+		if parseErr != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Invalid expiresIn (Go duration): %v", parseErr)})
+			return
+		}
+		if d <= 0 || d > maxOwnershipInviteExpiry {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "expiresIn must be positive and at most 720h (30 days)"})
+			return
+		}
+		expiry = d
+	}
+
+	authMethod, authMethodID := web_ui.CaptureAuthMethod(ctx)
+	creator := userId
+	if creator == "" {
+		creator = user
+	}
+	link, plaintext, err := database.CreateRegistrationOwnershipInviteLink(
+		database.ServerDatabase, id, creator, time.Now().Add(expiry), authMethod, authMethodID,
+	)
+	if err != nil {
+		log.Errorf("Failed to mint ownership invite for registration %d: %v", id, err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to mint ownership invite"})
+		return
+	}
+	ctx.JSON(http.StatusCreated, createRegistrationOwnershipInviteRes{
+		ID:          link.ID,
+		InviteToken: plaintext,
+		ExpiresAt:   link.ExpiresAt,
+		IsSingleUse: link.IsSingleUse,
+	})
+}
+
 func updateNamespaceStatus(ctx *gin.Context, status server_structs.RegistrationStatus) {
 	user := ctx.GetString("User")
 	idStr := ctx.Param("id")
@@ -1213,6 +1353,7 @@ func RegisterRegistryWebAPI(router *gin.RouterGroup) error {
 		registryWebAPI.DELETE("/namespaces/:id", web_ui.AuthHandler, web_ui.AdminAuthHandler, deleteNamespace)
 		registryWebAPI.GET("/namespaces/:id/pubkey", getNamespaceJWKS)
 		registryWebAPI.POST("/namespaces/:id/claim", web_ui.AuthHandler, claimNamespace)
+		registryWebAPI.POST("/namespaces/:id/ownership-invites", web_ui.AuthHandler, createRegistrationOwnershipInvite)
 		registryWebAPI.PATCH("/namespaces/:id/approve", web_ui.AuthHandler, web_ui.AdminAuthHandler, func(ctx *gin.Context) {
 			updateNamespaceStatus(ctx, server_structs.RegApproved)
 		})

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -1378,6 +1378,52 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 		assert.Equal(t, "newDescription", nss[0].AdminMetadata.Description)
 	})
 
+	t.Run("reg-user-edit-of-denied-ns-resubmits-as-pending", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		mockInsts := []registrationFieldOption{{ID: "1000"}}
+		require.NoError(t, param.Registry_Institutions.Set(mockInsts))
+
+		pubKeyStr, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		mockNs := server_structs.Registration{
+			Prefix: "/foo",
+			Pubkey: pubKeyStr,
+			AdminMetadata: server_structs.AdminMetadata{
+				Description: "oldDescription",
+				Institution: "1000",
+				UserID:      "u-mock-id", // same as currently signed-in user
+				Status:      server_structs.RegDenied,
+				SiteName:    "test-site-name",
+			},
+		}
+
+		err = insertMockDBData([]server_structs.Registration{mockNs})
+		require.NoError(t, err)
+
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		// The owner fixes the problem that led to the denial and resubmits
+		updatedNs := mockNs
+		updatedNs.AdminMetadata.Description = "newDescription"
+
+		mockNsBytes, err := json.Marshal(updatedNs)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/namespaces/"+strconv.Itoa(id), bytes.NewReader(mockNsBytes))
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "newDescription", got.AdminMetadata.Description)
+		// The edit moved the registration back into the review queue
+		assert.Equal(t, server_structs.RegPending, got.AdminMetadata.Status)
+	})
+
 	t.Run("admin-can-change-anybody", func(t *testing.T) {
 		resetMockRegistryDB(t)
 		mockInsts := []registrationFieldOption{{ID: "1000"}}

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -337,8 +337,8 @@ func TestListNamespacesForUser(t *testing.T) {
 
 	mockUserNss := func() []server_structs.Registration {
 		return []server_structs.Registration{
-			mockNamespace("/foo", "", "", server_structs.AdminMetadata{UserID: "mockUser", Status: server_structs.RegPending}),
-			mockNamespace("/bar", "", "", server_structs.AdminMetadata{UserID: "mockUser", Status: server_structs.RegApproved}),
+			mockNamespace("/foo", "", "", server_structs.AdminMetadata{UserID: "u-mock-id", Status: server_structs.RegPending}),
+			mockNamespace("/bar", "", "", server_structs.AdminMetadata{UserID: "u-mock-id", Status: server_structs.RegApproved}),
 		}
 	}()
 
@@ -397,6 +397,7 @@ func TestListNamespacesForUser(t *testing.T) {
 				router := gin.Default()
 				router.GET("/namespaces/user", func(ctx *gin.Context) {
 					ctx.Set("User", "mockUser")
+					ctx.Set("UserId", "u-mock-id")
 				}, listNamespacesForUser)
 				router.ServeHTTP(w, req)
 			} else {
@@ -428,7 +429,7 @@ func TestGetNamespace(t *testing.T) {
 	setupMockRegistryDB(t)
 	defer teardownMockRegistryDB(t)
 
-	mockUserNs := mockNamespace("/mockUser", "", "", server_structs.AdminMetadata{UserID: "mockUser"})
+	mockUserNs := mockNamespace("/mockUser", "", "", server_structs.AdminMetadata{UserID: "u-mock-id"})
 
 	tests := []struct {
 		description  string
@@ -439,8 +440,10 @@ func TestGetNamespace(t *testing.T) {
 		userName     string
 	}{
 		{
-			description:  "valid-request-with-empty-key",
-			expectedCode: http.StatusOK,
+			// An anonymous caller (empty username) must not be treated as the
+			// owner of an unclaimed registration (empty user_id)
+			description:  "valid-request-without-user-is-forbidden",
+			expectedCode: http.StatusForbidden,
 			validID:      true,
 		},
 		{
@@ -519,6 +522,12 @@ func TestGetNamespace(t *testing.T) {
 				router := gin.Default()
 				router.GET("/test/:id", func(ctx *gin.Context) {
 					ctx.Set("User", tc.userName)
+					// Ownership is matched on the Pelican user ID, never the username
+					if tc.userName == "mockUser" {
+						ctx.Set("UserId", "u-mock-id")
+					} else if tc.userName == "randomUser" {
+						ctx.Set("UserId", "u-random-id")
+					}
 				}, getNamespace)
 				router.ServeHTTP(w, req)
 			} else {
@@ -758,6 +767,7 @@ func TestCreateNamespace(t *testing.T) {
 	router := gin.Default()
 	router.POST("/namespaces", func(ctx *gin.Context) {
 		ctx.Set("User", "admin")
+		ctx.Set("UserId", "u-admin-id")
 		createUpdateNamespace(ctx, false)
 	})
 
@@ -1011,7 +1021,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(nss))
 		assert.Equal(t, "/foo", nss[0].Prefix)
-		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
+		assert.Equal(t, "u-admin-id", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
 	})
@@ -1068,7 +1078,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(nss))
 		assert.Equal(t, "/foo", nss[0].Prefix)
-		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
+		assert.Equal(t, "u-admin-id", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
 	})
@@ -1109,7 +1119,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(nss))
 		assert.Equal(t, "/topo/foo/bar", nss[0].Prefix)
-		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
+		assert.Equal(t, "u-admin-id", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
 		config.ResetConfig()
@@ -1151,7 +1161,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(nss))
 		assert.Equal(t, "/topo/foo", nss[0].Prefix)
-		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
+		assert.Equal(t, "u-admin-id", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
 		config.ResetConfig()
@@ -1175,6 +1185,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 	router := gin.Default()
 	router.PUT("/namespaces/:id", func(ctx *gin.Context) {
 		ctx.Set("User", "mockUser")
+		ctx.Set("UserId", "u-mock-id")
 		createUpdateNamespace(ctx, true)
 	})
 
@@ -1285,7 +1296,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 			Pubkey: pubKeyStr,
 			AdminMetadata: server_structs.AdminMetadata{
 				Institution: "1000",
-				UserID:      "mockUser",                 // same as currently sign-in user
+				UserID:      "u-mock-id",                // same as currently sign-in user
 				Status:      server_structs.RegApproved, // but it's approved
 				SiteName:    "test-site-name",
 			},
@@ -1325,7 +1336,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 			AdminMetadata: server_structs.AdminMetadata{
 				Description: "oldDescription",
 				Institution: "1000",
-				UserID:      "mockUser",                // same as currently sign-in user
+				UserID:      "u-mock-id",               // same as currently sign-in user
 				Status:      server_structs.RegPending, // but it's approved
 				SiteName:    "test-site-name",
 			},
@@ -1371,7 +1382,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 			AdminMetadata: server_structs.AdminMetadata{
 				Description: "oldDescription",
 				Institution: "1000",
-				UserID:      "mockUser",                 // same as currently sign-in user
+				UserID:      "u-mock-id",                // same as currently sign-in user
 				Status:      server_structs.RegApproved, // but it's approved
 				SiteName:    "test-site-name",
 			},
@@ -1435,6 +1446,7 @@ func TestUpdateNamespaceAccessTokenProofOfPossession(t *testing.T) {
 	router := gin.Default()
 	router.PUT("/namespaces/:id", func(ctx *gin.Context) {
 		ctx.Set("User", "mockUser")
+		ctx.Set("UserId", "u-mock-id")
 		createUpdateNamespace(ctx, true)
 	})
 
@@ -1579,8 +1591,297 @@ func TestUpdateNamespaceAccessTokenProofOfPossession(t *testing.T) {
 
 		got, err := getRegistrationById(id)
 		require.NoError(t, err)
-		assert.Equal(t, "mockUser", got.AdminMetadata.UserID, "unowned registration should be claimable")
+		assert.Equal(t, "u-mock-id", got.AdminMetadata.UserID, "unowned registration should be claimable")
 		assert.Equal(t, storedJWKS, got.Pubkey)
+	})
+}
+
+// TestUpdateNamespaceOwnerNeverFromBody is a regression test for the
+// ownership back door: a PUT body must never set, change, or clear the
+// recorded owner. Ownership transitions only through the claim flow
+// (claimRegistration); the update path carries the stored owner forward
+// regardless of what the request body says — and must not depend on the web
+// form happening to round-trip user_id.
+func TestUpdateNamespaceOwnerNeverFromBody(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(func() { server_utils.ResetTestState() })
+	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	mockInsts := []registrationFieldOption{{ID: "1000"}}
+	require.NoError(t, param.Registry_Institutions.Set(mockInsts))
+
+	_, _, storedJWKS, err := test_utils.GenerateJWK()
+	require.NoError(t, err)
+
+	newRouter := func(user, userId string) *gin.Engine {
+		router := gin.Default()
+		router.PUT("/namespaces/:id", func(ctx *gin.Context) {
+			ctx.Set("User", user)
+			ctx.Set("UserId", userId)
+			createUpdateNamespace(ctx, true)
+		})
+		return router
+	}
+
+	mockOwned := func() server_structs.Registration {
+		return server_structs.Registration{
+			Prefix: "/foo",
+			Pubkey: storedJWKS,
+			AdminMetadata: server_structs.AdminMetadata{
+				Description: "mock description",
+				Institution: "1000",
+				UserID:      "u-mock-id",
+				Status:      server_structs.RegPending,
+				SiteName:    "test-site-name",
+			},
+		}
+	}
+
+	putBody := func(t *testing.T, router *gin.Engine, id int, body server_structs.Registration) *httptest.ResponseRecorder {
+		payload, err := json.Marshal(body)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/namespaces/"+strconv.Itoa(id), bytes.NewReader(payload))
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("owner-cannot-reassign-owner", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		require.NoError(t, insertMockDBData([]server_structs.Registration{mockOwned()}))
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		body := mockOwned()
+		body.AdminMetadata.UserID = "u-victim-id" // attempted reassignment
+		body.AdminMetadata.SiteName = "new-site-name"
+		w := putBody(t, newRouter("mockUser", "u-mock-id"), id, body)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode, w.Body.String())
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-mock-id", got.AdminMetadata.UserID, "body-supplied user_id must not change the owner")
+		assert.Equal(t, "new-site-name", got.AdminMetadata.SiteName, "legitimate field edits still apply")
+	})
+
+	t.Run("owner-edit-works-without-user-id-in-body", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		require.NoError(t, insertMockDBData([]server_structs.Registration{mockOwned()}))
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		body := mockOwned()
+		body.AdminMetadata.UserID = ""
+		w := putBody(t, newRouter("mockUser", "u-mock-id"), id, body)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode, w.Body.String())
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-mock-id", got.AdminMetadata.UserID, "an omitted user_id must neither fail validation nor clear the owner")
+	})
+
+	t.Run("admin-edit-cannot-clear-owner", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		require.NoError(t, insertMockDBData([]server_structs.Registration{mockOwned()}))
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		body := mockOwned()
+		body.AdminMetadata.UserID = "" // e.g. a scripted admin PUT with a partial body
+		// The built-in "admin" username carries the server.admin scope
+		w := putBody(t, newRouter("admin", "u-admin-id"), id, body)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode, w.Body.String())
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-mock-id", got.AdminMetadata.UserID, "an admin edit must not clear or take the owner")
+	})
+}
+
+// TestClaimNamespaceHandler exercises POST /namespaces/:id/claim against the
+// mock DB: the auth guards, the key-possession proof against the STORED
+// public key, idempotent re-claims by the owner, and the conflict answer for
+// everyone else.
+func TestClaimNamespaceHandler(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(func() { server_utils.ResetTestState() })
+	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	mintEditToken := func(t *testing.T, privKey jwk.Key) string {
+		tok, err := jwt.NewBuilder().
+			Claim("scope", token_scopes.Registry_EditRegistration.String()).
+			Build()
+		require.NoError(t, err)
+		signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, privKey))
+		require.NoError(t, err)
+		return string(signed)
+	}
+
+	newRouter := func(user, userId string) *gin.Engine {
+		router := gin.Default()
+		router.POST("/namespaces/:id/claim", func(ctx *gin.Context) {
+			if user != "" {
+				ctx.Set("User", user)
+			}
+			if userId != "" {
+				ctx.Set("UserId", userId)
+			}
+			claimNamespace(ctx)
+		})
+		return router
+	}
+
+	insertUnowned := func(t *testing.T, jwksStr string) int {
+		require.NoError(t, insertMockDBData([]server_structs.Registration{{
+			Prefix: "/foo",
+			Pubkey: jwksStr,
+			AdminMetadata: server_structs.AdminMetadata{
+				Status: server_structs.RegIncomplete,
+			},
+		}}))
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+		return id
+	}
+
+	post := func(router *gin.Engine, id string, token string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		target := "/namespaces/" + id + "/claim"
+		if token != "" {
+			target += "?access_token=" + url.QueryEscape(token)
+		}
+		req, _ := http.NewRequest("POST", target, nil)
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("login-required", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		privKey, _, jwksStr, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+		id := insertUnowned(t, jwksStr)
+
+		w := post(newRouter("", ""), strconv.Itoa(id), mintEditToken(t, privKey))
+		assert.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
+	})
+
+	t.Run("user-id-required", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		privKey, _, jwksStr, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+		id := insertUnowned(t, jwksStr)
+
+		// e.g. the CLI admin token: a session with a username but no user row
+		w := post(newRouter("mockUser", ""), strconv.Itoa(id), mintEditToken(t, privKey))
+		assert.Equal(t, http.StatusForbidden, w.Result().StatusCode)
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "", got.AdminMetadata.UserID, "a refused claim must not write an owner")
+	})
+
+	t.Run("access-token-required", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		_, _, jwksStr, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+		id := insertUnowned(t, jwksStr)
+
+		w := post(newRouter("mockUser", "u-mock-id"), strconv.Itoa(id), "")
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	})
+
+	t.Run("invalid-id-format", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		w := post(newRouter("mockUser", "u-mock-id"), "abc", "dummy-token")
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	})
+
+	t.Run("unknown-id-not-found", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		w := post(newRouter("mockUser", "u-mock-id"), "404404", "dummy-token")
+		assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+	})
+
+	t.Run("wrong-key-token-rejected", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		_, _, jwksStr, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+		id := insertUnowned(t, jwksStr)
+
+		attackerPriv, _, _, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+
+		w := post(newRouter("mockUser", "u-mock-id"), strconv.Itoa(id), mintEditToken(t, attackerPriv))
+		assert.Equal(t, http.StatusForbidden, w.Result().StatusCode)
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "", got.AdminMetadata.UserID, "a rejected token must not write an owner")
+	})
+
+	t.Run("valid-claim-records-user-id", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		privKey, _, jwksStr, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+		id := insertUnowned(t, jwksStr)
+
+		w := post(newRouter("mockUser", "u-mock-id"), strconv.Itoa(id), mintEditToken(t, privKey))
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode, w.Body.String())
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-mock-id", got.AdminMetadata.UserID, "the claim must record the caller's Pelican user ID")
+	})
+
+	t.Run("re-claim-by-owner-is-idempotent", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		privKey, _, jwksStr, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+		id := insertUnowned(t, jwksStr)
+		router := newRouter("mockUser", "u-mock-id")
+		token := mintEditToken(t, privKey)
+
+		w := post(router, strconv.Itoa(id), token)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode, w.Body.String())
+
+		// A stale link, browser back, or lost response replays the claim
+		w = post(router, strconv.Itoa(id), token)
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode, "re-claiming your own registration must succeed")
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-mock-id", got.AdminMetadata.UserID)
+	})
+
+	t.Run("claim-of-owned-registration-conflicts", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		privKey, _, jwksStr, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+		id := insertUnowned(t, jwksStr)
+		token := mintEditToken(t, privKey)
+
+		w := post(newRouter("mockUser", "u-mock-id"), strconv.Itoa(id), token)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode, w.Body.String())
+
+		// A second operator with log access presents the same valid token
+		w = post(newRouter("otherUser", "u-other-id"), strconv.Itoa(id), token)
+		assert.Equal(t, http.StatusConflict, w.Result().StatusCode)
+
+		got, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-mock-id", got.AdminMetadata.UserID, "a conflicting claim must not steal ownership")
 	})
 }
 

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -487,6 +487,16 @@ func TestGetNamespace(t *testing.T) {
 			expectedCode: http.StatusForbidden,
 		},
 		{
+			// Regression for the removed username leg: a caller whose
+			// USERNAME equals the stored owner (a user ID) must not be
+			// treated as the owner — ownership matches the user ID only.
+			description:  "username-equal-to-owner-does-not-grant",
+			validID:      true,
+			checkAdmin:   true,
+			userName:     "u-mock-id",
+			expectedCode: http.StatusForbidden,
+		},
+		{
 			description:  "admin-can-see-any-ns",
 			validID:      true,
 			checkAdmin:   true,
@@ -2101,4 +2111,170 @@ func TestDeleteNamespaceKeepsServerWhenMultipleServices(t *testing.T) {
 	// Ensure the remaining registration is the origin one
 	remainingPrefix := returned.Registration[0].Prefix
 	assert.Equal(t, "/origins/both-roles.edu", remainingPrefix)
+}
+
+// TestClaimNamespace covers the login-gated claim endpoint: a valid
+// server-minted token binds an unowned registration to the caller's
+// Pelican user ID; everything else is rejected.
+func TestClaimNamespace(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	privKey, _, pubJwksStr, err := test_utils.GenerateJWK()
+	require.NoError(t, err)
+
+	mintClaimToken := func(t *testing.T, key jwk.Key) string {
+		tok := jwt.New()
+		require.NoError(t, tok.Set(jwt.IssuedAtKey, time.Now()))
+		require.NoError(t, tok.Set(jwt.ExpirationKey, time.Now().Add(10*time.Minute)))
+		require.NoError(t, tok.Set("scope", token_scopes.Registry_EditRegistration.String()))
+		signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, key))
+		require.NoError(t, err)
+		return string(signed)
+	}
+
+	newClaimRouter := func(user, userId string) *gin.Engine {
+		router := gin.Default()
+		router.POST("/test/:id/claim", func(ctx *gin.Context) {
+			ctx.Set("User", user)
+			if userId != "" {
+				ctx.Set("UserId", userId)
+			}
+			claimNamespace(ctx)
+		})
+		return router
+	}
+
+	t.Run("valid-token-claims-with-pelican-user-id", func(t *testing.T) {
+		err := insertMockDBData([]server_structs.Registration{
+			mockNamespace("/origins/claim-test.org", pubJwksStr, "", server_structs.AdminMetadata{SiteName: "claim-site"}),
+		})
+		require.NoError(t, err)
+		defer resetMockRegistryDB(t)
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		router := newClaimRouter("mockUser", "u-mock-id")
+		w := httptest.NewRecorder()
+		reqUrl := fmt.Sprintf("/test/%d/claim?access_token=%s", id, url.QueryEscape(mintClaimToken(t, privKey)))
+		req, _ := http.NewRequest("POST", reqUrl, nil)
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		ns, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "u-mock-id", ns.AdminMetadata.UserID,
+			"the stable Pelican user ID must be recorded as the owner")
+	})
+
+	t.Run("no-user-id-is-rejected", func(t *testing.T) {
+		// The owner is recorded as the Pelican user ID only — a session
+		// without one (e.g. the CLI admin token) must not claim, and in
+		// particular the login username must never be written as owner.
+		err := insertMockDBData([]server_structs.Registration{
+			mockNamespace("/origins/claim-test.org", pubJwksStr, "", server_structs.AdminMetadata{SiteName: "claim-site"}),
+		})
+		require.NoError(t, err)
+		defer resetMockRegistryDB(t)
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		router := newClaimRouter("mockUser", "")
+		w := httptest.NewRecorder()
+		reqUrl := fmt.Sprintf("/test/%d/claim?access_token=%s", id, url.QueryEscape(mintClaimToken(t, privKey)))
+		req, _ := http.NewRequest("POST", reqUrl, nil)
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Code)
+		ns, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "", ns.AdminMetadata.UserID, "a claim without a user ID must write nothing")
+	})
+
+	t.Run("missing-token-returns-400", func(t *testing.T) {
+		err := insertMockDBData([]server_structs.Registration{
+			mockNamespace("/origins/claim-test.org", pubJwksStr, "", server_structs.AdminMetadata{}),
+		})
+		require.NoError(t, err)
+		defer resetMockRegistryDB(t)
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		router := newClaimRouter("mockUser", "u-mock-id")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", fmt.Sprintf("/test/%d/claim", id), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("already-claimed-returns-409", func(t *testing.T) {
+		err := insertMockDBData([]server_structs.Registration{
+			mockNamespace("/origins/claim-test.org", pubJwksStr, "", server_structs.AdminMetadata{UserID: "someone-else"}),
+		})
+		require.NoError(t, err)
+		defer resetMockRegistryDB(t)
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		router := newClaimRouter("mockUser", "u-mock-id")
+		w := httptest.NewRecorder()
+		reqUrl := fmt.Sprintf("/test/%d/claim?access_token=%s", id, url.QueryEscape(mintClaimToken(t, privKey)))
+		req, _ := http.NewRequest("POST", reqUrl, nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+		ns, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Equal(t, "someone-else", ns.AdminMetadata.UserID,
+			"a claim attempt on an owned registration must not change the owner")
+	})
+
+	t.Run("token-from-wrong-key-returns-403", func(t *testing.T) {
+		err := insertMockDBData([]server_structs.Registration{
+			mockNamespace("/origins/claim-test.org", pubJwksStr, "", server_structs.AdminMetadata{}),
+		})
+		require.NoError(t, err)
+		defer resetMockRegistryDB(t)
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		wrongKey, _, _, err := test_utils.GenerateJWK()
+		require.NoError(t, err)
+
+		router := newClaimRouter("mockUser", "u-mock-id")
+		w := httptest.NewRecorder()
+		reqUrl := fmt.Sprintf("/test/%d/claim?access_token=%s", id, url.QueryEscape(mintClaimToken(t, wrongKey)))
+		req, _ := http.NewRequest("POST", reqUrl, nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		ns, err := getRegistrationById(id)
+		require.NoError(t, err)
+		assert.Empty(t, ns.AdminMetadata.UserID)
+	})
+
+	t.Run("unauthenticated-returns-401", func(t *testing.T) {
+		err := insertMockDBData([]server_structs.Registration{
+			mockNamespace("/origins/claim-test.org", pubJwksStr, "", server_structs.AdminMetadata{}),
+		})
+		require.NoError(t, err)
+		defer resetMockRegistryDB(t)
+		id, err := getLastNamespaceId()
+		require.NoError(t, err)
+
+		router := gin.Default()
+		router.POST("/test/:id/claim", claimNamespace)
+		w := httptest.NewRecorder()
+		reqUrl := fmt.Sprintf("/test/%d/claim?access_token=%s", id, url.QueryEscape(mintClaimToken(t, privKey)))
+		req, _ := http.NewRequest("POST", reqUrl, nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
 }

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -993,7 +993,7 @@ func TestCreateNamespace(t *testing.T) {
 		pubKeyStr, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 
-		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name"}}
+		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name", Description: "test description"}}
 		mockNsBytes, err := json.Marshal(mockNs)
 		require.NoError(t, err)
 		// Create a request to the endpoint
@@ -1048,7 +1048,7 @@ func TestCreateNamespace(t *testing.T) {
 		mockNs := server_structs.Registration{
 			Prefix:        "/foo",
 			Pubkey:        pubKeyStr,
-			AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name"},
+			AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name", Description: "test description"},
 			CustomFields:  customFieldsVals,
 		}
 		mockNsBytes, err := json.Marshal(mockNs)
@@ -1559,6 +1559,7 @@ func TestUpdateNamespaceAccessTokenProofOfPossession(t *testing.T) {
 				UserID:      "",
 				Status:      server_structs.RegPending,
 				SiteName:    "test-site-name",
+				Description: "test description",
 			},
 		}
 		require.NoError(t, insertMockDBData([]server_structs.Registration{stored}))

--- a/server_structs/registry.go
+++ b/server_structs/registry.go
@@ -45,8 +45,8 @@ type RegistrationStatus string
 // endpoint to tell the UI if a field is required. For other validator tags,
 // visit: https://pkg.go.dev/github.com/go-playground/validator/v10
 type AdminMetadata struct {
-	UserID                string             `json:"user_id" post:"exclude"` // "sub" claim of user JWT who requested registration
-	Description           string             `json:"description"`
+	UserID                string             `json:"user_id" post:"exclude" validate:"required"` // "sub" claim of user JWT who requested registration
+	Description           string             `json:"description" validate:"required"`
 	SiteName              string             `json:"site_name"`
 	Institution           string             `json:"institution" validate:"required"`                                                                                // the unique identifier of the institution
 	SecurityContactUserID string             `json:"security_contact_user_id" description:"User Identifier of the user responsible for the security of the service"` // "sub" claim of user who is responsible for taking security concern
@@ -105,6 +105,10 @@ type (
 )
 
 const (
+	// RegIncomplete: auto-registered by an origin/cache; the human-facing
+	// registration form has not been completed and submitted yet.
+	RegIncomplete RegistrationStatus = "Incomplete"
+	// RegPending: registration form submitted; awaiting admin review.
 	RegPending  RegistrationStatus = "Pending"
 	RegApproved RegistrationStatus = "Approved"
 	RegDenied   RegistrationStatus = "Denied"
@@ -137,7 +141,7 @@ func (Registration) TableName() string {
 }
 
 func IsValidRegStatus(s string) bool {
-	return s == "Pending" || s == "Approved" || s == "Denied" || s == "Unknown"
+	return s == "Incomplete" || s == "Pending" || s == "Approved" || s == "Denied" || s == "Unknown"
 }
 
 // Server represents a Pelican server (origin or cache) in the registry

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -3812,6 +3812,84 @@ paths:
           schema:
             type: object
             $ref: "#/definitions/ErrorModelV2"
+  /registry_ui/namespaces/{id}/claim:
+    post:
+      tags:
+        - "registry_ui"
+      summary: Claim an unowned namespace registration for the logged-in user
+      description: "`Authentication Required`
+
+
+        Bind an unowned (auto-registered) namespace registration to the logged-in user.
+        The `access_token` must be minted by the registered server and is verified against
+        the registration's stored public key with scope `registry.edit_registration` —
+        possession of a token signed by the registration's private key proves the caller
+        operates the registered server.
+
+
+        The recorded owner is the caller's stable Pelican user ID; a session without one
+        (e.g. the CLI admin token) cannot take ownership and receives 403.
+
+
+        Re-claiming a registration the caller already owns succeeds idempotently. A
+        registration owned by another user returns 409; ownership can then only be
+        transferred by the current owner or a federation administrator.
+        "
+      operationId: claimNamespaceById
+      parameters:
+        - name: id
+          in: path
+          description: ID of the namespace registration to claim
+          required: true
+          type: integer
+        - name: access_token
+          in: query
+          description: Access token minted by the registered server, signed by the private key matching the registration's stored public key, carrying the scope `registry.edit_registration`
+          required: true
+          type: string
+        - in: header
+          name: X-CSRF-Token
+          description: The CSRF token for protecting against Cross-Site Request Forgery (CSRF) attacks. Obtained by requesting `/api/v1.0/auth/whoami` and reading response header `X-CSRF-Token`
+          type: string
+          required: true
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: Success. The registration is now owned by the logged-in user (also returned when the caller already owns it)
+          schema:
+            type: object
+            $ref: "#/definitions/SuccessModelV2"
+        "400":
+          description: Invalid namespace ID, or the `access_token` query parameter is missing
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
+        "401":
+          description: Authentication required to perform this action
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
+        "403":
+          description: The access token failed verification against the registration's stored public key, or the session carries no Pelican user ID to record as the owner
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
+        "404":
+          description: Namespace not found because it does not exist
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
+        "409":
+          description: The registration is already owned by another user
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
+        "500":
+          description: Internal server error
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
   /registry_ui/namespaces/{id}/approve:
     patch:
       tags:

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -1279,8 +1279,8 @@ definitions:
     description: >-
       Pre-redemption metadata returned by GET /invites/info. Lets the
       redemption UI render the right form (password entry vs.
-      confirm-join-group vs. accept-collection-ownership) without
-      consuming the token. Intentionally omits creator and target user
+      confirm-join-group vs. accept-collection-ownership vs.
+      accept-registration-ownership) without consuming the token. Intentionally omits creator and target user
       to avoid leaking information beyond what the token-bearer already
       implicitly knows.
     properties:
@@ -1290,6 +1290,7 @@ definitions:
           - group
           - password
           - collection_ownership
+          - registration_ownership
       expiresAt:
         type: string
         format: date-time
@@ -1313,6 +1314,15 @@ definitions:
       collectionNamespace:
         type: string
         description: Path prefix the collection is rooted at (e.g. "/research/dataset-A"). Shown in the redemption UI so the recipient sees what they're claiming.
+      registrationId:
+        type: integer
+        description: Present only when kind=registration_ownership.
+      registrationPrefix:
+        type: string
+        description: Namespace prefix of the registration (e.g. "/origins/example.org") for kind=registration_ownership. Shown in the redemption UI so the recipient sees what they're claiming.
+      registrationSiteName:
+        type: string
+        description: Site name from the registration's admin metadata; friendly label for kind=registration_ownership.
   ScopeCatalogEntry:
     type: object
     description: >-
@@ -3889,6 +3899,84 @@ paths:
           description: Internal server error
           schema:
             type: object
+            $ref: "#/definitions/ErrorModelV2"
+  /registry_ui/namespaces/{id}/ownership-invites:
+    post:
+      tags:
+        - "registry_ui"
+      summary: Mint a single-use ownership-transfer invite for a registration
+      description: >-
+        `Authentication Required`. Mints a single-use invite link that,
+        when redeemed by an authenticated user, transfers ownership of
+        the registration (the Pelican user ID recorded in its admin
+        metadata) to the redeemer. Issued only to the registration's
+        current owner or to a registry admin — admins can mint these to
+        rescue registrations whose stored owner is a legacy value
+        (CILogon sub URL, pre-7.28 login name) no session can match.
+
+
+        Single-use is forced server-side; no client toggle. Default
+        expiration is 7 days; supply `expiresIn` (a Go duration string)
+        to override — it must be positive and at most 720h (30 days).
+        Any change of the registration's owner (a claim or a redeemed
+        transfer) revokes its other outstanding transfer invites: they
+        were minted under authority that no longer holds.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          description: Registration ID.
+        - in: body
+          name: body
+          required: false
+          schema:
+            type: object
+            properties:
+              expiresIn:
+                type: string
+                description: >-
+                  Go duration string ("168h" = 7 days). Defaults to 7d;
+                  must be positive and at most 720h (30 days).
+      responses:
+        "201":
+          description: Invite minted; the plaintext token is shown ONCE here.
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              inviteToken:
+                type: string
+                description: Plaintext token. Shown only on creation.
+              expiresAt:
+                type: string
+                format: date-time
+              isSingleUse:
+                type: boolean
+        "400":
+          description: Invalid namespace ID or invalid expiresIn duration.
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "401":
+          description: Authentication required.
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "403":
+          description: Caller is neither the registration's owner nor an admin.
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "404":
+          description: Namespace not found.
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "500":
+          description: Internal server error.
+          schema:
             $ref: "#/definitions/ErrorModelV2"
   /registry_ui/namespaces/{id}/approve:
     patch:
@@ -6673,6 +6761,67 @@ paths:
               collectionId:
                 type: string
               previousOwnerId:
+                type: string
+        "400":
+          description: Token missing, expired, revoked, already used, or wrong kind.
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "401":
+          description: Authentication required.
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "404":
+          description: Invite link not found.
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+  /invites/redeem/registration-ownership:
+    post:
+      tags:
+        - invites
+      summary: Redeem a registration-ownership invite
+      description: >-
+        `Authentication Required`. Consumes a single-use ownership-
+        transfer invite — the authenticated caller becomes the owner of
+        the referenced registry registration (their Pelican user ID is
+        written into the registration's admin metadata; the invite is
+        marked redeemed in the same transaction). The previous owner, if
+        any, loses ownership at the same moment.
+
+
+        The caller must be authenticated — anonymous redemption would
+        let link-holders make ANYBODY the owner. Ordinary user
+        accounts (existing or self-enrolled via OIDC on first login)
+        are accepted; brand-new local-password users need to be
+        onboarded separately first (admin-issued password-set invite).
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required:
+              - token
+            properties:
+              token:
+                type: string
+                description: Plaintext invite token from the link.
+      responses:
+        "200":
+          description: Ownership transferred to the calling user.
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+              message:
+                type: string
+              registrationId:
+                type: integer
+              registrationPrefix:
                 type: string
         "400":
           description: Token missing, expired, revoked, already used, or wrong kind.

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -66,6 +66,11 @@ type (
 		Authenticated bool     `json:"authenticated"`
 		Role          UserRole `json:"role"`
 		User          string   `json:"user"`
+		// UserId is the stable Pelican user ID from the user database.
+		// Surfaced so the frontend can match records (e.g. registry
+		// registration ownership) that reference users by ID rather
+		// than by login username.
+		UserId string `json:"user_id,omitempty"`
 		// DisplayName is the human label from the User row (if any).
 		// Surfaced here so the navbar's user menu can render it
 		// without a second /me round-trip on every page mount.
@@ -1217,6 +1222,7 @@ func whoamiHandler(ctx *gin.Context) {
 	} else {
 		res.Authenticated = true
 		res.User = user
+		res.UserId = userId
 
 		// Set header to carry CSRF token
 		ctx.Header("X-CSRF-Token", csrf.Token(ctx.Request))

--- a/web_ui/frontend/app/invite/redeem/page.tsx
+++ b/web_ui/frontend/app/invite/redeem/page.tsx
@@ -172,6 +172,9 @@ const RedeemRouter: React.FC = () => {
   if (info.kind === 'collection_ownership') {
     return <CollectionOwnershipRedeem token={token} info={info} />;
   }
+  if (info.kind === 'registration_ownership') {
+    return <RegistrationOwnershipRedeem token={token} info={info} />;
+  }
   return <GroupRedeem token={token} info={info} />;
 };
 
@@ -498,6 +501,118 @@ const CollectionOwnershipRedeem: React.FC<{
                   sx={{ fontFamily: 'monospace', fontWeight: 600 }}
                 >
                   {info.collectionNamespace}
+                </Box>
+              </>
+            )}
+            .
+          </Typography>
+          {error && <Alert severity='error'>{error}</Alert>}
+          <Box display='flex' justifyContent='flex-end' gap={1}>
+            <Button onClick={() => router.push('/')} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button variant='contained' onClick={submit} disabled={submitting}>
+              {submitting ? 'Accepting…' : 'Accept ownership'}
+            </Button>
+          </Box>
+        </Stack>
+      </Paper>
+    </AuthenticatedContent>
+  );
+};
+
+// ============================================================================
+// Registration-ownership kind: authenticated confirm page. Accepting makes
+// the caller the owner of the registry registration named by the invite.
+// ============================================================================
+
+const RegistrationOwnershipRedeem: React.FC<{
+  token: string;
+  info: InviteInfo;
+}> = ({ token, info }) => {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const registrationLabel =
+    info.registrationSiteName?.trim() ||
+    info.registrationPrefix ||
+    'a registration';
+
+  const submit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await InviteService.redeemRegistrationOwnership(token);
+      setDone(true);
+    } catch (err) {
+      let message = 'Failed to redeem invite';
+      if (err instanceof Response) {
+        try {
+          message = await getErrorMessage(err);
+        } catch {
+          /* default */
+        }
+      } else if (err instanceof Error) {
+        message = err.message;
+      }
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <Paper variant='outlined' sx={{ p: 4 }}>
+        <Stack spacing={2}>
+          <Typography variant='h4'>Ownership transferred</Typography>
+          <Alert severity='success'>
+            You are now the owner of <strong>{registrationLabel}</strong>
+            {info.registrationPrefix && (
+              <>
+                {' '}
+                (<code>{info.registrationPrefix}</code>)
+              </>
+            )}
+            .
+          </Alert>
+          <Box display='flex' gap={1}>
+            <Button
+              variant='contained'
+              onClick={() => router.push('/registry/')}
+            >
+              Go to registry
+            </Button>
+            <Button variant='text' onClick={() => router.push('/')}>
+              Home
+            </Button>
+          </Box>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  return (
+    <AuthenticatedContent redirect>
+      <Paper variant='outlined' sx={{ p: 4 }}>
+        <Stack spacing={2}>
+          <Typography variant='h4'>Accept registration ownership</Typography>
+          <Typography variant='body1'>
+            Accepting will make you the owner of the registration{' '}
+            <Box component='span' sx={{ fontWeight: 600 }}>
+              {registrationLabel}
+            </Box>
+            {info.registrationPrefix && (
+              <>
+                {' '}
+                for prefix{' '}
+                <Box
+                  component='span'
+                  sx={{ fontFamily: 'monospace', fontWeight: 600 }}
+                >
+                  {info.registrationPrefix}
                 </Box>
               </>
             )}

--- a/web_ui/frontend/app/registry/claim/layout.tsx
+++ b/web_ui/frontend/app/registry/claim/layout.tsx
@@ -1,0 +1,5 @@
+export const metadata = {
+  title: 'Claim Registration',
+};
+
+export { default } from '@/components/layout/MetaLayout';

--- a/web_ui/frontend/app/registry/claim/page.tsx
+++ b/web_ui/frontend/app/registry/claim/page.tsx
@@ -1,0 +1,187 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+'use client';
+
+import { Box, Button, Grid, Paper, Skeleton, Typography } from '@mui/material';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import AuthenticatedContent from '@/components/layout/AuthenticatedContent';
+import { RegistryNamespace } from '@/index';
+import { AlertDispatchContext } from '@/components/AlertProvider';
+import { alertOnError } from '@/helpers/util';
+import { claimNamespace, getNamespace } from '@/helpers/api';
+
+// The claim page sits in front of the registration edit form: it is the
+// target of the registration link a Pelican server prints to its log after
+// auto-registering. After the operator logs in, accepting the claim binds
+// the registration to their Pelican user before they continue to the form.
+export default function Page() {
+  const dispatch = useContext(AlertDispatchContext);
+  const router = useRouter();
+
+  const [id, setId] = useState<number | undefined>(undefined);
+  const [accessToken, setAccessToken] = useState<string | undefined>(undefined);
+  const [fromUrl, setFromUrl] = useState<string | undefined>(undefined);
+  const [namespace, setNamespace] = useState<RegistryNamespace | undefined>(
+    undefined
+  );
+  const [claiming, setClaiming] = useState<boolean>(false);
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const idParam = urlParams.get('id');
+    const accessTokenParam = urlParams.get('access_token');
+    const fromUrlParam = urlParams.get('fromUrl');
+
+    if (idParam === null || accessTokenParam === null) {
+      dispatch({
+        type: 'openAlert',
+        payload: {
+          title: 'Invalid claim link',
+          message:
+            "This link is missing the 'id' or 'access_token' parameter. Copy the most recent registration link from your server's log; the token it carries expires after 15 minutes.",
+          onClose: () => dispatch({ type: 'closeAlert' }),
+        },
+      });
+      return;
+    }
+
+    const parsedId = parseInt(idParam);
+    if (isNaN(parsedId)) {
+      dispatch({
+        type: 'openAlert',
+        payload: {
+          title: 'Invalid Namespace ID provided',
+          message: 'The Namespace ID in this link is not a valid number.',
+          alertProps: {
+            severity: 'error',
+          },
+          onClose: () => dispatch({ type: 'closeAlert' }),
+        },
+      });
+      return;
+    }
+
+    setId(parsedId);
+    setAccessToken(accessTokenParam);
+    setFromUrl(fromUrlParam || undefined);
+
+    (async () => {
+      const response = await alertOnError(
+        async () => await getNamespace(parsedId, accessTokenParam),
+        "Couldn't get namespace",
+        dispatch
+      );
+      if (response) {
+        setNamespace(await response.json());
+      }
+    })();
+  }, [dispatch]);
+
+  // The GET response is the raw registration, so derive the server type from
+  // the prefix the same way the registry list page does
+  const namespaceType = useMemo(() => {
+    if (namespace === undefined) {
+      return undefined;
+    }
+    if (namespace.prefix.startsWith('/caches/')) {
+      return 'cache';
+    }
+    if (namespace.prefix.startsWith('/origins/')) {
+      return 'origin';
+    }
+    return 'namespace';
+  }, [namespace]);
+
+  const editUrl = useMemo(() => {
+    if (id === undefined || namespaceType === undefined) {
+      return undefined;
+    }
+    const params = new URLSearchParams({ id: id.toString() });
+    if (accessToken) {
+      params.set('access_token', accessToken);
+    }
+    if (fromUrl) {
+      params.set('fromUrl', fromUrl);
+    }
+    return `/registry/${namespaceType}/edit/?${params.toString()}`;
+  }, [id, namespaceType, accessToken, fromUrl]);
+
+  const claimAndContinue = async () => {
+    if (id === undefined || accessToken === undefined || editUrl == undefined) {
+      return;
+    }
+    setClaiming(true);
+    const response = await alertOnError(
+      async () => await claimNamespace(id, accessToken),
+      "Couldn't claim the registration",
+      dispatch
+    );
+    setClaiming(false);
+    if (response) {
+      router.push(editUrl);
+    }
+  };
+
+  return (
+    <AuthenticatedContent redirect={true} boxProps={{ width: '100%' }}>
+      <Grid container spacing={2}>
+        <Grid
+          size={{
+            xs: 12,
+            lg: 6,
+          }}
+        >
+          {namespace ? (
+            <Paper sx={{ p: 3 }} elevation={3}>
+              <Typography variant={'h5'} pb={2}>
+                Claim Registration
+              </Typography>
+              <Typography variant={'body1'} pb={2}>
+                A Pelican server registered itself with this federation and
+                needs an owner. Accepting makes your account the owner of this
+                registration so you can complete and manage it.
+              </Typography>
+              <Box pb={2}>
+                <Typography variant={'subtitle2'}>Prefix</Typography>
+                <Typography variant={'body2'} pb={1}>
+                  {namespace.prefix}
+                </Typography>
+                <Typography variant={'subtitle2'}>Site Name</Typography>
+                <Typography variant={'body2'}>
+                  {namespace.admin_metadata?.site_name || '—'}
+                </Typography>
+              </Box>
+              <Button
+                variant={'contained'}
+                disabled={claiming}
+                onClick={claimAndContinue}
+              >
+                Accept and Continue
+              </Button>
+            </Paper>
+          ) : (
+            <Skeleton variant='rectangular' width='100%' height={300} />
+          )}
+        </Grid>
+      </Grid>
+    </AuthenticatedContent>
+  );
+}

--- a/web_ui/frontend/app/registry/components/Form.tsx
+++ b/web_ui/frontend/app/registry/components/Form.tsx
@@ -21,6 +21,7 @@ import { alertOnError } from '@/helpers/util';
 import { optionsNamespaceRegistrationFields } from '@/helpers/api';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { getUser } from '@/helpers/login';
+import { userOwnsNamespace } from '@/components/Namespace';
 
 interface FormProps {
   namespace?: RegistryNamespace;
@@ -71,21 +72,31 @@ const Form = ({ namespace, onSubmit }: FormProps) => {
     { fallbackData: [] }
   );
 
-  // Auto-fill in the security contact if no security contact and request came from Origin
+  // Auto-fill the security contact when the current user is the operator of
+  // this registration and no contact has been set yet
   const { data: user } = useSWR('getUser', getUser);
   useEffect(() => {
-    // If there is a fromUrl param then it came from the Origin
-    // We can assume this user is likely to be the security contact
-    const fromUrl = new URL(window.location.href).searchParams.get('fromUrl');
-
     if (
-      fromUrl &&
-      user !== undefined &&
-      !namespace?.admin_metadata?.security_contact_user_id
+      user === undefined ||
+      namespace?.admin_metadata?.security_contact_user_id
     ) {
+      return;
+    }
+
+    // The current user is known to be the operator when either:
+    //  - the request came from their Origin/Cache web UI (fromUrl param), or
+    //  - they already own the registration, e.g. right after claiming it via
+    //    the completion link the server logs, which carries no fromUrl
+    const fromUrl = new URL(window.location.href).searchParams.get('fromUrl');
+    const ownsRegistration =
+      namespace !== undefined && userOwnsNamespace(user, namespace);
+
+    if (fromUrl || ownsRegistration) {
+      // Prefer the stable Pelican user ID over the login username so the
+      // contact reference survives identity-provider changes
       onChange(
         'admin_metadata.security_contact_user_id',
-        user?.user,
+        user?.user_id || user?.user,
         setFormNamespace
       );
     }

--- a/web_ui/frontend/app/registry/page.tsx
+++ b/web_ui/frontend/app/registry/page.tsx
@@ -34,6 +34,7 @@ import { getUser } from '@/helpers/login';
 import { Add } from '@mui/icons-material';
 import useSWR from 'swr';
 import { CardProps } from '@/components/Namespace/Card';
+import { userOwnsNamespace } from '@/components/Namespace';
 import { PendingCardProps } from '@/components/Namespace/PendingCard';
 import { IncompleteCardProps } from '@/components/Namespace/IncompleteCard';
 import { AlertDispatchContext } from '@/components/AlertProvider';
@@ -68,16 +69,14 @@ export default function Home() {
     return data?.filter(
       ({ namespace }) =>
         namespace.admin_metadata.status === 'Pending' &&
-        (user?.user == namespace.admin_metadata.user_id ||
-          user?.role == 'admin')
+        (userOwnsNamespace(user, namespace) || user?.role == 'admin')
     );
   }, [data, user]);
   const incompleteData = useMemo(() => {
     return data?.filter(
       ({ namespace }) =>
         namespace.admin_metadata.status === 'Incomplete' &&
-        (user?.user == namespace.admin_metadata.user_id ||
-          user?.role == 'admin')
+        (userOwnsNamespace(user, namespace) || user?.role == 'admin')
     );
   }, [data, user]);
   const approvedOriginData = useMemo(

--- a/web_ui/frontend/app/registry/page.tsx
+++ b/web_ui/frontend/app/registry/page.tsx
@@ -24,6 +24,7 @@ import React, { useContext, useMemo } from 'react';
 import {
   Card,
   CreateNamespaceCard,
+  IncompleteCard,
   NamespaceCardList,
   PendingCard,
 } from '@/components';
@@ -34,6 +35,7 @@ import { Add } from '@mui/icons-material';
 import useSWR from 'swr';
 import { CardProps } from '@/components/Namespace/Card';
 import { PendingCardProps } from '@/components/Namespace/PendingCard';
+import { IncompleteCardProps } from '@/components/Namespace/IncompleteCard';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { alertOnError } from '@/helpers/util';
 import { getExtendedNamespaces } from '@/helpers/get';
@@ -66,6 +68,14 @@ export default function Home() {
     return data?.filter(
       ({ namespace }) =>
         namespace.admin_metadata.status === 'Pending' &&
+        (user?.user == namespace.admin_metadata.user_id ||
+          user?.role == 'admin')
+    );
+  }, [data, user]);
+  const incompleteData = useMemo(() => {
+    return data?.filter(
+      ({ namespace }) =>
+        namespace.admin_metadata.status === 'Incomplete' &&
         (user?.user == namespace.admin_metadata.user_id ||
           user?.role == 'admin')
     );
@@ -133,6 +143,40 @@ export default function Home() {
                 <NamespaceCardList<PendingCardProps>
                   data={pendingData}
                   Card={PendingCard}
+                  cardProps={{
+                    authenticated: user,
+                    onUpdate: () => mutateNamespaces(),
+                  }}
+                />
+              </Paper>
+            </Grid>
+          )}
+
+          {incompleteData && incompleteData.length > 0 && (
+            <Grid size={12} mt={pendingData && pendingData.length > 0 ? 2 : 0}>
+              <Paper
+                sx={{
+                  p: 2,
+                  borderColor: 'warning.main',
+                  borderWidth: '3px',
+                  borderType: 'solid',
+                }}
+                elevation={3}
+              >
+                <Typography variant={'h5'} pb={2}>
+                  Incomplete Registrations
+                </Typography>
+                <Typography variant={'subtitle1'} pb={2}>
+                  {user !== undefined &&
+                    user?.role == 'admin' &&
+                    'Awaiting completion by their creators before they can be reviewed by you.'}
+                  {user !== undefined &&
+                    user?.role != 'admin' &&
+                    'Awaiting completion by their creators.'}
+                </Typography>
+                <NamespaceCardList<IncompleteCardProps>
+                  data={incompleteData}
+                  Card={IncompleteCard}
                   cardProps={{
                     authenticated: user,
                     onUpdate: () => mutateNamespaces(),

--- a/web_ui/frontend/components/Namespace/Card.tsx
+++ b/web_ui/frontend/components/Namespace/Card.tsx
@@ -23,6 +23,7 @@ import ConfirmButton from '@chtc/web-components/ConfirmButton';
 
 import InformationDropdown from './InformationDropdown';
 import NamespaceTitle from '@/components/Namespace/NamespaceTitle';
+import { userOwnsNamespace } from '@/components/Namespace/index';
 import { deleteNamespace, NAMESPACE_KEY } from '@/helpers/api';
 import { useSWRConfig } from 'swr';
 import { AlertDispatchContext } from '@/components/AlertProvider';
@@ -66,24 +67,23 @@ export const Card = ({ namespace, authenticated, onUpdate }: CardProps) => {
           <NamespaceTitle namespace={namespace} />
           <Box display={'flex'} flexDirection={'row'}>
             <Box my={'auto'} display={'flex'}>
-              {authenticated !== undefined &&
-                authenticated.user == namespace.admin_metadata.user_id && (
-                  <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
-                    <Tooltip title={'Created By You'}>
-                      <Avatar
-                        sx={{
-                          my: 'auto',
-                          mr: 2,
-                          ...(size === 'small'
-                            ? { width: 30, height: 30 }
-                            : { width: 40, height: 40 }),
-                        }}
-                      >
-                        <Person fontSize={size} />
-                      </Avatar>
-                    </Tooltip>
-                  </Box>
-                )}
+              {userOwnsNamespace(authenticated, namespace) && (
+                <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
+                  <Tooltip title={'Created By You'}>
+                    <Avatar
+                      sx={{
+                        my: 'auto',
+                        mr: 2,
+                        ...(size === 'small'
+                          ? { width: 30, height: 30 }
+                          : { width: 40, height: 40 }),
+                      }}
+                    >
+                      <Person fontSize={size} />
+                    </Avatar>
+                  </Tooltip>
+                </Box>
+              )}
               <Tooltip title={'Download Public Key'}>
                 <a
                   href={`/api/v1.0/registry_ui/namespaces/${namespace.id}/pubkey`}

--- a/web_ui/frontend/components/Namespace/Card.tsx
+++ b/web_ui/frontend/components/Namespace/Card.tsx
@@ -5,8 +5,15 @@ import React, { useContext, useRef, useState } from 'react';
 import {
   Avatar,
   Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   IconButton,
   Paper,
+  TextField,
   Tooltip,
   Typography,
   useMediaQuery,
@@ -17,6 +24,7 @@ import {
   Download,
   Edit,
   Person,
+  SwapHoriz,
 } from '@mui/icons-material';
 import Link from 'next/link';
 import ConfirmButton from '@chtc/web-components/ConfirmButton';
@@ -24,7 +32,11 @@ import ConfirmButton from '@chtc/web-components/ConfirmButton';
 import InformationDropdown from './InformationDropdown';
 import NamespaceTitle from '@/components/Namespace/NamespaceTitle';
 import { userOwnsNamespace } from '@/components/Namespace/index';
-import { deleteNamespace, NAMESPACE_KEY } from '@/helpers/api';
+import {
+  createRegistrationOwnershipInvite,
+  deleteNamespace,
+  NAMESPACE_KEY,
+} from '@/helpers/api';
 import { useSWRConfig } from 'swr';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { alertOnError } from '@/helpers/util';
@@ -43,7 +55,25 @@ export const Card = ({ namespace, authenticated, onUpdate }: CardProps) => {
 
   const dispatch = useContext(AlertDispatchContext);
   const [transition, setTransition] = useState<boolean>(false);
+  const [transferDialogOpen, setTransferDialogOpen] = useState<boolean>(false);
+  const [transferLink, setTransferLink] = useState<string | undefined>(
+    undefined
+  );
   const { mutate } = useSWRConfig();
+
+  const mintTransferInvite = async () => {
+    const response = await alertOnError(
+      async () => await createRegistrationOwnershipInvite(namespace.id),
+      "Couldn't create ownership transfer invite",
+      dispatch
+    );
+    if (response) {
+      const created = await response.json();
+      setTransferLink(
+        `${window.location.origin}/view/invite/redeem/?token=${encodeURIComponent(created.inviteToken)}`
+      );
+    }
+  };
 
   return (
     <>
@@ -97,6 +127,72 @@ export const Card = ({ namespace, authenticated, onUpdate }: CardProps) => {
                   </IconButton>
                 </a>
               </Tooltip>
+              {(authenticated?.role == 'admin' ||
+                userOwnsNamespace(authenticated, namespace)) && (
+                <>
+                  <Tooltip title={'Transfer Ownership'}>
+                    <IconButton
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        setTransferDialogOpen(true);
+                      }}
+                      size={size}
+                    >
+                      <SwapHoriz fontSize={size} />
+                    </IconButton>
+                  </Tooltip>
+                  <Dialog
+                    open={transferDialogOpen}
+                    onClose={() => {
+                      setTransferDialogOpen(false);
+                      setTransferLink(undefined);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    fullWidth
+                  >
+                    <DialogTitle>Transfer Ownership</DialogTitle>
+                    <DialogContent>
+                      <DialogContentText>
+                        Generate a single-use invite link and send it to the new
+                        owner. Whoever redeems it (after logging in to their own
+                        account) becomes the owner of this registration. The
+                        link expires after 7 days.
+                      </DialogContentText>
+                      {transferLink && (
+                        <TextField
+                          fullWidth
+                          margin={'dense'}
+                          label={'Invite Link'}
+                          value={transferLink}
+                          onFocus={(e) => e.target.select()}
+                          slotProps={{ input: { readOnly: true } }}
+                          helperText={
+                            'Copy this link now; it is shown only once.'
+                          }
+                        />
+                      )}
+                    </DialogContent>
+                    <DialogActions>
+                      <Button
+                        onClick={() => {
+                          setTransferDialogOpen(false);
+                          setTransferLink(undefined);
+                        }}
+                      >
+                        Close
+                      </Button>
+                      {!transferLink && (
+                        <Button
+                          variant={'contained'}
+                          onClick={mintTransferInvite}
+                        >
+                          Generate Link
+                        </Button>
+                      )}
+                    </DialogActions>
+                  </Dialog>
+                </>
+              )}
               {authenticated?.role == 'admin' && (
                 <>
                   <Tooltip title={'Edit Registration'}>

--- a/web_ui/frontend/components/Namespace/DeniedCard.tsx
+++ b/web_ui/frontend/components/Namespace/DeniedCard.tsx
@@ -4,7 +4,7 @@ import { Avatar, Box, IconButton, Tooltip, Typography } from '@mui/material';
 import { Check, Delete, Person } from '@mui/icons-material';
 import { Alert, RegistryNamespace, User } from '@/index';
 import InformationDropdown from './InformationDropdown';
-import { NamespaceIcon } from '@/components/Namespace/index';
+import { NamespaceIcon, userOwnsNamespace } from '@/components/Namespace/index';
 import { AlertContext, AlertDispatchContext } from '@/components/AlertProvider';
 import { useSWRConfig } from 'swr';
 import {
@@ -58,23 +58,22 @@ export const DeniedCard = ({ namespace, authenticated }: DeniedCardProps) => {
           <NamespaceTitle namespace={namespace} />
           <Box display={'flex'}>
             <Box my={'auto'} display={'flex'} flexDirection={'row'}>
-              {authenticated !== undefined &&
-                authenticated.user == namespace.admin_metadata.user_id && (
-                  <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
-                    <Tooltip title={'Created By You'}>
-                      <Avatar
-                        sx={{
-                          height: '40px',
-                          width: '40px',
-                          my: 'auto',
-                          mr: 2,
-                        }}
-                      >
-                        <Person />
-                      </Avatar>
-                    </Tooltip>
-                  </Box>
-                )}
+              {userOwnsNamespace(authenticated, namespace) && (
+                <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
+                  <Tooltip title={'Created By You'}>
+                    <Avatar
+                      sx={{
+                        height: '40px',
+                        width: '40px',
+                        my: 'auto',
+                        mr: 2,
+                      }}
+                    >
+                      <Person />
+                    </Avatar>
+                  </Tooltip>
+                </Box>
+              )}
               {authenticated?.role == 'admin' && (
                 <>
                   <Tooltip title={'Delete Registration'}>

--- a/web_ui/frontend/components/Namespace/DeniedCard.tsx
+++ b/web_ui/frontend/components/Namespace/DeniedCard.tsx
@@ -1,7 +1,8 @@
 import React, { useContext, useRef, useState } from 'react';
 import { green, red } from '@mui/material/colors';
 import { Avatar, Box, IconButton, Tooltip, Typography } from '@mui/material';
-import { Check, Delete, Person } from '@mui/icons-material';
+import { Check, Delete, Edit, Person } from '@mui/icons-material';
+import Link from 'next/link';
 import { Alert, RegistryNamespace, User } from '@/index';
 import InformationDropdown from './InformationDropdown';
 import { NamespaceIcon, userOwnsNamespace } from '@/components/Namespace/index';
@@ -113,6 +114,20 @@ export const DeniedCard = ({ namespace, authenticated }: DeniedCardProps) => {
                     </IconButton>
                   </Tooltip>
                 </>
+              )}
+              {(authenticated?.role == 'admin' ||
+                userOwnsNamespace(authenticated, namespace)) && (
+                <Tooltip title={'Edit and Resubmit Registration'}>
+                  <Link
+                    href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}
+                  >
+                    <IconButton
+                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                    >
+                      <Edit />
+                    </IconButton>
+                  </Link>
+                </Tooltip>
               )}
             </Box>
           </Box>

--- a/web_ui/frontend/components/Namespace/IncompleteCard.tsx
+++ b/web_ui/frontend/components/Namespace/IncompleteCard.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 
 import { Alert, RegistryNamespace, User } from '@/index';
 import InformationDropdown from './InformationDropdown';
+import { userOwnsNamespace } from '@/components/Namespace/index';
 import { alertOnError } from '@/helpers/util';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { denyNamespace } from '@/helpers/api';
@@ -54,24 +55,23 @@ export const IncompleteCard = ({
         <NamespaceTitle namespace={namespace} />
         <Box display={'flex'}>
           <Box my={'auto'} display={'flex'} flexDirection={'row'}>
-            {authenticated !== undefined &&
-              authenticated.user == namespace.admin_metadata.user_id && (
-                <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
-                  <Tooltip title={'Created By You'}>
-                    <Avatar
-                      sx={{
-                        my: 'auto',
-                        mr: 2,
-                        ...(size === 'small'
-                          ? { width: 30, height: 30 }
-                          : { width: 40, height: 40 }),
-                      }}
-                    >
-                      <Person fontSize={size} />
-                    </Avatar>
-                  </Tooltip>
-                </Box>
-              )}
+            {userOwnsNamespace(authenticated, namespace) && (
+              <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
+                <Tooltip title={'Created By You'}>
+                  <Avatar
+                    sx={{
+                      my: 'auto',
+                      mr: 2,
+                      ...(size === 'small'
+                        ? { width: 30, height: 30 }
+                        : { width: 40, height: 40 }),
+                    }}
+                  >
+                    <Person fontSize={size} />
+                  </Avatar>
+                </Tooltip>
+              </Box>
+            )}
             {authenticated?.role == 'admin' && (
               <Tooltip title={'Deny Registration'}>
                 <IconButton
@@ -93,7 +93,7 @@ export const IncompleteCard = ({
               </Tooltip>
             )}
             {(authenticated?.role == 'admin' ||
-              authenticated?.user == namespace.admin_metadata.user_id) && (
+              userOwnsNamespace(authenticated, namespace)) && (
               <Tooltip title={'Complete Registration'}>
                 <Link
                   href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}

--- a/web_ui/frontend/components/Namespace/IncompleteCard.tsx
+++ b/web_ui/frontend/components/Namespace/IncompleteCard.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import React, { useContext, useState } from 'react';
+import { Avatar, Box, IconButton, Tooltip, useMediaQuery } from '@mui/material';
+import { Block, Edit, Person } from '@mui/icons-material';
+import Link from 'next/link';
+
+import { Alert, RegistryNamespace, User } from '@/index';
+import InformationDropdown from './InformationDropdown';
+import { alertOnError } from '@/helpers/util';
+import { AlertDispatchContext } from '@/components/AlertProvider';
+import { denyNamespace } from '@/helpers/api';
+import { Theme } from '@mui/system';
+import NamespaceTitle from '@/components/Namespace/NamespaceTitle';
+
+export interface IncompleteCardProps {
+  namespace: RegistryNamespace;
+  onUpdate: () => void;
+  onAlert: (alert: Alert) => void;
+  authenticated?: User;
+}
+
+export const IncompleteCard = ({
+  namespace,
+  onUpdate,
+  authenticated,
+}: IncompleteCardProps) => {
+  const size = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'))
+    ? 'small'
+    : 'medium';
+
+  const [transition, setTransition] = useState<boolean>(false);
+
+  const dispatch = useContext(AlertDispatchContext);
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          cursor: 'pointer',
+          display: 'flex',
+          width: '100%',
+          justifyContent: 'space-between',
+          border: 'solid #ececec 1px',
+          borderRadius: transition ? '10px 10px 0px 0px' : 2,
+          '&:hover': {
+            bgcolor: '#ececec',
+          },
+          p: 1,
+        }}
+        bgcolor={'secondary'}
+        onClick={() => setTransition(!transition)}
+      >
+        <NamespaceTitle namespace={namespace} />
+        <Box display={'flex'}>
+          <Box my={'auto'} display={'flex'} flexDirection={'row'}>
+            {authenticated !== undefined &&
+              authenticated.user == namespace.admin_metadata.user_id && (
+                <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
+                  <Tooltip title={'Created By You'}>
+                    <Avatar
+                      sx={{
+                        my: 'auto',
+                        mr: 2,
+                        ...(size === 'small'
+                          ? { width: 30, height: 30 }
+                          : { width: 40, height: 40 }),
+                      }}
+                    >
+                      <Person fontSize={size} />
+                    </Avatar>
+                  </Tooltip>
+                </Box>
+              )}
+            {authenticated?.role == 'admin' && (
+              <Tooltip title={'Deny Registration'}>
+                <IconButton
+                  sx={{ bgcolor: '#ff00001a', mx: 1 }}
+                  size={size}
+                  color={'error'}
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    await alertOnError(
+                      () => denyNamespace(namespace.id),
+                      "Couldn't deny namespace",
+                      dispatch
+                    );
+                    onUpdate();
+                  }}
+                >
+                  <Block fontSize={size} />
+                </IconButton>
+              </Tooltip>
+            )}
+            {(authenticated?.role == 'admin' ||
+              authenticated?.user == namespace.admin_metadata.user_id) && (
+              <Tooltip title={'Complete Registration'}>
+                <Link
+                  href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}
+                >
+                  <IconButton
+                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                    size={size}
+                  >
+                    <Edit fontSize={size} />
+                  </IconButton>
+                </Link>
+              </Tooltip>
+            )}
+          </Box>
+        </Box>
+      </Box>
+      <Box>
+        <InformationDropdown
+          adminMetadata={namespace.admin_metadata}
+          transition={transition}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default IncompleteCard;

--- a/web_ui/frontend/components/Namespace/InformationDropdown.tsx
+++ b/web_ui/frontend/components/Namespace/InformationDropdown.tsx
@@ -5,6 +5,7 @@ import {
   InformationSpan,
   NamespaceAdminMetadata,
 } from '@/components';
+import { getStatusDisplayName } from '@/components/Namespace';
 
 interface InformationDropdownProps {
   adminMetadata: NamespaceAdminMetadata;
@@ -29,7 +30,7 @@ const InformationDropdown = ({
       name: 'Security Contact User ID',
       value: adminMetadata.security_contact_user_id,
     },
-    { name: 'Status', value: adminMetadata.status },
+    { name: 'Status', value: getStatusDisplayName(adminMetadata.status) },
     { name: 'Approver ID', value: adminMetadata.approver_id.toString() },
     { name: 'Approved At', value: approvedAt },
     {

--- a/web_ui/frontend/components/Namespace/PendingCard.tsx
+++ b/web_ui/frontend/components/Namespace/PendingCard.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link';
 
 import { Alert, RegistryNamespace, User } from '@/index';
 import InformationDropdown from './InformationDropdown';
-import { NamespaceIcon } from '@/components/Namespace/index';
+import { NamespaceIcon, userOwnsNamespace } from '@/components/Namespace/index';
 import { alertOnError } from '@/helpers/util';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { approveNamespace, denyNamespace } from '@/helpers/api';
@@ -63,24 +63,23 @@ export const PendingCard = ({
         <NamespaceTitle namespace={namespace} />
         <Box display={'flex'}>
           <Box my={'auto'} display={'flex'} flexDirection={'row'}>
-            {authenticated !== undefined &&
-              authenticated.user == namespace.admin_metadata.user_id && (
-                <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
-                  <Tooltip title={'Created By You'}>
-                    <Avatar
-                      sx={{
-                        my: 'auto',
-                        mr: 2,
-                        ...(size === 'small'
-                          ? { width: 30, height: 30 }
-                          : { width: 40, height: 40 }),
-                      }}
-                    >
-                      <Person fontSize={size} />
-                    </Avatar>
-                  </Tooltip>
-                </Box>
-              )}
+            {userOwnsNamespace(authenticated, namespace) && (
+              <Box sx={{ borderRight: 'solid 1px #ececec', mr: 1 }}>
+                <Tooltip title={'Created By You'}>
+                  <Avatar
+                    sx={{
+                      my: 'auto',
+                      mr: 2,
+                      ...(size === 'small'
+                        ? { width: 30, height: 30 }
+                        : { width: 40, height: 40 }),
+                    }}
+                  >
+                    <Person fontSize={size} />
+                  </Avatar>
+                </Tooltip>
+              </Box>
+            )}
             {authenticated?.role == 'admin' && (
               <>
                 <Tooltip title={'Deny Registration'}>
@@ -122,7 +121,7 @@ export const PendingCard = ({
               </>
             )}
             {(authenticated?.role == 'admin' ||
-              authenticated?.user == namespace.admin_metadata.user_id) && (
+              userOwnsNamespace(authenticated, namespace)) && (
               <Tooltip title={'Edit Registration'}>
                 <Link
                   href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}

--- a/web_ui/frontend/components/Namespace/index.tsx
+++ b/web_ui/frontend/components/Namespace/index.tsx
@@ -3,6 +3,7 @@ import Card, { CardProps } from './Card';
 import CreateNamespaceCard from './CreateNamespaceCard';
 import CardSkeleton from './CardSkeleton';
 import PendingCard, { PendingCardProps } from './PendingCard';
+import IncompleteCard from './IncompleteCard';
 import NamespaceCardList from './NamespaceCardList';
 import NamespaceIcon from './NamespaceIcon';
 
@@ -12,7 +13,25 @@ export {
   CreateNamespaceCard,
   CardSkeleton,
   PendingCard,
+  IncompleteCard,
   NamespaceIcon,
+};
+
+export type RegistrationStatus =
+  | 'Incomplete'
+  | 'Pending'
+  | 'Approved'
+  | 'Denied'
+  | 'Unknown';
+
+// Human-facing labels for registration statuses
+export const getStatusDisplayName = (status: RegistrationStatus): string => {
+  switch (status) {
+    case 'Pending':
+      return 'Pending (Ready to review)';
+    default:
+      return status;
+  }
 };
 
 export interface NamespaceAdminMetadata {
@@ -21,7 +40,7 @@ export interface NamespaceAdminMetadata {
   site_name: string;
   institution: string;
   security_contact_user_id: string;
-  status: 'Pending' | 'Approved' | 'Denied' | 'Unknown';
+  status: RegistrationStatus;
   approver_id: number;
   approved_at: string;
   created_at: string;

--- a/web_ui/frontend/components/Namespace/index.tsx
+++ b/web_ui/frontend/components/Namespace/index.tsx
@@ -1,4 +1,4 @@
-import { RegistryNamespace } from '@/index';
+import { RegistryNamespace, User } from '@/index';
 import Card, { CardProps } from './Card';
 import CreateNamespaceCard from './CreateNamespaceCard';
 import CardSkeleton from './CardSkeleton';
@@ -46,6 +46,19 @@ export interface NamespaceAdminMetadata {
   created_at: string;
   updated_at: string;
 }
+
+// Owners are recorded by the stable Pelican user ID only; legacy owner
+// strings (e.g. CILogon subs) never match until transferred.
+export const userOwnsNamespace = (
+  user: User | undefined,
+  namespace: RegistryNamespace
+): boolean => {
+  const owner = namespace.admin_metadata.user_id;
+  if (user === undefined || !owner) {
+    return false;
+  }
+  return user.user_id === owner;
+};
 
 export interface FlatObject {
   [key: string]: Exclude<any, object>;

--- a/web_ui/frontend/helpers/api/Invite/service.ts
+++ b/web_ui/frontend/helpers/api/Invite/service.ts
@@ -8,7 +8,11 @@ import { fetchApi } from '@/helpers/api';
 // require the caller to be authenticated (we need a user to add to the
 // group), password invites do not (the token IS the credential).
 
-export type InviteKind = 'group' | 'password' | 'collection_ownership';
+export type InviteKind =
+  | 'group'
+  | 'password'
+  | 'collection_ownership'
+  | 'registration_ownership';
 
 export interface InviteInfo {
   kind: InviteKind;
@@ -27,6 +31,13 @@ export interface InviteInfo {
   collectionId?: string;
   collectionName?: string;
   collectionNamespace?: string;
+  /** ID + prefix + site name for registration-ownership invites — drive
+   * the "Accept ownership of <prefix>?" confirmation page. The prefix is
+   * what the recipient is actually claiming authority over, so it MUST
+   * be visible at confirm time. */
+  registrationId?: number;
+  registrationPrefix?: string;
+  registrationSiteName?: string;
 }
 
 export interface InviteLinkBase {
@@ -77,6 +88,23 @@ const InviteService = {
           body: JSON.stringify({ token }),
           headers: { 'Content-Type': 'application/json' },
         })
+    );
+  },
+
+  // Registration-ownership redeem. Caller must be authenticated; the
+  // invite makes the calling user the owner of the linked registry
+  // registration.
+  redeemRegistrationOwnership: async (token: string): Promise<void> => {
+    await fetchApi(
+      async () =>
+        await secureFetch(
+          `${API_V1_BASE_URL}/invites/redeem/registration-ownership`,
+          {
+            method: 'POST',
+            body: JSON.stringify({ token }),
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
     );
   },
 

--- a/web_ui/frontend/helpers/api/index.ts
+++ b/web_ui/frontend/helpers/api/index.ts
@@ -269,6 +269,30 @@ export const claimNamespace = async (
   );
 };
 
+/**
+ * Mints a single-use ownership-transfer invite for a namespace
+ * registration; the redeemer becomes the new owner. Owner/admin only.
+ * @param id Namespace ID
+ * @param expiresIn Optional Go duration string (e.g. "168h"); server
+ *   defaults to 7 days
+ */
+export const createRegistrationOwnershipInvite = async (
+  id: number,
+  expiresIn?: string
+): Promise<Response> => {
+  return await fetchApi(
+    async () =>
+      await secureFetch(
+        `${API_V1_BASE_URL}/registry_ui/namespaces/${id}/ownership-invites`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ expiresIn: expiresIn ?? '' }),
+        }
+      )
+  );
+};
+
 export const postGeneralNamespace = async (
   data: RegistryNamespace
 ): Promise<Response> => {

--- a/web_ui/frontend/helpers/api/index.ts
+++ b/web_ui/frontend/helpers/api/index.ts
@@ -249,6 +249,26 @@ export const getNamespace = async (
   return await fetchApi(async () => await fetch(url));
 };
 
+/**
+ * Claims an unowned namespace registration for the logged-in user
+ * @param id Namespace ID
+ * @param accessToken Access token minted by the registered server, proving
+ *   the caller operates it
+ */
+export const claimNamespace = async (
+  id: string | number,
+  accessToken: string
+): Promise<Response> => {
+  const url = new URL(
+    `${API_V1_BASE_URL}/registry_ui/namespaces/${id}/claim`,
+    window.location.origin
+  );
+  url.searchParams.append('access_token', accessToken);
+  return await fetchApi(
+    async () => await secureFetch(url.toString(), { method: 'POST' })
+  );
+};
+
 export const postGeneralNamespace = async (
   data: RegistryNamespace
 ): Promise<Response> => {

--- a/web_ui/frontend/helpers/login.ts
+++ b/web_ui/frontend/helpers/login.ts
@@ -101,6 +101,8 @@ export const getUser = async (): Promise<User> => {
     const user = {
       authenticated: json['authenticated'],
       user: json['user'] == '' ? null : json['user'],
+      // Stable Pelican user ID; used alongside `user` for ownership checks
+      user_id: json['user_id'] || undefined,
       role: json['role'] == '' ? null : json['role'],
       // Optional human label from the User row. Always-mounted UI
       // (e.g. the navbar's user menu) prefers this over `user`.

--- a/web_ui/frontend/index.ts
+++ b/web_ui/frontend/index.ts
@@ -5,6 +5,10 @@ export interface User {
   authenticated: boolean;
   role?: 'admin' | 'user' | 'guest';
   user?: string;
+  // user_id is the stable Pelican user ID from the user database,
+  // surfaced by /whoami. Records like registry registrations reference
+  // their owner by this ID (claim flow) in ownership checks.
+  user_id?: string;
   // displayName is the human label from the User row, surfaced by
   // /whoami so the navbar / other always-mounted UI can render it
   // without a separate /me round-trip. Empty when the row has no

--- a/web_ui/groups.go
+++ b/web_ui/groups.go
@@ -1709,6 +1709,67 @@ func handleRedeemCollectionOwnershipInvite(ctx *gin.Context) {
 	})
 }
 
+// handleRedeemRegistrationOwnershipInvite consumes a single-use
+// ownership-transfer invite for a registry registration, recording the
+// authenticated caller's Pelican User.ID as the registration's owner.
+// Single-use is enforced inside the DB helper; the caller MUST be
+// authenticated — anonymous redemption would let link-holders make
+// ANYBODY the owner; we record the caller's User.ID specifically so
+// the registration names a real account.
+func handleRedeemRegistrationOwnershipInvite(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+	var req RedeemInviteLinkReq
+	if err := ctx.ShouldBindJSON(&req); err != nil || req.Token == "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "invite token is required",
+		})
+		return
+	}
+	_, userId, _, err := GetUserGroups(ctx)
+	if err != nil || userId == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to identify user",
+		})
+		return
+	}
+	registrationID, prefix, err := database.RedeemRegistrationOwnershipInviteLink(database.ServerDatabase, req.Token, userId)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "invite link not found",
+			})
+		} else {
+			log.Warningf("Failed to redeem registration ownership invite link: %v", err)
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Failed to redeem invite link",
+			})
+		}
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{
+		"status":             server_structs.RespOK,
+		"message":            "Registration ownership transferred to you.",
+		"registrationId":     registrationID,
+		"registrationPrefix": prefix,
+	})
+}
+
 // --- User Status / AUP Handlers ---
 
 func handleUpdateUserStatus(ctx *gin.Context) {

--- a/web_ui/password_invite.go
+++ b/web_ui/password_invite.go
@@ -193,6 +193,13 @@ type inviteInfoResp struct {
 	CollectionID        string `json:"collectionId,omitempty"`
 	CollectionName      string `json:"collectionName,omitempty"`
 	CollectionNamespace string `json:"collectionNamespace,omitempty"`
+	// RegistrationID + RegistrationPrefix + RegistrationSiteName are
+	// populated when Kind == InviteKindRegistrationOwnership. The prefix
+	// is the load-bearing detail: it is what the redeemer is actually
+	// accepting ownership of, so always render it on the confirm page.
+	RegistrationID       int    `json:"registrationId,omitempty"`
+	RegistrationPrefix   string `json:"registrationPrefix,omitempty"`
+	RegistrationSiteName string `json:"registrationSiteName,omitempty"`
 }
 
 // handleGetInviteInfo lets the redemption UI peek at a token *without*
@@ -253,6 +260,17 @@ func handleGetInviteInfo(ctx *gin.Context) {
 			resp.CollectionID = coll.ID
 			resp.CollectionName = coll.Name
 			resp.CollectionNamespace = coll.Namespace
+		}
+	}
+	if link.Kind == database.InviteKindRegistrationOwnership && link.RegistrationID != 0 {
+		// Resolve the registration's prefix + site name so the confirm
+		// page can say what the redeemer is about to own. Errors are
+		// non-fatal — the page still renders, just less helpfully.
+		var reg server_structs.Registration
+		if err := database.ServerDatabase.Select("id", "prefix", "admin_metadata").Where("id = ?", link.RegistrationID).First(&reg).Error; err == nil {
+			resp.RegistrationID = reg.ID
+			resp.RegistrationPrefix = reg.Prefix
+			resp.RegistrationSiteName = reg.AdminMetadata.SiteName
 		}
 	}
 	ctx.JSON(http.StatusOK, resp)

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -763,6 +763,8 @@ func registerCommonEndpoints(routerGroup *gin.RouterGroup) error {
 	// doesn't grant management-policy authority — those gates run on
 	// the API surface itself, not on the act of being an owner).
 	routerGroup.POST("/invites/redeem/collection-ownership", AuthHandler, handleRedeemCollectionOwnershipInvite)
+	// Same posture for registry-registration ownership transfers.
+	routerGroup.POST("/invites/redeem/registration-ownership", AuthHandler, handleRedeemRegistrationOwnershipInvite)
 	// Public-info probe so the redemption UI can render the right form
 	// without consuming the link.
 	routerGroup.GET("/invites/info", handleGetInviteInfo)


### PR DESCRIPTION
Closes #3677

<img width="1500" height="639" alt="image" src="https://github.com/user-attachments/assets/9899bd0d-45a8-491e-8253-c90a4ca5779f" />

This PR comes with the docs change, see `docs/app/federating-your-data/registration/page.mdx`.

## What changes for admins

Today an origin or cache auto-registers as `Pending` with no owner, and the registrant can only find it by hunting through the registry UI. With this branch:

1. Auto-registrations start as `Incomplete` (key material + site name only).
2. The service **logs a completion link** (and writes it to `Server.RegistrationCompletionLinkFile`) every 10 min while incomplete; the link carries a 15-min token signed with the service's own key. If a server admin doesn't bind their account to their Pelican user yet, this will pop up FOREVER.
3. Opening the link, after login, shows a **claim page**; accepting records the logged-in **Pelican user ID** as the owner and drops the user into the registration form. A complete form moves the row to `Pending`.
4. Owners can **transfer ownership** with a single-use, 7-day invite link, and can **edit and resubmit** a `Denied` registration back into the queue.
5. **[For Registry admin]** Legacy rows still owned by a raw CILogon `sub` are **replaced** by the matching Pelican user ID at registry start (see this gated [Google Doc](https://docs.google.com/document/d/1vrUL4Sj0PP5jcm_yY7gGsUgxeUuTvTLInP8qU7BETdQ/edit?usp=sharing)).

Approval stays the trust boundary: the Director only serves approved registrations, and approved rows can only be changed by an admin.


