### PR TITLE
Logging metadata http handler

### DIFF
--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pelicanplatform/pelican/daemon"
 	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/launcher_utils"
+	"github.com/pelicanplatform/pelican/log_exports"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/oa4mp"
 	issuer "github.com/pelicanplatform/pelican/oauth2/issuer"
@@ -357,6 +358,29 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 		// routes would exist but be reachable by no one.
 		origin_serve.RegisterStorageAPI(engine.Group("/api/v1.0"),
 			web_ui.AuthHandler, web_ui.AdminAuthHandler)
+
+		// HTTP access to this origin's own logs, under /pelican/logging.
+		//
+		// Registers nothing unless the admin opted in, so an origin that has
+		// not enabled log export simply has no such route.
+		//
+		// No AuthHandler/AdminAuthHandler pair here, unlike the storage API
+		// above: callers are federation clients presenting a token scoped to
+		// the logging namespace, not web-UI administrators, and the token may
+		// arrive as a query parameter because the Director's redirect drops
+		// the Authorization header.  The handler verifies it itself.
+		//
+		// The middleware choices are this launcher's: log_exports serves any
+		// server type, so the origin's HTTP transfer metrics -- whose labels
+		// are origin-specific -- are attached here, where the server type is
+		// known.  A cache launcher must supply its own equivalent.
+		//
+		// Mounted inside this branch, so it follows the POSIXv2 origin and an
+		// XRootD origin never gets the route.
+		if err := log_exports.RegisterLoggingExportAPI(ctx, engine, server_structs.OriginType,
+			web_ui.ServerHeaderMiddleware, origin_serve.HttpMetricsMiddleware()); err != nil {
+			return errors.Wrap(err, "failed to register the logging namespace handler")
+		}
 
 		// For POSIXv2, the origin serves files directly via the web server, not XRootD.
 		// Update Origin.Url to use the external web URL which is now set to the correct port.

--- a/log_exports/logging_api.go
+++ b/log_exports/logging_api.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /***************************************************************
  *
  * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
@@ -279,7 +281,8 @@ func checkLoggingPrefixCollision() error {
 		// report; whatever asked for them will have surfaced it already.
 		// Skipping the guard is safe for the same reason: if the exports could
 		// not be loaded here, the WebDAV handlers could not have mounted their
-		// catch-alls from them either, so there is nothing to collide with.
+		// catch-all routes from them either, so there is nothing to collide
+		// with.
 		return nil
 	}
 	for _, export := range exports {

--- a/log_exports/logging_api.go
+++ b/log_exports/logging_api.go
@@ -1,0 +1,635 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// The logging namespace: HTTP access to this server's own logs.
+//
+// A server that opts in registers /pelican/logging/{sitename} and serves log
+// entries under it as virtual objects -- time windows assembled on demand
+// rather than files on disk.  That makes logs reachable with the same client,
+// the same tokens, and the same authorization model as data, instead of
+// requiring shell access to the host.
+//
+// This is not WebDAV.  There is no directory tree to walk: the log is one
+// rolling file, and the paths beneath the namespace are a naming scheme for
+// slices of it.  A single catch-all route with its own parser fits that, and
+// leaves room to name slices differently later (by job UUID, say) without
+// touching the routing table.
+//
+// Enabling this makes the log file readable by anyone the namespace's tokens
+// authorize.  Whatever the server writes to its log, it now hands out; that is
+// a property of the feature rather than a flaw in it, but it means log hygiene
+// becomes an access-control concern for anyone who turns this on.
+
+package log_exports
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// loggingNamespaceRoot is the federation prefix all logging namespaces live
+// under.  It is deliberately not configurable: clients, the Registry's
+// auto-approval rules, and the Director's routing all have to agree on it.
+const loggingNamespaceRoot = "/pelican/logging"
+
+// logWindowDuration is the width of one addressable window.
+const logWindowDuration = time.Hour
+
+// logSettleMargin is how long after an hour ends before that hour is served.
+//
+// A closed hour is not the same as a complete one.  The async writer holds
+// entries until a size threshold or Logging.Rotation.FlushInterval (50ms by
+// default) pushes them out, so at the instant an hour ends some of its last
+// entries are still in memory.  Serving the hour then would hand out a copy
+// missing its tail -- and, because a closed window is advertised as immutable,
+// a cache would keep that truncated copy for good: Cache-Control governs
+// whether a response is stored, not whether a stored one is discarded.
+//
+// Waiting is the whole fix.  Five minutes is enormous next to a 50ms flush and
+// costs only freshness, which this endpoint is not the tool for anyway --
+// recent lines are what the in-memory buffer behind /api/v1.0/logs/tail is
+// for.
+const logSettleMargin = 5 * time.Minute
+
+// maxConcurrentLogReads bounds how many log queries run at once.
+//
+// Each one can walk a large file, so this is the difference between a slow
+// endpoint and a server that stops serving data because something is
+// polling its logs.  Full rate limiting belongs to infrastructure these
+// servers do not have yet; until then a small semaphore is the honest tool.
+const maxConcurrentLogReads = 4
+
+// immutableCacheMaxAge is how long a closed, fully-covered window may be
+// cached.  A closed hour never changes, so this only needs to be long enough
+// to be worth having.
+const immutableCacheMaxAge = 24 * time.Hour
+
+// Sentinel errors from parseLogSelector.
+//
+// These are distinguishable on purpose.  "I do not recognise this kind of
+// request" and "this is the kind of request I know, spelled wrongly" are
+// different answers, and keeping them apart is what lets a future selector
+// kind be added without the error text for today's typos changing meaning.
+var (
+	errUnknownSelectorKind = errors.New("unrecognized logging object path")
+	errMalformedWindow     = errors.New("malformed time window in logging object path")
+)
+
+// loggingHandler holds everything a request needs, resolved once at startup.
+type loggingHandler struct {
+	// sitename is this server's own name, as it appears in the namespace.
+	sitename string
+
+	// scope is the resource scope a caller's token must cover.
+	scope token_scopes.ResourceScope
+
+	source logSource
+
+	// now is injected so that the settle-margin refusal and cache-directive
+	// selection are testable without depending on the wall clock.
+	now func() time.Time
+
+	// sem bounds concurrent reads.  Buffered channel rather than a
+	// semaphore type to match how the rest of the codebase does this.
+	sem chan struct{}
+
+	// authorize decides whether a request may read these logs, writing its own
+	// refusal when the answer is no.  It is a field rather than a method call
+	// so that tests can exercise everything around it -- path parsing, cache
+	// directives, streaming -- without standing up an issuer and minting
+	// tokens for each case.
+	authorize func(*gin.Context) bool
+}
+
+// LoggingNamespaceForSitename returns the federation prefix a server's logs
+// are published under.
+func LoggingNamespaceForSitename(sitename string) string {
+	return path.Join(loggingNamespaceRoot, sitename)
+}
+
+// RegisterLoggingExportAPI mounts the logging namespace routes, if this server
+// is configured to export its logs.
+//
+// Registering nothing when the feature is off is deliberate: a server that
+// has not opted in should answer 404, which tells an operator plainly that
+// this server has no such interface, rather than mounting a route whose only
+// possible answer is a refusal.
+//
+// Middleware is variadic and supplied by the caller: this package serves any
+// server type, so anything server-specific -- the web layer's standard
+// headers, a server type's HTTP metrics accounting -- is the launcher's to
+// choose and thread in, which also keeps this package from importing the web
+// layer.  Note that authorization is NOT among them -- it happens inside the
+// handler, because the check is against this namespace's scope and the token
+// may arrive as a query parameter rather than a header.
+func RegisterLoggingExportAPI(ctx context.Context, engine *gin.Engine, serverType server_structs.ServerType, middleware ...gin.HandlerFunc) error {
+	if !param.Logging_LogExports_Enabled.GetBool() {
+		return nil
+	}
+
+	metadata, err := server_utils.GetServerMetadata(ctx, serverType)
+	if err != nil {
+		return errors.Wrapf(err, "unable to determine this server's name, which %s requires",
+			param.Logging_LogExports_Enabled.GetName())
+	}
+
+	return registerLoggingExportFor(engine, metadata.Name, middleware...)
+}
+
+// registerLoggingExportFor does the work of RegisterLoggingExportAPI once the
+// server's own name is known.
+//
+// Split at the name lookup because that is the one step needing a registry:
+// everything after it -- name validation, the route collision guard,
+// mounting -- is decidable from local state, and is where a mistake actually
+// costs something.  Keeping it reachable without a federation means it can be
+// tested.
+func registerLoggingExportFor(engine *gin.Engine, sitename string, middleware ...gin.HandlerFunc) error {
+
+	// The sitename becomes a URL path segment, the value compared against the
+	// decoded :sitename parameter, and part of a token scope.  Nothing else in
+	// Pelican constrains it -- Xrootd.Sitename is documented as human-readable
+	// and flows into registry prefixes verbatim -- so a name that cannot
+	// survive that round trip has to be caught here.  Refusing at startup is
+	// kinder than mounting a route nobody can address.
+	if err := validateSitenameForURL(sitename); err != nil {
+		return errors.Wrapf(err, "cannot export logs for server name %q", sitename)
+	}
+
+	// The WebDAV handlers mount a catch-all at each export's federation
+	// prefix.  An export at /pelican or above would own this route's subtree,
+	// and registering a static child under an existing catch-all panics Gin as
+	// the server comes up.  A federation prefix of / is already refused during
+	// configuration for the same reason; this covers the narrower collision.
+	if err := checkLoggingPrefixCollision(); err != nil {
+		return err
+	}
+
+	handler := &loggingHandler{
+		sitename: sitename,
+		scope: token_scopes.NewResourceScope(
+			token_scopes.Wlcg_Storage_Read, LoggingNamespaceForSitename(sitename)),
+		source: &activeFileSource{path: param.Logging_LogLocation.GetString()},
+		now:    time.Now,
+		sem:    make(chan struct{}, maxConcurrentLogReads),
+	}
+	handler.authorize = handler.verifyToken
+
+	registerLoggingRoutes(engine, handler, middleware...)
+
+	log.Infof("Exporting this server's logs at %s", LoggingNamespaceForSitename(sitename))
+	return nil
+}
+
+// registerLoggingRoutes mounts the routes for an already-built handler.
+//
+// Split out from RegisterLoggingExportAPI so tests can supply a sitename and a
+// log source directly, without a registry to ask or a real log file to read.
+func registerLoggingRoutes(engine *gin.Engine, handler *loggingHandler, middleware ...gin.HandlerFunc) {
+	group := engine.Group(loggingNamespaceRoot+"/:sitename", middleware...)
+
+	// HEAD is not a courtesy here.  The Director stats a server before
+	// redirecting to it (Director.CheckOriginPresence and
+	// Director.CheckCachePresence, both on by default), and it stats with
+	// HEAD.  Without this route that stat draws a 405, the server looks
+	// absent, and it is dropped from routing entirely.
+	group.GET("/*object", handler.serve)
+	group.HEAD("/*object", handler.serve)
+}
+
+// validateSitenameForURL rejects names that cannot be used as a single path
+// segment.
+func validateSitenameForURL(sitename string) error {
+	if sitename == "" {
+		return errors.New("server name is empty")
+	}
+	// A name that changes when it makes the round trip through a URL cannot be
+	// compared against the value arriving in a request.
+	if url.PathEscape(sitename) != sitename {
+		return errors.Errorf("server name is not usable as a URL path segment; "+
+			"set %s to a name made up of unreserved URL characters",
+			param.Xrootd_Sitename.GetName())
+	}
+	// PathEscape leaves these alone, but each would change how the path parses.
+	if strings.ContainsAny(sitename, "/?#") || sitename == "." || sitename == ".." {
+		return errors.Errorf("server name may not contain '/', '?' or '#', or be '.' or '..'; "+
+			"set %s to a simple name", param.Xrootd_Sitename.GetName())
+	}
+	return nil
+}
+
+// prefixShadowsLoggingRoute reports whether mounting the logging routes
+// alongside a WebDAV export at federationPrefix would panic Gin as the server
+// comes up.
+//
+// An export mounts a catch-all at its own prefix.  Gin refuses to register a
+// route that descends *through* an existing catch-all, so the collision is
+// exactly the case where the export sits at or above /pelican/logging -- its
+// catch-all then owns the path this route needs to reach.
+//
+// An export at or below /pelican/logging/<something> does not collide: a
+// static segment and a :param segment coexist happily at the same level, so
+// only the ancestor case is a problem.  Rejecting more than this would refuse
+// configurations that work.
+func prefixShadowsLoggingRoute(federationPrefix string) bool {
+	prefix := path.Clean("/" + federationPrefix)
+	if prefix == "/" || prefix == loggingNamespaceRoot {
+		return true
+	}
+	return strings.HasPrefix(loggingNamespaceRoot+"/", prefix+"/")
+}
+
+// checkLoggingPrefixCollision refuses to mount when an export would shadow the
+// logging namespace's route.
+func checkLoggingPrefixCollision() error {
+	exports, err := server_utils.GetOriginExports()
+	if err != nil {
+		// Not being able to read the exports is not this feature's failure to
+		// report; whatever asked for them will have surfaced it already.
+		// Skipping the guard is safe for the same reason: if the exports could
+		// not be loaded here, the WebDAV handlers could not have mounted their
+		// catch-alls from them either, so there is nothing to collide with.
+		return nil
+	}
+	for _, export := range exports {
+		if prefixShadowsLoggingRoute(export.FederationPrefix) {
+			return errors.Errorf(
+				"cannot export logs: the export at %s would shadow the %s route and panic the web server at startup; "+
+					"either change that export's federation prefix or disable %s",
+				export.FederationPrefix, loggingNamespaceRoot,
+				param.Logging_LogExports_Enabled.GetName())
+		}
+	}
+	return nil
+}
+
+// refuseLogRequest answers a request without serving a window, and marks the
+// refusal uncacheable.
+//
+// The marking is load-bearing on the 404s: RFC 9111 makes 404 heuristically
+// cacheable even with no Cache-Control at all, so an unmarked "not available
+// yet" minted during the settle margin could be stored by a cache on the path
+// and go on being served long after the window became available.  The other
+// statuses do not strictly need it, but a refusal is never a durable answer
+// here, and one rule is easier to keep than five.
+func refuseLogRequest(c *gin.Context, status int, msg string) {
+	c.Header("Cache-Control", "no-store")
+	c.JSON(status, server_structs.SimpleApiResp{
+		Status: server_structs.RespFailed,
+		Msg:    msg,
+	})
+}
+
+// serve answers a request for one window of this server's logs.
+func (h *loggingHandler) serve(c *gin.Context) {
+	// The namespace is per-server, so a request naming a different server
+	// reached the wrong host.  Answering it would be answering for someone
+	// else's logs.
+	if c.Param("sitename") != h.sitename {
+		refuseLogRequest(c, http.StatusForbidden,
+			"this server does not serve logs for the requested server name")
+		return
+	}
+
+	// Authorize before interpreting the request, so an unauthenticated caller
+	// learns nothing about which paths parse or which windows exist.
+	if !h.authorize(c) {
+		return
+	}
+
+	selector, err := parseLogSelector(c.Param("object"), h.now)
+	if err != nil {
+		refuseLogRequest(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// An hour that has not finished and settled is not a servable object yet.
+	// Refusing is what keeps every response immutable: there is no such thing
+	// here as a window whose contents can still change, so nothing has to be
+	// kept away from caches.
+	_, windowEnd := selector.Bounds()
+	if !h.windowSettled(windowEnd) {
+		available := windowEnd.Add(logSettleMargin).UTC().Format(time.RFC3339)
+		refuseLogRequest(c, http.StatusNotFound,
+			"that hour is not available yet; logs are served once an hour has ended and its "+
+				"entries have reached disk, which for this window is "+available+
+				". For recent activity use the server's log viewer or /api/v1.0/logs/tail")
+		return
+	}
+
+	// One open serves the whole request.  Coverage and the streamed body must
+	// describe the same bytes: with separate opens, a rotation between them
+	// could let the coverage check vouch for an hour and the read then stream
+	// the fresh, nearly-empty replacement file -- an empty answer under an
+	// immutable header, which a cache would keep for good.
+	reader, err := h.source.Open(c.Request.Context())
+	if err != nil {
+		log.WithError(err).Warning("Unable to open the server log for export")
+		refuseLogRequest(c, http.StatusInternalServerError, "unable to read the server log")
+		return
+	}
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.WithError(err).Debug("Failed to close the log reader after an export request")
+		}
+	}()
+
+	// Cacheability needs answering before any bytes go out, since it decides a
+	// header.  Coverage is the cheap half of it: reading the oldest entry the
+	// file still holds.
+	oldest, covered, err := reader.Coverage(c.Request.Context())
+	if err != nil {
+		log.WithError(err).Warning("Unable to determine log file coverage")
+		refuseLogRequest(c, http.StatusInternalServerError, "unable to read the server log")
+		return
+	}
+
+	start, _ := selector.Bounds()
+	h.setCacheHeaders(c, selector, oldest, covered, start)
+	c.Header("Content-Type", "text/plain; charset=utf-8")
+
+	// A HEAD asks whether this object is servable, not for its contents.
+	// Answering it without reading the window keeps the Director's presence
+	// check from costing a file scan.  Responses stream, so there is no
+	// Content-Length to report either way.
+	if c.Request.Method == http.MethodHead {
+		c.Status(http.StatusOK)
+		return
+	}
+
+	select {
+	case h.sem <- struct{}{}:
+		defer func() { <-h.sem }()
+	default:
+		c.Header("Retry-After", strconv.Itoa(int(time.Minute.Seconds())))
+		refuseLogRequest(c, http.StatusServiceUnavailable,
+			"too many concurrent log queries; retry shortly")
+		return
+	}
+
+	c.Status(http.StatusOK)
+	if err := reader.Read(c.Request.Context(), selector, c.Writer); err != nil {
+		// The status line is already out, so this cannot become a 500 -- but it
+		// must not become a clean 200 either.  The client going away is the
+		// one harmless case: nothing downstream will store what nobody
+		// received.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			log.WithError(err).Debug("Log export stream ended early; the client went away")
+			return
+		}
+		// Anything else means the body is truncated.  Returning normally would
+		// let the server finish the response framing, making the truncation
+		// invisible -- and the headers already sent may say immutable, so a
+		// cache would keep the short copy forever.  Kill the connection
+		// instead, so what went out is visibly incomplete.
+		log.WithError(err).Warning("Failed while streaming a log export; aborting the connection " +
+			"so the truncated response cannot be mistaken for the whole window")
+		abortResponse(c)
+	}
+}
+
+// abortResponse closes the client's connection without finishing the response,
+// so a body cut short by a server-side failure arrives visibly incomplete
+// rather than as a well-formed short answer.
+//
+// Hijacking the connection is best-effort.  HTTP/2 offers no hijacking, and
+// gin's writer panics rather than erroring when the underlying writer cannot
+// hijack, so the recover turns "cannot abort" into "nothing more to be done"
+// -- the failure is already logged either way.  The standard tool for this,
+// panic(http.ErrAbortHandler), is not available here: the engine-wide
+// gin.Recovery() swallows every panic and then lets the response finish
+// normally, which is exactly the clean framing this function exists to avoid.
+func abortResponse(c *gin.Context) {
+	defer func() {
+		_ = recover()
+	}()
+	if conn, _, err := c.Writer.Hijack(); err == nil {
+		_ = conn.Close()
+	}
+}
+
+// windowSettled reports whether a window has both ended and had time for its
+// entries to be flushed to disk.
+func (h *loggingHandler) windowSettled(end time.Time) bool {
+	return !end.Add(logSettleMargin).After(h.now())
+}
+
+// verifyToken checks that the caller holds a token covering this server's
+// logging namespace, writing the refusal itself if not.
+//
+// This is two steps rather than one because token.Verify's own scope check
+// compares scope strings exactly.  A federation administrator holding
+// storage.read:/ legitimately covers every logging namespace in the
+// federation, and an exact comparison would turn that into a refusal.  So the
+// first step establishes that the token is real and from an issuer we accept,
+// and the second asks the hierarchical question the scopes were designed for.
+func (h *loggingHandler) verifyToken(c *gin.Context) bool {
+	authOption := token.AuthOption{
+		// Authz matters as much as Header: the Director hands the token to the
+		// server by appending ?authz= to the redirect, because an HTTP
+		// redirect drops the Authorization header on the way.
+		Sources: []token.TokenSource{token.Authz, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer},
+		// Left empty on purpose -- see the scope check below.
+		Scopes: []token_scopes.TokenScope{},
+	}
+	if param.Logging_LogExports_AllowFederationAdmin.GetBool() {
+		authOption.Issuers = append(authOption.Issuers, token.FederationIssuer)
+	}
+
+	result, status, ok, err := token.VerifyAndExtract(c, authOption)
+	if !ok {
+		if err != nil {
+			log.WithError(err).Debug("Rejected a log export request during token verification")
+		}
+		refuseLogRequest(c, status, "authorization is required to read this server's logs")
+		return false
+	}
+
+	if result == nil || result.Token == nil {
+		// Verification passed but produced no parsed token, so the scope
+		// question cannot be answered.  Refusing is the only safe reading.
+		log.Error("Token verification succeeded without yielding a parsed token; refusing log export")
+		refuseLogRequest(c, http.StatusForbidden, "authorization could not be evaluated")
+		return false
+	}
+
+	if h.scopeAuthorized(result.Token) {
+		return true
+	}
+
+	refuseLogRequest(c, http.StatusForbidden, "the provided token does not grant "+h.scope.String())
+	return false
+}
+
+// scopeAuthorized reports whether any scope the token carries covers this
+// server's logging namespace.
+//
+// Hierarchical rather than exact, which is the entire reason this is not left
+// to token.Verify: a federation administrator holding storage.read:/ covers
+// every logging namespace in the federation, and comparing scope strings for
+// equality would refuse precisely the caller AllowFederationAdmin exists to
+// admit.
+//
+// Separated from verifyToken so the decision can be tested against real
+// tokens without an issuer, a signature, or an HTTP request -- the surrounding
+// verification is token.Verify's business and has its own tests.
+func (h *loggingHandler) scopeAuthorized(tok jwt.Token) bool {
+	if tok == nil {
+		return false
+	}
+	for _, granted := range token_scopes.ParseResourceScopeString(tok) {
+		if granted.Contains(h.scope) {
+			return true
+		}
+	}
+	return false
+}
+
+// setCacheHeaders states whether the response may be stored.
+//
+// Two independent things have to hold before it may.  The window must have
+// closed, or the bytes are a prefix of an hour still being written.  And the
+// log must still reach back far enough to cover it, or the empty response
+// produced for a rotated-away hour would be cached as though it were that
+// hour's real contents -- and no later response could dislodge it, because
+// no-store governs storing rather than evicting.
+func (h *loggingHandler) setCacheHeaders(c *gin.Context, sel logSelector, oldest time.Time, covered bool, start time.Time) {
+	cacheable := sel.Cacheable() && covered && !oldest.After(start)
+	if cacheable {
+		c.Header("Cache-Control", "public, max-age="+
+			strconv.Itoa(int(immutableCacheMaxAge.Seconds()))+", immutable")
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+}
+
+// parseLogSelector turns an object path into the set of entries it names.
+//
+// One spelling is understood:
+//
+//	/{year}/{month}/{day}/{hour}[.log]   one hour, addressed in UTC
+//
+// There is deliberately no way to ask for "the last hour" or for the hour in
+// progress.  Every window this endpoint serves has finished and settled, which
+// is what lets every response be immutable and cacheable, and removes any need
+// to keep some responses away from caches.  Recent lines are a different
+// question with a better answer already built: the in-memory buffer behind
+// /api/v1.0/logs/tail and the log viewer in the web UI.
+//
+// The following are fixed, because changing any of them would silently alter
+// what an existing URL returns rather than breaking it visibly:
+//
+//   - Windows are addressed in UTC.  Entries carry their own offset, so
+//     matching compares instants and is zone-independent, but the address is
+//     UTC so a client and a server in different zones agree on what they are
+//     talking about.
+//   - The .log suffix is optional and both spellings name the same window.
+//   - Segments are fixed-width and zero-padded: /2026/08/20/05, never
+//     /2026/8/20/5.  Every accepted spelling of a window is a separate URL --
+//     a separate cache key -- for the same bytes, so there is exactly one.
+//   - A four-digit numeric first segment means a time window; any other first
+//     segment names a kind of selector.  Reserving that split now is what lets
+//     a future /job/{uuid} be added without having to tell a UUID from a date
+//     by inspection.
+func parseLogSelector(object string, now func() time.Time) (logSelector, error) {
+	trimmed := strings.Trim(object, "/")
+	if trimmed == "" {
+		return nil, errors.Wrap(errUnknownSelectorKind, "no log window was named")
+	}
+
+	segments := strings.Split(trimmed, "/")
+	head := segments[0]
+
+	// A named kind, rather than a date.  None exist yet -- the segment is
+	// reserved so one can be added later without having to tell a name from a
+	// date by inspection.
+	if _, ok := parseFixedDigits(head, 4); !ok {
+		return nil, errors.Wrapf(errUnknownSelectorKind,
+			"%q is not a kind of log object this server serves", head)
+	}
+
+	if len(segments) != 4 {
+		return nil, errors.Wrapf(errMalformedWindow,
+			"expected {year}/{month}/{day}/{hour}, got %d path segments", len(segments))
+	}
+
+	year, _ := parseFixedDigits(segments[0], 4)
+	month, ok := parseFixedDigits(segments[1], 2)
+	if !ok || month < 1 || month > 12 {
+		return nil, errors.Wrap(errMalformedWindow, "month must be two digits, 01-12")
+	}
+	day, ok := parseFixedDigits(segments[2], 2)
+	if !ok || day < 1 || day > 31 {
+		return nil, errors.Wrap(errMalformedWindow, "day must be two digits, 01-31")
+	}
+	hour, ok := parseFixedDigits(strings.TrimSuffix(segments[3], ".log"), 2)
+	if !ok || hour > 23 {
+		return nil, errors.Wrap(errMalformedWindow, "hour must be two digits, 00-23")
+	}
+
+	start := time.Date(year, time.Month(month), day, hour, 0, 0, 0, time.UTC)
+	// time.Date normalises out-of-range dates rather than refusing them, so
+	// 02/31 would quietly become 03/03.  Comparing back catches that.
+	if start.Day() != day || int(start.Month()) != month || start.Year() != year {
+		return nil, errors.Wrapf(errMalformedWindow, "%04d-%02d-%02d is not a date", year, month, day)
+	}
+
+	return &timeWindowSelector{
+		start: start,
+		end:   start.Add(logWindowDuration),
+		now:   now,
+	}, nil
+}
+
+// parseFixedDigits parses s as exactly width ASCII digits.
+//
+// The width is enforced, not just the value: strconv would accept "8", "015",
+// and even "+5" where "08", "15" were meant, and each accepted spelling is a
+// distinct URL -- hence a distinct cache key downstream -- for the same
+// window.  One window, one spelling; the optional .log suffix is the single
+// sanctioned exception.
+func parseFixedDigits(s string, width int) (int, bool) {
+	if len(s) != width {
+		return 0, false
+	}
+	v := 0
+	for i := 0; i < width; i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return 0, false
+		}
+		v = v*10 + int(s[i]-'0')
+	}
+	return v, true
+}

--- a/log_exports/logging_api_test.go
+++ b/log_exports/logging_api_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /***************************************************************
  *
  * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research

--- a/log_exports/logging_api_test.go
+++ b/log_exports/logging_api_test.go
@@ -1,0 +1,720 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package log_exports
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+func TestParseLogSelectorTimeWindow(t *testing.T) {
+	now := fixedClock(time.Date(2026, 8, 20, 18, 5, 0, 0, time.UTC))
+
+	t.Run("valid bucket is one UTC hour", func(t *testing.T) {
+		sel, err := parseLogSelector("/2026/08/20/15.log", now)
+		require.NoError(t, err)
+		start, end := sel.Bounds()
+		assert.Equal(t, time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC), start)
+		assert.Equal(t, time.Date(2026, 8, 20, 16, 0, 0, 0, time.UTC), end)
+	})
+
+	t.Run("the .log suffix is optional and means the same window", func(t *testing.T) {
+		withSuffix, err := parseLogSelector("/2026/08/20/15.log", now)
+		require.NoError(t, err)
+		without, err := parseLogSelector("/2026/08/20/15", now)
+		require.NoError(t, err)
+
+		s1, e1 := withSuffix.Bounds()
+		s2, e2 := without.Bounds()
+		assert.Equal(t, s1, s2)
+		assert.Equal(t, e1, e2)
+	})
+
+	// Each of these is the shape of a real client mistake, and each must be a
+	// 400 that names the window rather than a 404 or a silently wrong answer.
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"month out of range", "/2026/13/20/15"},
+		{"month zero", "/2026/00/20/15"},
+		{"day out of range", "/2026/08/32/15"},
+		{"hour out of range", "/2026/08/20/24"},
+		{"day absent from month", "/2026/02/31/15"},
+		{"too few segments", "/2026/08/20"},
+		{"too many segments", "/2026/08/20/15/30"},
+		{"non-numeric hour", "/2026/08/20/xx"},
+		// One window, one spelling: every accepted variant is a separate URL
+		// -- a separate cache key -- for the same bytes, so widths are fixed
+		// and only the .log suffix may vary.
+		{"unpadded month", "/2026/8/20/15"},
+		{"unpadded day", "/2026/08/2/15"},
+		{"unpadded hour", "/2026/08/20/5"},
+		{"overlong hour", "/2026/08/20/015"},
+		{"signed hour", "/2026/08/20/+5"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseLogSelector(tc.path, now)
+			require.Error(t, err)
+			// Malformed, not unrecognized: the caller asked for a time window
+			// and spelled it wrong, which is a different fix than asking for
+			// something this server does not serve.
+			assert.ErrorIs(t, err, errMalformedWindow)
+			assert.NotErrorIs(t, err, errUnknownSelectorKind)
+		})
+	}
+}
+
+func TestParseLogSelectorReservedNamespace(t *testing.T) {
+	now := fixedClock(time.Date(2026, 8, 20, 18, 5, 0, 0, time.UTC))
+
+	// A non-numeric leading segment names a kind of selector.  None exist:
+	// there is deliberately no way to ask for "the last hour", because recent
+	// activity is what the in-memory buffer behind /api/v1.0/logs/tail is for,
+	// and because keeping every servable window closed is what lets every
+	// response be immutable.
+	//
+	// The error still has to say "unknown kind" rather than "malformed date",
+	// so that adding /job/{uuid} later is additive and does not change what
+	// today's errors mean.
+	for _, path := range []string{"/latest", "/latest.log", "/job/abc-123", "/metrics/5m", "/uuid"} {
+		t.Run(path, func(t *testing.T) {
+			_, err := parseLogSelector(path, now)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errUnknownSelectorKind)
+			assert.NotErrorIs(t, err, errMalformedWindow)
+		})
+	}
+
+	t.Run("empty path", func(t *testing.T) {
+		_, err := parseLogSelector("/", now)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errUnknownSelectorKind)
+	})
+}
+
+func TestValidateSitenameForURL(t *testing.T) {
+	// Nothing else in Pelican constrains a sitename, but here it has to
+	// survive being a path segment, the value compared against the decoded
+	// :sitename parameter, and part of a token scope.
+	for _, name := range []string{"uw-origin", "UW_OSDF_ORIGIN", "origin1.example.com", "a.b-c_d"} {
+		t.Run("accepts "+name, func(t *testing.T) {
+			assert.NoError(t, validateSitenameForURL(name))
+		})
+	}
+
+	for _, tc := range []struct{ name, sitename string }{
+		{"empty", ""},
+		{"space", "uw origin"},
+		{"slash", "uw/origin"},
+		{"question mark", "uw?origin"},
+		{"fragment", "uw#origin"},
+		{"dot", "."},
+		{"dot dot", ".."},
+		{"percent", "uw%20origin"},
+		{"non-ascii", "uw-orígen"},
+	} {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			assert.Error(t, validateSitenameForURL(tc.sitename))
+		})
+	}
+}
+
+// stubSource serves a fixed body and coverage, so handler tests can assert on
+// status and headers without a log file.  It is its own reader: Open returns
+// the stub itself, which keeps the handler exercising the real open/close
+// sequence without a file behind it.
+type stubSource struct {
+	body     string
+	oldest   time.Time
+	covered  bool
+	readErr  error
+	readCall int
+}
+
+func (s *stubSource) Open(context.Context) (logReader, error) { return s, nil }
+
+func (s *stubSource) Close() error { return nil }
+
+func (s *stubSource) Coverage(context.Context) (time.Time, bool, error) {
+	return s.oldest, s.covered, nil
+}
+
+func (s *stubSource) Read(_ context.Context, _ logSelector, w io.Writer) error {
+	s.readCall++
+	if _, err := w.Write([]byte(s.body)); err != nil {
+		return err
+	}
+	return s.readErr
+}
+
+// newLoggingEngine mounts the real routes with authorization stubbed, so the
+// tests exercise the handler rather than the token stack.
+func newLoggingEngine(t *testing.T, sitename string, src logSource, now time.Time) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+
+	h := &loggingHandler{
+		sitename:  sitename,
+		scope:     token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Read, LoggingNamespaceForSitename(sitename)),
+		source:    src,
+		now:       fixedClock(now),
+		sem:       make(chan struct{}, maxConcurrentLogReads),
+		authorize: func(*gin.Context) bool { return true },
+	}
+	registerLoggingRoutes(engine, h)
+	return engine
+}
+
+func do(t *testing.T, engine *gin.Engine, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	return rec
+}
+
+func TestLoggingHandlerSitenameMismatch(t *testing.T) {
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{body: "entries\n", covered: true}
+	engine := newLoggingEngine(t, "uw-origin", src, now)
+
+	// The namespace is per-server.  A request naming a different server has
+	// reached the wrong host, and answering it would be answering for someone
+	// else's logs.
+	rec := do(t, engine, http.MethodGet, "/pelican/logging/other-origin/2026/08/20/15.log")
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Zero(t, src.readCall, "a mismatched sitename must be refused before any log is read")
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"),
+		"a refusal is never a durable answer and must not be cached")
+}
+
+func TestLoggingHandlerMalformedPath(t *testing.T) {
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{covered: true}
+	engine := newLoggingEngine(t, "uw-origin", src, now)
+
+	rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/13/20/15.log")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Zero(t, src.readCall)
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"),
+		"a refusal is never a durable answer and must not be cached")
+}
+
+func TestLoggingHandlerServesWindow(t *testing.T) {
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{
+		body:    "one\ntwo\n",
+		oldest:  time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+		covered: true,
+	}
+	engine := newLoggingEngine(t, "uw-origin", src, now)
+
+	rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "one\ntwo\n", rec.Body.String())
+	assert.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+}
+
+func TestLoggingHandlerEmptyWindowIsOK(t *testing.T) {
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{
+		body:    "",
+		oldest:  time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+		covered: true,
+	}
+	engine := newLoggingEngine(t, "uw-origin", src, now)
+
+	// An hour in which the server logged nothing is a real answer, not a 404.
+	rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Body.String())
+}
+
+func TestLoggingHandlerHead(t *testing.T) {
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{
+		body:    "one\ntwo\n",
+		oldest:  time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+		covered: true,
+	}
+	engine := newLoggingEngine(t, "uw-origin", src, now)
+
+	// The Director stats a server with HEAD before redirecting to it, and
+	// the presence checks are on by default.  Without this route that stat
+	// draws a 405 and the server drops out of routing entirely.
+	rec := do(t, engine, http.MethodHead, "/pelican/logging/uw-origin/2026/08/20/15.log")
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+	assert.Zero(t, src.readCall,
+		"a presence check should not cost a scan of the log file")
+}
+
+func TestLoggingHandlerCacheDirectives(t *testing.T) {
+	// 18:30, so the 18:00 bucket is still open while the 15:00 one is closed.
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	wellCovered := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+
+	t.Run("closed and covered is immutable", func(t *testing.T) {
+		engine := newLoggingEngine(t, "uw-origin",
+			&stubSource{oldest: wellCovered, covered: true}, now)
+		rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Header().Get("Cache-Control"), "immutable")
+	})
+
+	t.Run("an unsettled window is refused rather than served uncacheably", func(t *testing.T) {
+		// Everything this endpoint serves has finished and settled, so there
+		// is no such thing as a served-but-uncacheable window.  That is what
+		// removes the need to keep any response away from a cache.
+		engine := newLoggingEngine(t, "uw-origin",
+			&stubSource{oldest: wellCovered, covered: true}, now)
+		rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/18.log")
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("a rotated-away window is not cacheable", func(t *testing.T) {
+		// The log now only reaches back to 17:00, so the 15:00 bucket comes
+		// back empty because its entries were rotated away -- not because
+		// nothing happened then.  Marking that immutable would let a cache
+		// pin an empty answer for a real hour, permanently.
+		engine := newLoggingEngine(t, "uw-origin",
+			&stubSource{oldest: time.Date(2026, 8, 20, 17, 0, 0, 0, time.UTC), covered: true}, now)
+		rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	})
+
+	t.Run("an empty log covers nothing", func(t *testing.T) {
+		engine := newLoggingEngine(t, "uw-origin", &stubSource{covered: false}, now)
+		rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	})
+}
+
+// TestRegisterLoggingExportAPIDisabled covers the exported entry point's
+// opt-in gate.  A server that has not enabled log export must mount nothing,
+// so the endpoint 404s by absence rather than existing only to refuse.
+func TestRegisterLoggingExportAPIDisabled(t *testing.T) {
+	prev := param.Logging_LogExports_Enabled.GetBool()
+	require.NoError(t, param.Logging_LogExports_Enabled.Set(false))
+	t.Cleanup(func() { _ = param.Logging_LogExports_Enabled.Set(prev) })
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	require.NoError(t, RegisterLoggingExportAPI(context.Background(), engine, server_structs.OriginType))
+
+	rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+	assert.Equal(t, http.StatusNotFound, rec.Code, "a disabled server must have no such route")
+}
+
+// TestRegisterLoggingExportForWiring exercises everything the exported
+// registration does once the server's name is known.  This is the region the
+// route actually gets assembled in -- and the region a missing middleware
+// argument hid in until it was audited -- so it is worth reaching directly
+// rather than only through the unexported route mounting.
+func TestRegisterLoggingExportForWiring(t *testing.T) {
+	t.Run("rejects a sitename that is not URL-safe", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		err := registerLoggingExportFor(engine, "uw origin/bad")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uw origin/bad",
+			"the error should name the offending value so an admin can fix it")
+	})
+
+	t.Run("mounts a working route for a valid sitename", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		require.NoError(t, registerLoggingExportFor(engine, "uw-origin"))
+
+		// Real registration wires the real token check, so an unauthenticated
+		// request must be refused rather than served.  What matters here is
+		// that the route exists and reaches the handler at all.
+		rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+		assert.NotEqual(t, http.StatusNotFound, rec.Code, "the route should be mounted")
+		assert.Equal(t, http.StatusForbidden, rec.Code, "and should refuse an unauthenticated caller")
+	})
+
+	t.Run("supplied middleware reaches the mounted route", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		var ran int
+		require.NoError(t, registerLoggingExportFor(engine, "uw-origin",
+			func(c *gin.Context) { ran++; c.Next() }))
+
+		do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+		assert.Equal(t, 1, ran, "middleware handed to the exported API must be attached")
+	})
+
+	t.Run("both methods are mounted", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		require.NoError(t, registerLoggingExportFor(engine, "uw-origin"))
+
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			rec := do(t, engine, method, "/pelican/logging/uw-origin/2026/08/20/15.log")
+			assert.NotEqual(t, http.StatusMethodNotAllowed, rec.Code,
+				"%s must be routed -- the Director stats with HEAD and a 405 drops this server from routing", method)
+		}
+	})
+
+	t.Run("registration is server-type-agnostic", func(t *testing.T) {
+		// Nothing below the name lookup knows what kind of server this is:
+		// anything server-specific, like a server type's metrics middleware,
+		// is the launcher's to supply.  A cache's sitename mounts on the same
+		// terms as an origin's.
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		require.NoError(t, registerLoggingExportFor(engine, "uw-cache"))
+
+		rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-cache/2026/08/20/15.log")
+		assert.NotEqual(t, http.StatusNotFound, rec.Code, "the route should be mounted for a cache's sitename")
+	})
+}
+
+func TestLoggingRoutesRunSuppliedMiddleware(t *testing.T) {
+	// Middleware is threaded in from the launcher rather than imported here,
+	// which makes it easy to mount the group and forget to pass anything --
+	// exactly what happened once.  Assert it actually runs, on both methods.
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			engine := gin.New()
+
+			var ran int
+			h := &loggingHandler{
+				sitename:  "uw-origin",
+				source:    &stubSource{oldest: time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC), covered: true},
+				now:       fixedClock(now),
+				sem:       make(chan struct{}, maxConcurrentLogReads),
+				authorize: func(*gin.Context) bool { return true },
+			}
+			registerLoggingRoutes(engine, h, func(c *gin.Context) {
+				ran++
+				c.Header("X-Test-Middleware", "ran")
+				c.Next()
+			})
+
+			rec := do(t, engine, method, "/pelican/logging/uw-origin/2026/08/20/15.log")
+			require.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, 1, ran, "supplied middleware must run for %s", method)
+			assert.Equal(t, "ran", rec.Header().Get("X-Test-Middleware"))
+		})
+	}
+}
+
+func TestLoggingHandlerSettleMargin(t *testing.T) {
+	// The trap this guards: an hour ending is not the same as all of its
+	// entries being on disk.  The async writer holds entries until a size
+	// threshold or the flush interval pushes them out, so serving an hour the
+	// instant it ends would hand out a copy missing its tail -- and a cache
+	// would keep that copy for good, since Cache-Control decides whether a
+	// response is stored, not whether a stored one is dropped.
+	wellCovered := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	src := func() *stubSource { return &stubSource{oldest: wellCovered, covered: true} }
+
+	// The 17:00 bucket ends at 18:00, so it becomes servable at 18:05.
+	for _, tc := range []struct {
+		name  string
+		now   time.Time
+		want  int
+		cache string
+	}{
+		{"during the hour itself", time.Date(2026, 8, 20, 17, 30, 0, 0, time.UTC), http.StatusNotFound, "no-store"},
+		{"the instant it ends", time.Date(2026, 8, 20, 18, 0, 0, 0, time.UTC), http.StatusNotFound, "no-store"},
+		{"one minute after", time.Date(2026, 8, 20, 18, 1, 0, 0, time.UTC), http.StatusNotFound, "no-store"},
+		{"just short of the margin", time.Date(2026, 8, 20, 18, 4, 59, 0, time.UTC), http.StatusNotFound, "no-store"},
+		{"exactly at the margin", time.Date(2026, 8, 20, 18, 5, 0, 0, time.UTC), http.StatusOK, "immutable"},
+		{"well after", time.Date(2026, 8, 20, 19, 0, 0, 0, time.UTC), http.StatusOK, "immutable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := src()
+			engine := newLoggingEngine(t, "uw-origin", s, tc.now)
+			rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/17.log")
+			require.Equal(t, tc.want, rec.Code)
+			// The refusal must itself be no-store: RFC 9111 makes a 404
+			// heuristically cacheable, so an unmarked "not available yet"
+			// could be stored by a cache on the path and outlive the settle
+			// margin that justified it.
+			assert.Contains(t, rec.Header().Get("Cache-Control"), tc.cache)
+			if tc.want == http.StatusNotFound {
+				assert.Zero(t, s.readCall, "an unsettled window must not be read")
+			}
+		})
+	}
+}
+
+func TestLoggingHandlerAuthorizesBeforeInterpretingRequest(t *testing.T) {
+	// An unauthenticated caller should not be able to learn which paths parse
+	// or which windows exist, so authorization runs before both checks.
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	h := &loggingHandler{
+		sitename: "uw-origin",
+		source:   &stubSource{covered: true},
+		now:      fixedClock(now),
+		sem:      make(chan struct{}, maxConcurrentLogReads),
+		authorize: func(c *gin.Context) bool {
+			c.Status(http.StatusForbidden)
+			return false
+		},
+	}
+	registerLoggingRoutes(engine, h)
+
+	for _, path := range []string{
+		"/pelican/logging/uw-origin/2026/13/40/99.log", // malformed
+		"/pelican/logging/uw-origin/2026/08/20/18.log", // unsettled
+		"/pelican/logging/uw-origin/nonsense",          // unknown kind
+	} {
+		t.Run(path, func(t *testing.T) {
+			rec := do(t, engine, http.MethodGet, path)
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"the refusal must not depend on what was asked for")
+		})
+	}
+}
+
+func TestLoggingHandlerRefusesWhenUnauthorized(t *testing.T) {
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{body: "secret\n", covered: true}
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	h := &loggingHandler{
+		sitename: "uw-origin",
+		scope:    token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Read, LoggingNamespaceForSitename("uw-origin")),
+		source:   src,
+		now:      fixedClock(now),
+		sem:      make(chan struct{}, maxConcurrentLogReads),
+		authorize: func(c *gin.Context) bool {
+			c.Status(http.StatusForbidden)
+			return false
+		},
+	}
+	registerLoggingRoutes(engine, h)
+
+	rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Zero(t, src.readCall, "an unauthorized caller must not reach the log")
+	assert.NotContains(t, rec.Body.String(), "secret")
+}
+
+// tokenWithScope builds an unsigned token carrying a scope claim. Signature
+// and issuer are token.Verify's business; what is under test here is the
+// handler's own scope decision.
+func tokenWithScope(t *testing.T, scope string) jwt.Token {
+	t.Helper()
+	builder := jwt.NewBuilder().Issuer("https://origin.example.com").Subject("test")
+	if scope != "" {
+		builder = builder.Claim("scope", scope)
+	}
+	tok, err := builder.Build()
+	require.NoError(t, err)
+	return tok
+}
+
+func TestLoggingHandlerScopeAuthorized(t *testing.T) {
+	// This exercises the handler's own scope check, over real tokens.
+	// An earlier version of this test asserted on token_scopes.Contains
+	// directly, which tested the scopes package rather than any of this
+	// handler's behaviour -- the loop below was uncovered.
+	h := &loggingHandler{
+		sitename: "uw-origin",
+		scope: token_scopes.NewResourceScope(
+			token_scopes.Wlcg_Storage_Read, LoggingNamespaceForSitename("uw-origin")),
+	}
+
+	// A federation administrator holds one broad scope covering every
+	// server's logs. token.Verify compares scope strings exactly, which is why
+	// the handler asks the hierarchical question itself: an exact comparison
+	// would refuse precisely the caller AllowFederationAdmin exists to admit.
+	for _, scope := range []string{
+		"storage.read:/",
+		"storage.read:/pelican",
+		"storage.read:/pelican/logging",
+		"storage.read:/pelican/logging/uw-origin",
+		"storage.read:/pelican/logging/uw-origin/",
+		"storage.modify:/ storage.read:/pelican/logging", // several scopes, one sufficient
+	} {
+		t.Run("accepts "+scope, func(t *testing.T) {
+			assert.True(t, h.scopeAuthorized(tokenWithScope(t, scope)))
+		})
+	}
+
+	for _, scope := range []string{
+		"storage.read:/pelican/logging/other-origin",
+		"storage.read:/pelican/logging/uw-origin-2", // prefix-of-string but not of path
+		"storage.read:/pelican/metrics/uw-origin",
+		"storage.modify:/pelican/logging", // write does not imply read
+		"storage.create:/",
+		"pelican.log_read", // the web-UI identity scope is not a namespace grant
+		"",                 // no scope claim at all
+	} {
+		t.Run("rejects "+scope, func(t *testing.T) {
+			assert.False(t, h.scopeAuthorized(tokenWithScope(t, scope)))
+		})
+	}
+
+	t.Run("rejects a nil token", func(t *testing.T) {
+		assert.False(t, h.scopeAuthorized(nil),
+			"a missing token must never be read as authorization")
+	})
+
+	t.Run("a token for another server does not open this one", func(t *testing.T) {
+		other := &loggingHandler{
+			scope: token_scopes.NewResourceScope(
+				token_scopes.Wlcg_Storage_Read, LoggingNamespaceForSitename("other-origin")),
+		}
+		tok := tokenWithScope(t, "storage.read:/pelican/logging/uw-origin")
+		assert.True(t, h.scopeAuthorized(tok))
+		assert.False(t, other.scopeAuthorized(tok))
+	})
+}
+
+func TestLoggingNamespaceForSitename(t *testing.T) {
+	assert.Equal(t, "/pelican/logging/uw-origin", LoggingNamespaceForSitename("uw-origin"))
+}
+
+func TestPrefixShadowsLoggingRoute(t *testing.T) {
+	// These expectations are not guesses about Gin's routing -- each was
+	// checked against a live engine.  An export mounts a catch-all at its own
+	// prefix, and Gin refuses to register a route that descends through an
+	// existing catch-all, so only an export at or above /pelican/logging
+	// collides.  A static segment and a :param segment coexist at the same
+	// level, which is why an export *below* the logging root is fine and must
+	// not be rejected.
+	for _, prefix := range []string{"/", "/pelican", "/pelican/logging"} {
+		t.Run("shadows "+prefix, func(t *testing.T) {
+			assert.True(t, prefixShadowsLoggingRoute(prefix))
+		})
+	}
+
+	for _, prefix := range []string{
+		"/pelican/logging/some-export",
+		"/pelican/other",
+		"/pelicanish",
+		"/data",
+		"/chtc/staging",
+	} {
+		t.Run("does not shadow "+prefix, func(t *testing.T) {
+			assert.False(t, prefixShadowsLoggingRoute(prefix),
+				"rejecting this would refuse a configuration that works")
+		})
+	}
+
+	t.Run("trailing slashes and un-normalized prefixes still match", func(t *testing.T) {
+		assert.True(t, prefixShadowsLoggingRoute("/pelican/"))
+		assert.True(t, prefixShadowsLoggingRoute("pelican"))
+		assert.True(t, prefixShadowsLoggingRoute("/pelican/logging/"))
+	})
+}
+
+// TestLoggingRoutesCoexistWithExportCatchall pins down the routing assumption
+// the guard above encodes: a WebDAV-style catch-all at a sibling or descendant
+// prefix does not stop the logging routes from mounting.  If a Gin upgrade
+// changes that, this fails rather than a server panicking on startup.
+func TestLoggingRoutesCoexistWithExportCatchall(t *testing.T) {
+	for _, prefix := range []string{"/pelican/logging/some-export", "/pelican/other", "/data"} {
+		t.Run(prefix, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			engine := gin.New()
+			engine.Group(prefix).Any("/*path", func(c *gin.Context) {})
+
+			require.NotPanics(t, func() {
+				registerLoggingRoutes(engine, &loggingHandler{
+					sitename:  "uw-origin",
+					source:    &stubSource{},
+					now:       fixedClock(time.Now()),
+					sem:       make(chan struct{}, 1),
+					authorize: func(*gin.Context) bool { return true },
+				})
+			})
+		})
+	}
+}
+
+func TestLoggingHandlerReadErrorAbortsResponse(t *testing.T) {
+	// A server-side failure mid-stream must not produce a response that looks
+	// complete: the headers -- possibly saying immutable -- are already out, so
+	// a clean finish would let a cache keep the truncated body forever.  The
+	// handler kills the connection instead, leaving the framing visibly
+	// unterminated.  A recorder cannot see framing, so this drives a real
+	// server.
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{
+		body:    "the part that made it out\n",
+		oldest:  time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+		covered: true,
+		readErr: errors.New("disk fell over"),
+	}
+	engine := newLoggingEngine(t, "uw-origin", src, now)
+
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	// The timeout bounds the whole exchange: if the abort path ever regresses
+	// into leaving the connection dangling, this test must fail in seconds,
+	// not hang the suite.
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(server.URL + "/pelican/logging/uw-origin/2026/08/20/15.log")
+	if err != nil {
+		// The connection died before the response came back at all -- equally
+		// impossible to mistake for a complete answer.
+		return
+	}
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	assert.Error(t, err, "a truncated stream must not read as a well-formed body")
+}
+
+func TestLoggingHandlerClientDisconnectIsNotAnError(t *testing.T) {
+	// The client going away mid-stream is routine -- a poller timing out, a
+	// person hitting ^C -- and must not travel the abort path or be logged as
+	// a failure.  It surfaces as context cancellation from the read.
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+	src := &stubSource{
+		oldest:  time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+		covered: true,
+		readErr: context.Canceled,
+	}
+	engine := newLoggingEngine(t, "uw-origin", src, now)
+
+	rec := do(t, engine, http.MethodGet, "/pelican/logging/uw-origin/2026/08/20/15.log")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/log_exports/logging_source.go
+++ b/log_exports/logging_source.go
@@ -1,0 +1,532 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Selection and reading for the logging namespace.
+//
+// A request names a set of log entries.  Today the only way to name them is a
+// time window, but the eventual goal is for selecting by job UUID, so the
+// query is modelled as a *predicate* (logSelector) rather than as a pair of
+// timestamps.
+
+package log_exports
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// logSelector decides which log entries belong in a response.
+//
+// Implementations must be safe for concurrent use: one selector is built per
+// request, but the source may consult it from a read loop.
+type logSelector interface {
+	// Matches reports whether an entry belongs in the response.
+	Matches(e *logEntry) bool
+
+	// Bounds is an optional time range the source may use to avoid reading
+	// the whole file.  Zero values mean unbounded, which obliges the source
+	// to consider every entry.  Bounds is an optimisation hint only --
+	// correctness comes from Matches.
+	Bounds() (start, end time.Time)
+
+	// Cacheable reports whether this selector names a stable set of entries,
+	// i.e. whether the same URL will keep meaning the same bytes.  A closed
+	// hour bucket does; an in-progress one does not, and neither would a
+	// future selector whose answer grows as the log does.
+	//
+	// This is only half the question -- the source must also still be able to
+	// serve the window (see logSource.Coverage).  The handler combines both.
+	Cacheable() bool
+}
+
+// logSource opens the log for one request.
+type logSource interface {
+	// Open pins the log so that everything one request learns and serves
+	// comes from the same underlying bytes.
+	//
+	// Coverage and Read used to be separate opens, which left a gap: rotation
+	// could rename the file between them, so the coverage check would vouch
+	// for an hour and Read would then stream the fresh, nearly-empty
+	// replacement -- an empty answer served under an immutable header, which a
+	// cache keeps for good.  One open handled to both methods closes that gap:
+	// a renamed file stays readable through an already-open descriptor.
+	//
+	// A source with nothing to serve (no log file yet) returns a reader that
+	// covers nothing and streams nothing; that is a normal state, not an
+	// error.  The caller owns the returned reader and must Close it.
+	Open(ctx context.Context) (logReader, error)
+}
+
+// logReader answers one request's questions about the log, all from the same
+// pinned view of it.
+type logReader interface {
+	// Coverage reports the timestamp of the oldest entry this reader can
+	// serve.  ok is false when it holds nothing, which is a normal state
+	// rather than an error.
+	//
+	// It exists so the handler can tell "this hour is empty" from "this hour
+	// was rotated away and we can no longer see it".  Both stream zero bytes,
+	// but only the first may be cached: labelling a rotated-away hour
+	// immutable would let a cache pin an empty answer for a real hour.
+	Coverage(ctx context.Context) (oldest time.Time, ok bool, err error)
+
+	// Read writes every matching entry to w in file order.
+	Read(ctx context.Context, sel logSelector, w io.Writer) error
+
+	io.Closer
+}
+
+// timeWindowSelector accepts entries in [start, end).
+type timeWindowSelector struct {
+	start time.Time
+	end   time.Time
+
+	// now lets Cacheable ask whether the window has closed without reaching
+	// for the wall clock, which keeps it testable.
+	now func() time.Time
+}
+
+func (s *timeWindowSelector) Matches(e *logEntry) bool {
+	return !e.Timestamp.Before(s.start) && e.Timestamp.Before(s.end)
+}
+
+func (s *timeWindowSelector) Bounds() (time.Time, time.Time) {
+	return s.start, s.end
+}
+
+func (s *timeWindowSelector) Cacheable() bool {
+	// An in-progress hour is still being appended to, so the response would
+	// be a truncated prefix of what the hour eventually holds.  Only a closed
+	// window is a stable answer.
+	//
+	// The handler refuses an unsettled window outright, so in practice
+	// anything reaching here has already passed a stricter test.  Keeping the
+	// check is cheap insurance on the one mistake that cannot be undone: a
+	// cache that stored a truncated hour keeps it, because Cache-Control
+	// decides whether a response is stored and not whether a stored one is
+	// dropped.
+	return !s.end.After(s.now())
+}
+
+// logEntry is one log record: a leading timestamped line plus any continuation
+// lines that followed it.
+//
+// Non-timestamp fields are tokenised on demand.  Only a future UUID selector
+// needs them, and splitting every key=value pair on every line of a 100MB file
+// to answer a question about timestamps would be work spent for nothing.
+type logEntry struct {
+	Timestamp time.Time
+
+	// Raw is the entry exactly as it appeared, continuation lines included,
+	// with its trailing newline.  Responses stream this verbatim so a caller
+	// gets the same bytes the log holds.
+	Raw []byte
+
+	fields map[string]string
+	parsed bool
+}
+
+// Field returns a logrus field from the entry's first line.
+func (e *logEntry) Field(name string) (string, bool) {
+	if !e.parsed {
+		e.fields = parseEntryFields(e.Raw)
+		e.parsed = true
+	}
+	v, ok := e.fields[name]
+	return v, ok
+}
+
+// parseEntryFields tokenises the `key=value` and `key="quoted value"` pairs on
+// an entry's first line.  It is intentionally forgiving: a malformed pair is
+// skipped rather than failing the entry, because a log line we cannot fully
+// understand is still a log line the caller asked for.
+func parseEntryFields(raw []byte) map[string]string {
+	fields := make(map[string]string)
+
+	line := raw
+	if idx := bytes.IndexByte(line, '\n'); idx >= 0 {
+		line = line[:idx]
+	}
+	s := string(line)
+
+	for len(s) > 0 {
+		s = strings.TrimLeft(s, " ")
+		eq := strings.IndexByte(s, '=')
+		if eq <= 0 {
+			break
+		}
+		key := s[:eq]
+		s = s[eq+1:]
+
+		var value string
+		if strings.HasPrefix(s, `"`) {
+			s = s[1:]
+			// Find the closing quote, honouring backslash escapes.
+			var b strings.Builder
+			i := 0
+			for i < len(s) {
+				if s[i] == '\\' && i+1 < len(s) {
+					b.WriteByte(s[i+1])
+					i += 2
+					continue
+				}
+				if s[i] == '"' {
+					break
+				}
+				b.WriteByte(s[i])
+				i++
+			}
+			value = b.String()
+			if i < len(s) {
+				s = s[i+1:]
+			} else {
+				s = ""
+			}
+		} else {
+			sp := strings.IndexByte(s, ' ')
+			if sp < 0 {
+				value, s = s, ""
+			} else {
+				value, s = s[:sp], s[sp:]
+			}
+		}
+		fields[key] = value
+	}
+
+	return fields
+}
+
+// timeFieldPrefix is how every log line written to the file begins.
+const timeFieldPrefix = `time=`
+
+// parseEntryTime pulls the timestamp off a log line, reporting whether the
+// line begins an entry at all.  A line that does not is a continuation --
+// wrapped panic output, a stack trace -- and belongs to the entry above it.
+//
+// The unquoted form is accepted too.  Nothing writes it today, but a parser
+// that only understands one spelling of its input is a parser that breaks the
+// day a formatter option changes.
+func parseEntryTime(line []byte) (time.Time, bool) {
+	if !bytes.HasPrefix(line, []byte(timeFieldPrefix)) {
+		return time.Time{}, false
+	}
+	rest := line[len(timeFieldPrefix):]
+
+	var raw []byte
+	if len(rest) > 0 && rest[0] == '"' {
+		rest = rest[1:]
+		end := bytes.IndexByte(rest, '"')
+		if end < 0 {
+			return time.Time{}, false
+		}
+		raw = rest[:end]
+	} else {
+		end := bytes.IndexByte(rest, ' ')
+		if end < 0 {
+			raw = rest
+		} else {
+			raw = rest[:end]
+		}
+	}
+
+	ts, err := time.Parse(time.RFC3339, string(raw))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return ts, true
+}
+
+// activeFileSource reads the log file Pelican is currently writing.
+type activeFileSource struct {
+	path string
+}
+
+// Tuning for the search that locates a window inside the file.
+const (
+	// seekSlack is how far to rewind from a binary-search hit before scanning
+	// forward.  The search assumes timestamps increase down the file, which is
+	// very nearly true but not exactly: concurrent goroutines and clock steps
+	// can transpose neighbouring entries.  Rewinding means the search only has
+	// to land close, and Matches does the deciding.
+	seekSlack = 128 << 10
+
+	// scanTolerance is how far past the window's end to keep reading before
+	// concluding the remainder of the file is beyond it.  Stopping at the very
+	// first out-of-window entry would silently truncate a response whenever
+	// two entries were written out of order across the boundary.
+	scanTolerance = 5 * time.Minute
+
+	// readBufSize bounds the memory used per request.  Entries stream out as
+	// they are matched, so this only has to hold one line.
+	readBufSize = 64 << 10
+
+	// maxEntrySize caps how large a single entry may grow before it is passed
+	// along as-is.  A runaway line should not become a runaway allocation.
+	maxEntrySize = 1 << 20
+)
+
+func (s *activeFileSource) Open(ctx context.Context) (logReader, error) {
+	f, err := os.Open(s.path)
+	if err != nil {
+		// A missing log file is expected rather than exceptional: logs are
+		// only pushed to a file once FlushLogs does so, and a server can be
+		// serving before that happens.
+		if os.IsNotExist(err) {
+			return emptyLogReader{}, nil
+		}
+		return nil, errors.Wrapf(err, "unable to open log file %s", s.path)
+	}
+	return &activeFileReader{f: f, path: s.path}, nil
+}
+
+// emptyLogReader is what opening an absent log yields: it covers nothing and
+// streams nothing, and both of those are answers rather than errors.
+type emptyLogReader struct{}
+
+func (emptyLogReader) Coverage(context.Context) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}
+func (emptyLogReader) Read(context.Context, logSelector, io.Writer) error {
+	return nil
+}
+func (emptyLogReader) Close() error { return nil }
+
+// activeFileReader serves one request from one open descriptor.  Rotation may
+// rename the file at any moment; the descriptor keeps the renamed file's
+// contents visible, so Coverage and Read cannot disagree about which file they
+// are describing.
+type activeFileReader struct {
+	f    *os.File
+	path string
+}
+
+func (r *activeFileReader) Close() error { return r.f.Close() }
+
+func (r *activeFileReader) Coverage(ctx context.Context) (time.Time, bool, error) {
+	if _, err := r.f.Seek(0, io.SeekStart); err != nil {
+		return time.Time{}, false, errors.Wrapf(err, "unable to seek log file %s", r.path)
+	}
+
+	// The scan is bounded: normally the very first line is an entry, but a
+	// file whose head is unparseable garbage must not make every request walk
+	// it end to end looking for one.  Giving up reports "covers nothing",
+	// which errs in the safe direction -- the response becomes no-store rather
+	// than immutable.
+	scanner := bufio.NewScanner(io.LimitReader(r.f, maxEntrySize))
+	scanner.Buffer(make([]byte, 0, readBufSize), maxEntrySize)
+	for scanner.Scan() {
+		if ts, ok := parseEntryTime(scanner.Bytes()); ok {
+			return ts, true, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return time.Time{}, false, err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		// A head with no line break inside the bound overflows the scanner
+		// before it can see EOF.  That is the bound doing its job, not a read
+		// failure: nothing parseable was found, so nothing is provably
+		// covered.
+		if errors.Is(err, bufio.ErrTooLong) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, errors.Wrapf(err, "unable to read log file %s", r.path)
+	}
+	// Empty, all garbage, or garbage past the bound: nothing provably covered.
+	return time.Time{}, false, nil
+}
+
+func (r *activeFileReader) Read(ctx context.Context, sel logSelector, w io.Writer) error {
+	start, end := sel.Bounds()
+
+	offset := int64(0)
+	if !start.IsZero() {
+		var err error
+		if offset, err = r.findOffset(ctx, start); err != nil {
+			return err
+		}
+	}
+	if _, err := r.f.Seek(offset, io.SeekStart); err != nil {
+		return errors.Wrapf(err, "unable to seek log file %s", r.path)
+	}
+
+	return r.scan(ctx, offset, sel, end, w)
+}
+
+// findOffset returns a byte offset at or before the first entry not older than
+// target, so a forward scan from there sees the whole window.
+//
+// This is a binary search rather than a scan from either end because the two
+// obvious alternatives are each wrong for a common case: scanning forward from
+// the start reads the entire file to answer a query for the most recent
+// servable hour, which sits at the end of the file and is the likeliest
+// request, while scanning backward from the end reads the entire file to
+// answer a question about this morning.  A search costs a handful of seeks
+// either way.
+func (r *activeFileReader) findOffset(ctx context.Context, target time.Time) (int64, error) {
+	info, err := r.f.Stat()
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to stat log file %s", r.path)
+	}
+	size := info.Size()
+	if size <= seekSlack {
+		return 0, nil
+	}
+
+	lo, hi := int64(0), size
+	for hi-lo > seekSlack {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		mid := lo + (hi-lo)/2
+		ts, found, err := r.firstEntryAt(mid, hi)
+		if err != nil {
+			return 0, err
+		}
+		if !found {
+			// No parseable entry between mid and hi; the answer, if any, is
+			// below mid.
+			hi = mid
+			continue
+		}
+		if ts.Before(target) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+
+	// Rewind past the resolution of the search so slightly out-of-order
+	// entries just before the boundary are still seen.
+	if lo < seekSlack {
+		return 0, nil
+	}
+	return lo - seekSlack, nil
+}
+
+// firstEntryAt returns the timestamp of the first entry beginning at or after
+// off, without consuming the partial line off may land in the middle of.
+func (r *activeFileReader) firstEntryAt(off, limit int64) (time.Time, bool, error) {
+	if _, err := r.f.Seek(off, io.SeekStart); err != nil {
+		return time.Time{}, false, errors.Wrapf(err, "unable to seek log file %s", r.path)
+	}
+	reader := bufio.NewReaderSize(io.LimitReader(r.f, limit-off), readBufSize)
+
+	// Unless we happen to be at the very beginning, the first line is almost
+	// certainly a fragment of the line that straddles off.  Drop it.
+	if off > 0 {
+		if _, err := reader.ReadBytes('\n'); err != nil {
+			return time.Time{}, false, nil
+		}
+	}
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if ts, ok := parseEntryTime(bytes.TrimRight(line, "\r\n")); ok {
+				return ts, true, nil
+			}
+		}
+		if err != nil {
+			// io.EOF here just means we ran out of window, not out of file.
+			return time.Time{}, false, nil
+		}
+	}
+}
+
+// scan walks entries forward from offset, writing the ones the selector
+// accepts, and stops once the file has clearly moved past end.
+func (r *activeFileReader) scan(ctx context.Context, offset int64, sel logSelector, end time.Time, w io.Writer) error {
+	reader := bufio.NewReaderSize(r.f, readBufSize)
+
+	// Unless we began at the very start of the file, the first line is a
+	// fragment of whichever line straddles offset.  Drop it.
+	if offset > 0 {
+		if _, err := reader.ReadBytes('\n'); err != nil {
+			return nil
+		}
+	}
+
+	var (
+		current  *logEntry
+		stopTime time.Time
+	)
+	if !end.IsZero() {
+		stopTime = end.Add(scanTolerance)
+	}
+
+	// flush emits the entry just completed, if the selector wants it.
+	flush := func() error {
+		if current == nil {
+			return nil
+		}
+		e := current
+		current = nil
+		if !sel.Matches(e) {
+			return nil
+		}
+		_, err := w.Write(e.Raw)
+		return err
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		line, readErr := reader.ReadBytes('\n')
+
+		// ReadBytes only returns an error when it did not find the delimiter,
+		// so a non-nil error with bytes in hand means the writer was caught
+		// mid-flush.  A fragment is not yet a record, so it is not ours to
+		// interpret: drop it and finish with what we already have.
+		partial := readErr != nil && len(line) > 0
+
+		if len(line) > 0 && !partial {
+			if ts, ok := parseEntryTime(bytes.TrimRight(line, "\r\n")); ok {
+				if err := flush(); err != nil {
+					return err
+				}
+				if !stopTime.IsZero() && ts.After(stopTime) {
+					// Far enough past the window that the rest of the file
+					// cannot plausibly belong to it.
+					return nil
+				}
+				current = &logEntry{Timestamp: ts, Raw: line}
+			} else if current != nil && len(current.Raw)+len(line) <= maxEntrySize {
+				// Continuation of the entry above -- a stack trace, or a
+				// message containing a newline.  It shares that entry's fate.
+				current.Raw = append(current.Raw, line...)
+			}
+		}
+
+		if readErr != nil {
+			if readErr == io.EOF {
+				return flush()
+			}
+			return errors.Wrapf(readErr, "unable to read log file %s", r.path)
+		}
+	}
+}

--- a/log_exports/logging_source.go
+++ b/log_exports/logging_source.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /***************************************************************
  *
  * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
@@ -330,7 +332,7 @@ func (r *activeFileReader) Coverage(ctx context.Context) (time.Time, bool, error
 	}
 
 	// The scan is bounded: normally the very first line is an entry, but a
-	// file whose head is unparseable garbage must not make every request walk
+	// file whose head is unparsable garbage must not make every request walk
 	// it end to end looking for one.  Giving up reports "covers nothing",
 	// which errs in the safe direction -- the response becomes no-store rather
 	// than immutable.

--- a/log_exports/logging_source_test.go
+++ b/log_exports/logging_source_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /***************************************************************
  *
  * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
@@ -220,7 +222,7 @@ func TestActiveFileSourceCoverage(t *testing.T) {
 		assert.Equal(t, base, oldest.UTC())
 	})
 
-	t.Run("skips leading unparseable lines", func(t *testing.T) {
+	t.Run("skips leading unparsable lines", func(t *testing.T) {
 		src := writeLog(t, "not a log line at all\n"+logLine(base, "info", "first"))
 		oldest, ok := coverageOf(t, src)
 		require.True(t, ok)

--- a/log_exports/logging_source_test.go
+++ b/log_exports/logging_source_test.go
@@ -1,0 +1,400 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package log_exports
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedClock returns a now() that never moves, so the settle margin and the
+// cache-directive rules can be asserted exactly.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// logLine renders one entry the way logrus' TextFormatter writes it to the log
+// file: `time` first and quoted, since an RFC3339 timestamp contains colons.
+func logLine(ts time.Time, level, msg string) string {
+	return fmt.Sprintf("time=%q level=%s msg=%q\n", ts.Format(time.RFC3339), level, msg)
+}
+
+// writeLog puts content in a temp file and returns a source reading it.
+func writeLog(t *testing.T, content string) *activeFileSource {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "pelican.log")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0600))
+	return &activeFileSource{path: p}
+}
+
+// readWindow runs a selector over a source and returns what was streamed.
+func readWindow(t *testing.T, src logSource, sel logSelector) string {
+	t.Helper()
+	reader, err := src.Open(context.Background())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reader.Close()) }()
+	var sb strings.Builder
+	require.NoError(t, reader.Read(context.Background(), sel, &sb))
+	return sb.String()
+}
+
+// coverageOf opens a source and reports its coverage.
+func coverageOf(t *testing.T, src logSource) (time.Time, bool) {
+	t.Helper()
+	reader, err := src.Open(context.Background())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reader.Close()) }()
+	oldest, ok, err := reader.Coverage(context.Background())
+	require.NoError(t, err)
+	return oldest, ok
+}
+
+func TestTimeWindowSelectorCacheable(t *testing.T) {
+	now := time.Date(2026, 8, 20, 18, 30, 0, 0, time.UTC)
+
+	closed := &timeWindowSelector{
+		start: time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC),
+		end:   time.Date(2026, 8, 20, 16, 0, 0, 0, time.UTC),
+		now:   fixedClock(now),
+	}
+	assert.True(t, closed.Cacheable(), "a finished hour never changes again")
+
+	// The subtle case: an absolute path is not automatically immutable.  The
+	// 18:00 bucket fetched at 18:30 is a prefix of an hour still being
+	// written, and caching it would pin a truncated hour.
+	inProgress := &timeWindowSelector{
+		start: time.Date(2026, 8, 20, 18, 0, 0, 0, time.UTC),
+		end:   time.Date(2026, 8, 20, 19, 0, 0, 0, time.UTC),
+		now:   fixedClock(now),
+	}
+	assert.False(t, inProgress.Cacheable(),
+		"the current hour is still being appended to and must not be cached")
+}
+
+func TestActiveFileSourceWindowFiltering(t *testing.T) {
+	base := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+
+	src := writeLog(t, strings.Join([]string{
+		logLine(base.Add(-90*time.Minute), "info", "long before"),
+		logLine(base.Add(-time.Minute), "info", "just before"),
+		logLine(base.Add(time.Minute), "info", "inside one"),
+		logLine(base.Add(30*time.Minute), "warning", "inside two"),
+		logLine(base.Add(90*time.Minute), "info", "after"),
+	}, ""))
+
+	sel := &timeWindowSelector{
+		start: base,
+		end:   base.Add(time.Hour),
+		now:   fixedClock(base.Add(3 * time.Hour)),
+	}
+	got := readWindow(t, src, sel)
+
+	assert.Contains(t, got, "inside one")
+	assert.Contains(t, got, "inside two")
+	assert.NotContains(t, got, "just before")
+	assert.NotContains(t, got, "long before")
+	assert.NotContains(t, got, "after", "the window is half-open: [start, end)")
+}
+
+func TestActiveFileSourceContinuationLines(t *testing.T) {
+	base := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+
+	// A panic's stack trace arrives as lines with no time= field.  They belong
+	// to the entry above and have to share its fate, or a caller gets a
+	// message with its traceback silently removed.
+	src := writeLog(t, strings.Join([]string{
+		logLine(base.Add(-time.Hour), "error", "excluded parent"),
+		"\tgoroutine 1 [running]: excluded frame\n",
+		logLine(base.Add(time.Minute), "error", "included parent"),
+		"\tgoroutine 2 [running]: included frame\n",
+		"\tmain.main() included frame two\n",
+	}, ""))
+
+	got := readWindow(t, src, &timeWindowSelector{
+		start: base,
+		end:   base.Add(time.Hour),
+		now:   fixedClock(base.Add(3 * time.Hour)),
+	})
+
+	assert.Contains(t, got, "included parent")
+	assert.Contains(t, got, "included frame")
+	assert.Contains(t, got, "included frame two")
+	assert.NotContains(t, got, "excluded parent")
+	assert.NotContains(t, got, "excluded frame",
+		"a continuation line must be excluded along with the entry it belongs to")
+}
+
+func TestActiveFileSourcePartialTrailingLine(t *testing.T) {
+	base := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+
+	// The async writer flushes on byte thresholds, so a reader can catch the
+	// tail mid-line.  A fragment is not yet a record; treating it as one would
+	// hand the caller a truncated entry.
+	content := logLine(base.Add(time.Minute), "info", "complete entry") +
+		`time="2026-08-20T15:30:00Z" level=info msg="truncated mid`
+
+	src := writeLog(t, content)
+	got := readWindow(t, src, &timeWindowSelector{
+		start: base,
+		end:   base.Add(time.Hour),
+		now:   fixedClock(base.Add(3 * time.Hour)),
+	})
+
+	assert.Contains(t, got, "complete entry")
+	assert.NotContains(t, got, "truncated mid",
+		"a line still being written must be dropped, not served half-formed")
+}
+
+func TestActiveFileSourceOutOfOrderTimestamps(t *testing.T) {
+	base := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+
+	// Concurrent goroutines and clock steps can transpose neighbouring
+	// entries.  A scan that stopped at the first entry past the window would
+	// silently drop everything after the transposition.
+	src := writeLog(t, strings.Join([]string{
+		logLine(base.Add(10*time.Minute), "info", "first"),
+		logLine(base.Add(61*time.Minute), "info", "briefly past the end"),
+		logLine(base.Add(20*time.Minute), "info", "back inside the window"),
+		logLine(base.Add(30*time.Minute), "info", "still inside"),
+	}, ""))
+
+	got := readWindow(t, src, &timeWindowSelector{
+		start: base,
+		end:   base.Add(time.Hour),
+		now:   fixedClock(base.Add(3 * time.Hour)),
+	})
+
+	assert.Contains(t, got, "first")
+	assert.Contains(t, got, "back inside the window",
+		"an out-of-order entry must not truncate the scan")
+	assert.Contains(t, got, "still inside")
+	assert.NotContains(t, got, "briefly past the end")
+}
+
+func TestActiveFileSourceMissingFile(t *testing.T) {
+	base := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+
+	// Logs only reach a file once FlushLogs pushes them there, so a server
+	// can be serving before the file exists.  That is an empty answer, not an
+	// error.
+	src := &activeFileSource{path: filepath.Join(t.TempDir(), "absent.log")}
+
+	sel := &timeWindowSelector{start: base, end: base.Add(time.Hour), now: fixedClock(base)}
+	assert.Empty(t, readWindow(t, src, sel))
+
+	_, ok := coverageOf(t, src)
+	assert.False(t, ok, "a missing file covers nothing")
+}
+
+func TestActiveFileSourceCoverage(t *testing.T) {
+	base := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+
+	t.Run("reports the oldest entry", func(t *testing.T) {
+		src := writeLog(t, logLine(base, "info", "first")+logLine(base.Add(time.Hour), "info", "second"))
+		oldest, ok := coverageOf(t, src)
+		require.True(t, ok)
+		assert.Equal(t, base, oldest.UTC())
+	})
+
+	t.Run("skips leading unparseable lines", func(t *testing.T) {
+		src := writeLog(t, "not a log line at all\n"+logLine(base, "info", "first"))
+		oldest, ok := coverageOf(t, src)
+		require.True(t, ok)
+		assert.Equal(t, base, oldest.UTC())
+	})
+
+	t.Run("an empty file covers nothing", func(t *testing.T) {
+		src := writeLog(t, "")
+		_, ok := coverageOf(t, src)
+		assert.False(t, ok)
+	})
+
+	t.Run("a garbage head larger than the scan bound covers nothing", func(t *testing.T) {
+		// Coverage is bounded so a pathological file cannot make every request
+		// walk it end to end.  Giving up must land on the safe side: covers
+		// nothing, so responses are no-store rather than immutable.
+		src := writeLog(t, strings.Repeat("x", maxEntrySize+1)+"\n"+logLine(base, "info", "buried"))
+		_, ok := coverageOf(t, src)
+		assert.False(t, ok)
+	})
+}
+
+func TestActiveFileReaderSurvivesRotation(t *testing.T) {
+	base := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+	src := writeLog(t, logLine(base.Add(time.Minute), "info", "pinned entry"))
+
+	// The reason Open exists: coverage and the streamed body must describe the
+	// same bytes even if rotation renames the file mid-request.  The open
+	// descriptor keeps the original contents readable after the rename.
+	reader, err := src.Open(context.Background())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reader.Close()) }()
+
+	require.NoError(t, os.Rename(src.path, src.path+".rotated"))
+
+	oldest, ok, err := reader.Coverage(context.Background())
+	require.NoError(t, err)
+	require.True(t, ok, "the pinned view must still cover what it covered at open time")
+	assert.Equal(t, base.Add(time.Minute), oldest.UTC())
+
+	var sb strings.Builder
+	require.NoError(t, reader.Read(context.Background(), &timeWindowSelector{
+		start: base,
+		end:   base.Add(time.Hour),
+		now:   fixedClock(base.Add(3 * time.Hour)),
+	}, &sb))
+	assert.Contains(t, sb.String(), "pinned entry")
+}
+
+func TestActiveFileSourceSeeksRatherThanScanning(t *testing.T) {
+	// The point of the search: a window at the end of a large file must not
+	// cost a full read.  The most recent servable hour is the likeliest query
+	// and would otherwise be the most expensive one.
+	base := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+
+	var sb strings.Builder
+	const entries = 40000
+	for i := 0; i < entries; i++ {
+		sb.WriteString(logLine(base.Add(time.Duration(i)*time.Second), "info",
+			fmt.Sprintf("padding entry %06d to give the file some size", i)))
+	}
+	src := writeLog(t, sb.String())
+
+	info, err := os.Stat(src.path)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(4*seekSlack),
+		"the fixture must be large enough for the search to have somewhere to go")
+
+	f, err := os.Open(src.path)
+	require.NoError(t, err)
+	defer f.Close()
+	fileReader := &activeFileReader{f: f, path: src.path}
+
+	// Ask for a window near the end of the file.
+	target := base.Add(time.Duration(entries-100) * time.Second)
+	offset, err := fileReader.findOffset(context.Background(), target)
+	require.NoError(t, err)
+
+	assert.Greater(t, offset, int64(0), "a late window must not be read from the start of the file")
+	assert.Less(t, offset, info.Size(), "the offset must stay inside the file")
+
+	// And the seek must not have overshot: reading from it still finds the
+	// window.  This is the half that matters -- a fast answer that misses
+	// entries is worse than a slow one.
+	got := readWindow(t, src, &timeWindowSelector{
+		start: target,
+		end:   target.Add(time.Hour),
+		now:   fixedClock(base.Add(24 * time.Hour)),
+	})
+	assert.Contains(t, got, fmt.Sprintf("padding entry %06d", entries-100))
+	assert.Contains(t, got, fmt.Sprintf("padding entry %06d", entries-1))
+	assert.NotContains(t, got, fmt.Sprintf("padding entry %06d", entries-101),
+		"the entry just before the window must still be excluded")
+}
+
+func TestActiveFileSourceEarlyWindowInLargeFile(t *testing.T) {
+	// The mirror of the previous test: an early window must not require
+	// reading backward from the end.  Correctness is what is asserted here;
+	// the search direction is an implementation detail.
+	base := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+
+	var sb strings.Builder
+	for i := 0; i < 40000; i++ {
+		sb.WriteString(logLine(base.Add(time.Duration(i)*time.Second), "info",
+			fmt.Sprintf("padding entry %06d to give the file some size", i)))
+	}
+	src := writeLog(t, sb.String())
+
+	got := readWindow(t, src, &timeWindowSelector{
+		start: base,
+		end:   base.Add(time.Hour),
+		now:   fixedClock(base.Add(24 * time.Hour)),
+	})
+	assert.Contains(t, got, "padding entry 000000")
+	assert.Contains(t, got, "padding entry 003599")
+	assert.NotContains(t, got, "padding entry 003600", "3600s in is the exclusive end of the window")
+}
+
+func TestLogEntryFieldsAreLazy(t *testing.T) {
+	ts := time.Date(2026, 8, 20, 15, 0, 0, 0, time.UTC)
+	e := &logEntry{
+		Timestamp: ts,
+		Raw:       []byte(logLine(ts, "info", "hello world") + "\tcontinuation\n"),
+	}
+
+	// Nothing has asked for a field, so nothing has been tokenised.  A time
+	// window query never needs the fields, and paying to split every
+	// key=value pair on every line of a large file would be work spent for
+	// a question nobody asked.
+	assert.False(t, e.parsed, "fields must not be parsed until they are requested")
+
+	level, ok := e.Field("level")
+	require.True(t, ok)
+	assert.Equal(t, "info", level)
+	assert.True(t, e.parsed)
+
+	msg, ok := e.Field("msg")
+	require.True(t, ok)
+	assert.Equal(t, "hello world", msg, "a quoted value must come back unquoted")
+
+	_, ok = e.Field("no_such_field")
+	assert.False(t, ok)
+}
+
+func TestParseEntryTime(t *testing.T) {
+	ts := time.Date(2026, 8, 20, 15, 4, 5, 0, time.UTC)
+
+	t.Run("quoted, as logrus writes it", func(t *testing.T) {
+		got, ok := parseEntryTime([]byte(`time="2026-08-20T15:04:05Z" level=info msg="x"`))
+		require.True(t, ok)
+		assert.Equal(t, ts, got.UTC())
+	})
+
+	t.Run("unquoted is accepted too", func(t *testing.T) {
+		got, ok := parseEntryTime([]byte(`time=2026-08-20T15:04:05Z level=info`))
+		require.True(t, ok)
+		assert.Equal(t, ts, got.UTC())
+	})
+
+	t.Run("an offset other than UTC is honoured", func(t *testing.T) {
+		got, ok := parseEntryTime([]byte(`time="2026-08-20T17:04:05+02:00" level=info`))
+		require.True(t, ok)
+		assert.True(t, got.Equal(ts), "entries carry their own offset; matching compares instants")
+	})
+
+	for _, line := range []string{
+		`\tgoroutine 1 [running]:`,
+		`level=info msg="no time field"`,
+		`time="not a timestamp" level=info`,
+		``,
+	} {
+		t.Run("rejects "+line, func(t *testing.T) {
+			_, ok := parseEntryTime([]byte(line))
+			assert.False(t, ok)
+		})
+	}
+}

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -535,10 +535,13 @@ func authMiddleware() gin.HandlerFunc {
 	}
 }
 
-// httpMetricsMiddleware tracks Prometheus HTTP metrics for WebDAV requests.
+// HttpMetricsMiddleware tracks Prometheus HTTP metrics for WebDAV requests.
+// Exported so launchers can attach the same accounting to the origin's other
+// HTTP surfaces (the log export routes); the labels it records are
+// origin-specific, so it must not be reused on other server types.
 // It runs before authMiddleware so that rejected requests are still counted
 // in the Prometheus dashboard (total requests, duration, errors, bytes).
-func httpMetricsMiddleware() gin.HandlerFunc {
+func HttpMetricsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		method := c.Request.Method
@@ -648,7 +651,7 @@ func xrdMonitoringMiddleware() gin.HandlerFunc {
 		}
 
 		// Attach a monitoringTracker to the I/O wrappers (already
-		// installed by httpMetricsMiddleware) so that periodic isXfr
+		// installed by HttpMetricsMiddleware) so that periodic isXfr
 		// records are emitted during long-running transfers.
 		var tracker *monitoringTracker
 		knownSize := c.Request.ContentLength // PUT size; -1 if unknown
@@ -665,7 +668,7 @@ func xrdMonitoringMiddleware() gin.HandlerFunc {
 		c.Next()
 
 		// Read final byte counts from the I/O wrappers. These are the
-		// same wrappers that httpMetricsMiddleware created; they have been
+		// same wrappers that HttpMetricsMiddleware created; they have been
 		// accumulating bytes throughout the entire handler chain.
 		var bytesIn, bytesOut int64
 		if v, ok := c.Get(ctxKeyRequestReader); ok {
@@ -1359,7 +1362,7 @@ func RegisterHandlers(engine *gin.Engine, directorEnabled bool) error {
 
 		// Create a route group for this prefix
 		group := engine.Group(routePrefix)
-		group.Use(httpMetricsMiddleware())
+		group.Use(HttpMetricsMiddleware())
 		group.Use(authMiddleware())
 		group.Use(xrdMonitoringMiddleware())
 		group.Use(listingModeMiddleware())

--- a/origin_serve/http_metrics_test.go
+++ b/origin_serve/http_metrics_test.go
@@ -45,7 +45,7 @@ func setupTestServer() *gin.Engine {
 	router := gin.New()
 
 	// Add metrics middleware
-	router.Use(httpMetricsMiddleware())
+	router.Use(HttpMetricsMiddleware())
 
 	// Add test handlers
 	router.GET("/test", func(c *gin.Context) {

--- a/origin_serve/metrics_e2e_test.go
+++ b/origin_serve/metrics_e2e_test.go
@@ -261,9 +261,9 @@ func TestMetricsPrometheusIntegration(t *testing.T) {
 }
 
 // TestMetricsRecordedForAuthRejection is a regression test for the middleware
-// ordering in RegisterHandlers. httpMetricsMiddleware must run before
+// ordering in RegisterHandlers. HttpMetricsMiddleware must run before
 // authMiddleware so that auth-rejected requests (401/403) are still counted
-// in Prometheus. If the ordering were reversed, httpMetricsMiddleware would
+// in Prometheus. If the ordering were reversed, HttpMetricsMiddleware would
 // never execute for rejected requests and the dashboard would undercount.
 func TestMetricsRecordedForAuthRejection(t *testing.T) {
 	metrics.HttpRequestsTotal.Reset()

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -910,6 +910,11 @@ func mapPrometheusPath(c *gin.Context) string {
 		url = "/api/v1.0/director/healthTest/:testfile"
 		return url
 	}
+	// Log export names one time window per path, so left alone every hour ever
+	// requested would become its own series.
+	if strings.HasPrefix(url, "/pelican/logging/") {
+		return "/pelican/logging/:sitename/:object"
+	}
 	// Only keeps two level depth for object access
 	if strings.HasPrefix(url, "/api/v1.0/director/object/") {
 		objectPath := strings.TrimPrefix(path.Clean(url), "/api/v1.0/director/object/")


### PR DESCRIPTION
Closes #3431 

## What this does

Adds the first two slices of the log-export project: servers that opt in
via `Logging.LogExports.Enabled` serve their own log file over HTTP as
virtual objects under a reserved federation namespace,

    /pelican/logging/{sitename}/{year}/{month}/{day}/{hour}[.log]

so operators and federation admins can fetch a server's logs with the same
client, tokens, and authorization model as data — no shell access to the
host required. Each URL names one finished UTC hour of the log, assembled
on demand from the file at `Logging.LogLocation`.

The feature is off by default and registers no routes when disabled.

## What's included

- Config layer: `Logging.LogExports.{Enabled,AllowFederationAdmin}`,
  `Registry.EnableAutoLoggingRegistration`, and startup validation
  (`ValidateLogExportsConfig`) that fails fast on a misconfigured log
  location.
- A new server-type-agnostic `log_exports` package. Origins mount it now;
  the cache side (Stage 2) is planned to be the same registration call
  from the cache launcher. Anything server-specific (metrics middleware,
  standard headers) is supplied by the launcher.
- The handler itself: GET and HEAD (the Director's presence check stats
  with HEAD), streaming responses, a small concurrency semaphore, and
  hierarchical token-scope authorization — a federation admin's
  `storage.read:/` legitimately covers every logging namespace, which an
  exact-string scope check would refuse. Authorization runs before the
  request is interpreted.
- A Prometheus label collapse so the per-hour URL space doesn't mint one
  metric series per hour ever requested.

## Design notes for reviewers

Every response this endpoint serves is immutable, by construction:

- An hour is refused (404, `no-store`) until it has ended and settled
  (5 min past the hour, giving the async writer time to flush). Serving
  earlier would let a cache permanently pin a truncated hour.
- Cacheability also requires proof the active file still covers the
  window; an hour that rotation emptied is served `no-store` rather than
  pinning an empty `immutable` answer. Coverage and the streamed body
  come from a single opened descriptor so rotation can't split them
  mid-request.
- A server-side read failure mid-stream aborts the connection rather than
  finishing with clean framing, so a truncated body can't be mistaken for
  the whole window.

Because nothing servable can change, caches need no special routing rules
— there is deliberately no `/latest` or in-progress-hour endpoint (recent
lines are already served better by the in-memory buffer behind
`/api/v1.0/logs/tail` and the web UI log viewer).

The path grammar is frozen: UTC, fixed-width zero-padded segments (one
URL per window), optional `.log` suffix, and a reserved non-numeric first
segment so job-UUID selection can be added later without route changes.

## Security considerations

Enabling this makes everything the server logs readable by any holder of
a `storage.read` token scoped to the logging namespace (or `/`, for
federation admins when `AllowFederationAdmin` is on). Existing on-disk
redaction only covers JWT-shaped tokens in specific fields; log hygiene
becomes an access-control surface, and a later the admin docs slice will
carry that warning.

