### PR TITLE
Add Groups/Users/Collections/Shares Documentation

### DIFF
--- a/docs/app/_meta.js
+++ b/docs/app/_meta.js
@@ -14,6 +14,7 @@ export default {
 	"getting-started": "Getting Started",
 	"getting-data-with-pelican": "Getting Data with Pelican",
 	"federating-your-data": "Federating Your Data",
+	"managing-data-access": "Managing Data Access",
 	"operating-a-federation": "Operating a Federation",
 	"managing-your-server": "Managing Your Server",
 	"monitoring-pelican-services": "Monitoring Pelican Services",

--- a/docs/app/managing-data-access/_meta.js
+++ b/docs/app/managing-data-access/_meta.js
@@ -1,6 +1,6 @@
 export default {
-    "access-control-model": "How Access Control Works",
+    "collections-and-shares": "Managing Access to a Collection",
     "users-and-groups": "Managing Users and Groups",
-    "collections-and-shares": "Collections and Shares",
     "permissions-reference": "Permissions Reference",
+    "access-control-model": "How Access Control Works",
 }

--- a/docs/app/managing-data-access/_meta.js
+++ b/docs/app/managing-data-access/_meta.js
@@ -1,0 +1,6 @@
+export default {
+    "access-control-model": "How Access Control Works",
+    "users-and-groups": "Managing Users and Groups",
+    "collections-and-shares": "Collections and Shares",
+    "permissions-reference": "Permissions Reference",
+}

--- a/docs/app/managing-data-access/access-control-model/page.mdx
+++ b/docs/app/managing-data-access/access-control-model/page.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'nextra/components'
 # How Access Control Works
 
 A Pelican server answers two questions about every request: who is asking, and are they allowed.
-This page explains how it answers them, so the tasks on the other pages in this section read as one model rather than a list of buttons.
+This page explains how it answers them.
 For the authoritative "who may do what", go to the [Permissions Reference](/managing-data-access/permissions-reference).
 
 ## What access control is built from
@@ -17,202 +17,126 @@ A **share** is a child collection an ordinary user creates to hand part of their
 Authentication produces a user; authorization is always evaluated from the scopes and group memberships that user currently has, never from anything carried in the credential itself.
 That is why revoking a group membership or a scope takes effect on the next request rather than when a token expires.
 
-| Term | Definition | What it is NOT |
-|---|---|---|
-| User | A server-local record for a person or robot account, holding a username, a display name, and one or more linked login identities. | Not a permission. Having a user record grants nothing by itself. |
-| Username | The machine-readable handle (`bockelman`). The only identity string authorization ever matches on. | Not the display name, not the OIDC subject, not the internal ID. |
-| Display name | The human label shown in the interface (`Brian Bockelman`). Self-editable. | Never used for an authorization decision. |
-| Internal ID | An opaque generated string used to address a record in URLs and API paths. | Not a credential and not an authorization handle; knowing it grants nothing. |
-| Identity | An (issuer, subject) pair used to log in. A user may have several; each pair belongs to at most one user. | Not used for authorization. A matching subject never confers a matching username's privileges. |
-| Group | A named set of users. Groups are what ACLs, admin lists, and authorization templates are written against. | Not a permission by itself, and not a folder — groups do not contain data. |
-| Group owner | The one user who may rename ownership, delegate an administrator, delete the group, and who cannot leave it. | Not necessarily the creator; creating a group does not by itself confer ongoing authority. |
-| Group administrator | A user or a group delegated day-to-day membership and metadata management on a group. | Cannot transfer ownership or delete the group. |
-| Auth-template eligibility | A per-group flag that decides whether the group's *name* may match `Issuer.AuthorizationTemplates` and the `Server.*AdminGroups` lists. | Not a permission the group holds; it is permission for the group's name to be trusted as bearer authority. |
-| Scope | A named capability (`server.admin`, `server.user_admin`, `server.collection_admin`, `web_ui.access`, `pelican.log_read`, …) attached to a user or a group. | Not a group and not a token claim you can hand-edit; the management API only accepts scopes from the user-grantable catalogue. |
-| Effective scopes | The union of a user's direct scope grants, the grants on every group they belong to, and the grants implied by the operator's admin-list configuration. | Not a stored column — it is recomputed on every request. |
-| Collection | A prefix inside an exported namespace plus its ACLs, visibility, owner, and optional admin group. | Not a directory, not a dataset object, and not a namespace — the export must already exist. |
-| Collection owner | The single user responsible for a collection. The only principal who may transfer or delete it. | Not the same as the admin group, which can do everything except transfer and delete. |
-| Collection ACL | A row granting a named group `read` or `write` on the collection until an optional expiry. | Not a per-user grant — per-user access is expressed through the implicit `user-<username>` group. |
-| `@authenticated` | The virtual ACL target meaning "every signed-in caller". | Not a real group; it never appears in a token's group claim and cannot be created or joined. |
-| Share | A child collection created by a user who holds read access on the parent, delegating a subset of that access to others. | Not a copy of the data, not a public link, and not something you can create on a multi-user origin backend. |
-| Share owner | The user who created the share; data reached through the share is served as this user. | Not the parent collection's owner. |
-| Invite link | A single-use or time-bounded token that, when redeemed, joins a group, sets a password, or transfers collection ownership. | Not a login credential and not an email — Pelican mints the link; a human delivers it. |
-| AUP | The Acceptable Use Policy a user must accept before using the management surfaces. | Not a permission, and not something an administrator can accept on a user's behalf except by clearing and re-prompting. |
-
 ## Who you are, and what you may do
 
 ### Users are for authentication, not authorization
 
-A user record exists so the server can recognize you across sessions and attribute actions to you; it carries no permissions of its own.
+An account exists so the server can recognize you across sessions and attribute actions to you; it carries no permissions of its own.
 Most accounts appear by themselves on first sign-in, which is safe precisely because existence grants nothing.
-Each user has one or more identities, an (issuer, subject) pair per login method, and an identity proves you are the same person as last time and nothing more.
+Each user has one or more identities — an (issuer, subject) pair per login method — and an identity proves you are the same person as last time and nothing more.
 A pair belongs to at most one user, so accounts cannot be quietly shared, and a subject that resembles somebody's name never confers that person's privileges.
 
 Only the username is matched when the server decides whether you may act.
-The display name is a label for humans, and the internal ID is a routing handle that appears in URLs and API paths because something has to address the record.
+The display name is a label for humans, and the internal ID is an identifier that appears in URLs because something has to address the record.
 
 That has a consequence worth knowing before you edit a configuration file.
 The username-matched administrator lists, such as [`Server.UIAdminUsers`](/parameters#Server-UIAdminUsers), compare against the server-managed username only, so an entry that is an OIDC subject grants nothing at all.
-Pelican scans those lists at startup and logs an error naming every entry that can never match a username, so the lockout appears in your logs rather than as a mysterious login denial.
 Administrator access for people identified by their identity provider comes from [`Server.AdminGroups`](/parameters#Server-AdminGroups) instead, which matches on group names.
 
 ### Groups are how authorization is written down
 
-Because users hold no permissions, everything that grants permission is written against a group: collection ACLs, admin lists, and authorization templates all name groups.
+Because users hold no permissions, everything that grants permission is written against a group: collection access grants, admin lists, and authorization templates all name groups.
 Membership arrives from two directions — Pelican's own records, and the group names your login token asserts, filtered to names this server actually knows.
 The two are unioned, which is why someone added to a group in the web interface sees the effect immediately instead of waiting for their identity provider to catch up.
 
 Two names are synthesized rather than created.
-Every user implicitly belongs to a personal group named `user-` followed by their username, which is how a per-user ACL grant is expressed without a second kind of ACL row.
-`@authenticated` is the virtual target meaning "every signed-in caller", added to your group list whenever you have any identity at all; it begins with `@`, a character identifier validation rejects, so it can never collide with a real group name and nobody can create or join it.
+Every user implicitly belongs to a personal group named `user-` followed by their username, which is how you grant access to one person without a second kind of grant.
+`@authenticated` is the virtual target meaning "every signed-in caller", added to your group list whenever you have any identity at all.
+Neither can be created or joined, and neither can collide with a real group name.
 
 Within a group there are three positions.
 The owner may transfer ownership, delegate an administrator, and delete the group, and is the one member who cannot simply leave.
 The administrator — a user or another group — handles membership and metadata day to day but cannot transfer or delete.
 Members are everyone else and can always leave, which is why membership is never used to express a restriction.
 
-Group names are unique across the server and cannot begin with `user-`.
-Each group also carries an auth-template-eligibility flag, explained under [Where a scope can come from](#where-a-scope-can-come-from).
 See [Managing Users and Groups](/managing-data-access/users-and-groups) for how to create and run one.
 
 ### Scopes name what an account may do
 
-A scope is a named capability attached to a user record or a group record, and four of them shape this section.
+A scope is a named capability attached to an account or a group, and four of them shape this section.
 `web_ui.access` is the baseline: the account may sign in and use the interface at all.
-`server.user_admin` covers managing other people's accounts, `server.collection_admin` covers creating collections, and `server.admin` is the master scope that implies both — a system administrator is never granted the other two separately.
+`server.user_admin` covers managing other people's accounts, `server.collection_admin` covers creating collections, and `server.admin` is the master scope that implies both.
 
 Scopes are not free-form.
-The management API accepts only scopes from a fixed, user-grantable catalogue, and the effective-scope computation filters its output against that same catalogue.
-That is a deliberate seam: a data-access scope such as `storage.read` is not in the catalogue, so no amount of granting through the management surface can hand one out.
-Data-plane scopes are minted by the issuer, from collection ACLs, and by no other route.
+The management API accepts only scopes from a fixed, user-grantable catalogue.
+A data-access scope such as `storage.read` is not in the catalogue, so no amount of granting through the management API can hand one out.
+Data-plane scopes are minted by the issuer, from collection access grants, and by no other route.
 The full catalogue is on the [Permissions Reference](/managing-data-access/permissions-reference#management-scopes).
 
 ### Where a scope can come from
 
-Your effective scopes are not a stored column; they are recomputed on every request from several sources unioned together.
-Direct grants on your user record come first, then grants on any group you belong to through Pelican's own records, then grants on any group your login token asserts by name.
-On top of those sit the operator's configuration lists: the username-matched and group-matched admin settings, plus the built-in `admin` account.
-Finally `server.admin`, from wherever it came, pulls in the two subordinate scopes.
+Your effective scopes are not stored anywhere; they are recomputed on every request from several sources unioned together: direct grants on your account, grants on any group you belong to, grants on any group your login token asserts by name, and the operator's configuration lists.
 
 The two kinds of source differ in how you take a permission back.
-Configuration-derived grants are evaluated live against the file and never mirrored into the database, so editing the configuration withdraws them; database grants are withdrawn by revoking the grant.
+Configuration-derived grants are evaluated live against the file, so editing the configuration withdraws them; database grants are withdrawn by revoking the grant.
 Neither undoes the other, and a scope that arrived from configuration will not appear in a user's list of direct grants.
 Two smaller behaviors follow the same "recompute, don't remember" principle.
 New accounts receive the baseline named by [`Server.NewUserDefaultScopes`](/parameters#Server-NewUserDefaultScopes) at creation time only.
 API tokens re-intersect against the creator's *current* effective scopes on every use, so a long-lived credential shrinks as its owner's privileges shrink.
 
 Group creation itself is open.
-Any signed-in user can create a group, because users need groups of their own to write collection ACLs and share ACLs against.
+Any signed-in user can create a group, because users need groups of their own to grant access on their collections and shares.
 What a self-created group cannot do is act as bearer authority: [`Issuer.AuthorizationTemplates`](/parameters#Issuer-AuthorizationTemplates) and the [`Server.AdminGroups`](/parameters#Server-AdminGroups) settings match on a group's *name*, so a group you named yourself must not automatically start matching them.
 Each group therefore carries an auth-template-eligibility flag, and only a system administrator can turn it on for an existing group.
-Groups created before group creation was opened to everyone are eligible by default.
-Collection ACLs do not consult the flag — those rows are set on the collection itself, and group names are unique.
+Collection access grants do not consult the flag.
 
 ## How access to data is granted
 
 ### Collections control access inside a namespace you already export
 
 Exporting storage says which prefixes this origin serves and whether reads and writes are permitted there at all.
-A collection is the finer-grained layer on top: a prefix *inside* an already-exported namespace, plus the ACLs saying which groups may read or write it.
-It may be a sub-path rather than the whole export, so one export can carry many collections, and the path is canonicalized before it is checked and stored because that same string is later spliced into token scopes.
+A collection is the finer-grained layer on top: a prefix *inside* an already-exported namespace, plus the grants saying which groups may read or write it.
+It may be a sub-path rather than the whole export, so one export can carry many collections.
 
 A collection cannot widen what the export permits.
-If the export does not allow writes, no ACL row on a collection inside it produces a usable write.
+If the export does not allow writes, no grant on a collection inside it produces a usable write.
 Collections narrow and delegate; they never enlarge.
 
 Three kinds of authority attach to a collection.
-The owner is one user, responsible for it, and the only principal who can transfer or delete it.
-The admin group runs it day to day — metadata, descriptive fields, ACLs, and reassigning the admin group itself — and can do everything except transfer and delete.
-ACL rows grant `read` or `write` to a named group, optionally until an expiry, after which the row simply stops matching; holding `write` is authority over the collection's data, not over its access control.
+The owner is one user, responsible for it, and the only one who can transfer or delete it.
+The admin group runs it day to day and can do everything except transfer and delete.
+Each grant gives one group `read` or `write`, optionally until an expiry; holding `write` is authority over the collection's data, not over its access control.
 
-Visibility is a separate axis: a public collection has its existence visible to callers who hold no ACL on it, and a private one does not appear in their listing at all.
+Visibility is a separate axis: a public collection has its existence visible to callers who hold no access to it, and a private one does not appear in their listing at all.
 Visibility grants no data access, and `@authenticated` — which does grant data access to every signed-in caller — does not make a collection public.
-See [Collections and Shares](/managing-data-access/collections-and-shares) for the tasks.
+
+Your role on a collection is what becomes data access: owner or `write` yields read, modify, and create on that collection's namespace, `read` yields read alone, and no role yields nothing, because there is no implicit floor.
+See [Managing Access to a Collection](/managing-data-access/collections-and-shares) for the tasks, and [Data access](/managing-data-access/permissions-reference#data-access) for the full mapping.
 
 ### Shares delegate access you already hold
 
 Creating a collection needs `server.collection_admin`, and most people who want to share data do not have it and should not need it — which is what shares are for.
 A share is a child collection created by someone who already holds read access on the parent, once the parent's owner has turned sharing on.
-The creator owns the share, so they can write ACLs on it exactly as a collection owner would, without gaining any new privilege on the parent.
+The creator owns the share, so they can grant access on it exactly as a collection owner would, without gaining any new privilege on the parent.
 A share's prefix has to be the parent's namespace or a path beneath it, shares start private, and a share of a share is refused.
+
+Data reached through a share is served as the share's *owner*, not as the person presenting the token.
+That is what makes delegated access work, and it is why the share owner stays accountable for everything read or written through the share.
 
 Access through a share is always the weaker of two things: what the share grants its recipient, and what the share's owner can currently do on the parent collection.
 That intersection is recomputed each time a token is *issued*, so if the share owner is downgraded from write to read — or loses access to the parent altogether — every token minted through the share from that point on is clamped or emptied.
 A share cannot be used to delegate access its owner no longer has.
 
+<Callout type="warning">
 Refreshing an existing token does not re-run the intersection.
 The issuer re-grants the scopes already stored on the session, so an already-issued token keeps its original access until it expires and a new authorization is performed.
 Plan for access changes to take effect on the next issuance, not immediately.
+</Callout>
 
 Shares are not supported when the origin runs a multi-user POSIX backend ([`Origin.Multiuser`](/parameters#Origin-Multiuser)).
 Serving share data means acting as the share's owner, and the multi-user backend cannot safely re-target the operating-system identity it serves a request under.
-Creating a share on such an origin is refused with `409`, and if multi-user mode is turned on after shares already exist, any token carrying `share.access` is rejected outright rather than quietly falling back to the presenter's identity.
 
-## How a request is decided
+## Three checks decide every request
 
-### How an access token is assembled
+Knowing which check refused you is usually enough to fix the problem.
 
-When the issuer mints an access token for you, it walks every collection you can reach and turns your role on each one into scopes.
-
-```mermaid
-flowchart TD
-  U["Who you are: username + identities"]
-  G["Your groups: records, login claim,<br/>personal group, @authenticated"]
-  U --> G
-  U --> SC["Scope grants on you and your groups,<br/>plus config-derived grants"]
-  G --> SC
-  G --> ACL["Collection ACL rows that match<br/>-> role: read, write, or owner"]
-  ACL --> ST["Namespace scopes:<br/>storage.read / .modify / .create"]
-  ACL --> SH["If the row is a share: clamp to the<br/>owner's parent role, add share.access"]
-  SC --> TOK["Access token"]
-  ST --> TOK
-  SH --> TOK
-```
-
-Owner or `write` on a collection yields read, modify, and create on that collection's namespace; `read` yields read alone; no role yields nothing, because there is no implicit floor.
-The namespace is made issuer-relative before it goes into a scope, so it lines up with the per-namespace tokens the storage layer validates, and a collection outside this issuer's namespace gets management-plane scopes only.
-The token's group claim echoes the group names that actually matched an ACL, minus `@authenticated` — emitting a virtual target would invite downstream consumers to treat it as a real group.
-
-A token issued for a share carries `share.access:/<share-id>` alongside its storage scopes.
-That scope tells the origin to serve objects under the share's prefix as the share's *owner* rather than as the person presenting the token — which is what makes delegated access work.
-It is minted by the issuer only; it is not a scope you can grant to a user or a group.
-The full role-to-scope mapping is tabulated under [Data access](/managing-data-access/permissions-reference#data-access).
-
-### Five roles, from system administrator to ordinary user
-
-A **system administrator** holds `server.admin` and reaches every management surface: accounts, groups, scope grants, identity links, the Acceptable Use Policy, and every collection.
-It is the only role that can grant a scope, and the only one that can make an existing group eligible for authorization templates and admin lists ([Roles](/managing-data-access/permissions-reference#roles)).
-
-A **user administrator** holds `server.user_admin` and runs the account lifecycle: creating accounts, relabeling them, activating and deactivating them, minting password and onboarding invites, and recording or clearing policy acceptance.
-Their reach stops short of granting scopes, editing identity links, and acting on a system administrator's account ([User administration](/managing-data-access/permissions-reference#user-administration)).
-
-A **collection administrator** holds `server.collection_admin`, which buys exactly one thing nobody else can do: creating a collection.
-Everything after that — running it, writing its ACLs, handing it to a PI — is ordinary collection authority ([Collection administration](/managing-data-access/permissions-reference#collection-administration)).
-
-An **owner**, of a group or of a collection, holds authority that comes from being named on the row rather than from any scope: narrow, but total within its object.
-An admin group can do nearly everything an owner can, minus transfer and delete, which is what makes it safe to delegate ([Group administration](/managing-data-access/permissions-reference#group-administration)).
-
-An **ordinary user** holds `web_ui.access` and nothing else, which is more than it sounds.
-They can create groups and own them, manage their own account, hold ACL grants, and — where sharing is enabled — create and run shares ([Share administration](/managing-data-access/permissions-reference#share-administration)).
-
-### Three checks run on every request
-
-Three checks run in sequence, and knowing which one refused you is usually enough to fix the problem.
-
-The **login gate** establishes who you are and whether your account is still active, resolving your credential to a user record and collecting the group names your login asserts.
+The **login gate** establishes who you are and whether your account is still active.
 A deactivated account fails here on its next request, without waiting for a token to expire.
 
-The **management-API gate** compares your effective scopes against what the route requires, and the Acceptable Use Policy gate sits alongside it.
-If your server has an Acceptable Use Policy configured, you must accept the current version before you can use the user, group, or self-service management APIs.
-Until you do, those endpoints return `403` with `requires_aup: true` and the version you need to accept, and the web interface sends you to the acceptance page.
-Three things stay reachable so you can get unstuck: reading the policy, accepting it, and signing out.
-Editing the policy is also exempt, so rotating it cannot lock out the administrator who rotated it.
-[Acceptable Use Policy gate](/managing-data-access/permissions-reference#acceptable-use-policy-gate) lists which surfaces are gated and how the requirement is switched off.
+The **management-API gate** compares your effective scopes against what the route requires.
+The Acceptable Use Policy gate sits alongside it: where a policy is configured, you must accept the current version before the user, group, and self-service APIs will answer you.
+Reading the policy, accepting it, and signing out stay reachable so an unsigned user can get unstuck.
+See [Acceptable Use Policy gate](/managing-data-access/permissions-reference#acceptable-use-policy-gate) for which surfaces are gated.
 
-The **row-level check** decides whether you may act on this particular record: are you its owner, are you in its admin group, does an ACL row match one of your groups, and is that row still within its expiry.
-This is the layer that clamps a share against its owner's current access, and the layer a `write` ACL passes for data but not for ACL editing.
-
-<Callout type="info">
-Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it.
-A `404` on a collection or group you believe exists usually means you lack access, not that it is missing.
-</Callout>
+The **ownership and access check** decides whether you may act on this particular collection or group: are you its owner, are you in its admin group, does a grant match one of your groups, and has that entry expired.
+This is the layer that clamps a share against its owner's current access, and the layer a `write` grant passes for data but not for changing who else has access.

--- a/docs/app/managing-data-access/access-control-model/page.mdx
+++ b/docs/app/managing-data-access/access-control-model/page.mdx
@@ -1,0 +1,218 @@
+import { Callout } from 'nextra/components'
+
+# How Access Control Works
+
+A Pelican server answers two questions about every request: who is asking, and are they allowed.
+This page explains how it answers them, so the tasks on the other pages in this section read as one model rather than a list of buttons.
+For the authoritative "who may do what", go to the [Permissions Reference](/managing-data-access/permissions-reference).
+
+## What access control is built from
+
+A **user** is who you are.
+A **group** is a name that several users answer to.
+A **scope** is a permission the server has attached to a user or to a group.
+A **collection** is a named prefix inside an exported namespace together with the list of groups allowed to read or write it.
+A **share** is a child collection an ordinary user creates to hand part of their own access to someone else.
+
+Authentication produces a user; authorization is always evaluated from the scopes and group memberships that user currently has, never from anything carried in the credential itself.
+That is why revoking a group membership or a scope takes effect on the next request rather than when a token expires.
+
+| Term | Definition | What it is NOT |
+|---|---|---|
+| User | A server-local record for a person or robot account, holding a username, a display name, and one or more linked login identities. | Not a permission. Having a user record grants nothing by itself. |
+| Username | The machine-readable handle (`bockelman`). The only identity string authorization ever matches on. | Not the display name, not the OIDC subject, not the internal ID. |
+| Display name | The human label shown in the interface (`Brian Bockelman`). Self-editable. | Never used for an authorization decision. |
+| Internal ID | An opaque generated string used to address a record in URLs and API paths. | Not a credential and not an authorization handle; knowing it grants nothing. |
+| Identity | An (issuer, subject) pair used to log in. A user may have several; each pair belongs to at most one user. | Not used for authorization. A matching subject never confers a matching username's privileges. |
+| Group | A named set of users. Groups are what ACLs, admin lists, and authorization templates are written against. | Not a permission by itself, and not a folder — groups do not contain data. |
+| Group owner | The one user who may rename ownership, delegate an administrator, delete the group, and who cannot leave it. | Not necessarily the creator; creating a group does not by itself confer ongoing authority. |
+| Group administrator | A user or a group delegated day-to-day membership and metadata management on a group. | Cannot transfer ownership or delete the group. |
+| Auth-template eligibility | A per-group flag that decides whether the group's *name* may match `Issuer.AuthorizationTemplates` and the `Server.*AdminGroups` lists. | Not a permission the group holds; it is permission for the group's name to be trusted as bearer authority. |
+| Scope | A named capability (`server.admin`, `server.user_admin`, `server.collection_admin`, `web_ui.access`, `pelican.log_read`, …) attached to a user or a group. | Not a group and not a token claim you can hand-edit; the management API only accepts scopes from the user-grantable catalogue. |
+| Effective scopes | The union of a user's direct scope grants, the grants on every group they belong to, and the grants implied by the operator's admin-list configuration. | Not a stored column — it is recomputed on every request. |
+| Collection | A prefix inside an exported namespace plus its ACLs, visibility, owner, and optional admin group. | Not a directory, not a dataset object, and not a namespace — the export must already exist. |
+| Collection owner | The single user responsible for a collection. The only principal who may transfer or delete it. | Not the same as the admin group, which can do everything except transfer and delete. |
+| Collection ACL | A row granting a named group `read` or `write` on the collection until an optional expiry. | Not a per-user grant — per-user access is expressed through the implicit `user-<username>` group. |
+| `@authenticated` | The virtual ACL target meaning "every signed-in caller". | Not a real group; it never appears in a token's group claim and cannot be created or joined. |
+| Share | A child collection created by a user who holds read access on the parent, delegating a subset of that access to others. | Not a copy of the data, not a public link, and not something you can create on a multi-user origin backend. |
+| Share owner | The user who created the share; data reached through the share is served as this user. | Not the parent collection's owner. |
+| Invite link | A single-use or time-bounded token that, when redeemed, joins a group, sets a password, or transfers collection ownership. | Not a login credential and not an email — Pelican mints the link; a human delivers it. |
+| AUP | The Acceptable Use Policy a user must accept before using the management surfaces. | Not a permission, and not something an administrator can accept on a user's behalf except by clearing and re-prompting. |
+
+## Who you are, and what you may do
+
+### Users are for authentication, not authorization
+
+A user record exists so the server can recognize you across sessions and attribute actions to you; it carries no permissions of its own.
+Most accounts appear by themselves on first sign-in, which is safe precisely because existence grants nothing.
+Each user has one or more identities, an (issuer, subject) pair per login method, and an identity proves you are the same person as last time and nothing more.
+A pair belongs to at most one user, so accounts cannot be quietly shared, and a subject that resembles somebody's name never confers that person's privileges.
+
+Only the username is matched when the server decides whether you may act.
+The display name is a label for humans, and the internal ID is a routing handle that appears in URLs and API paths because something has to address the record.
+
+That has a consequence worth knowing before you edit a configuration file.
+The username-matched administrator lists, such as [`Server.UIAdminUsers`](/parameters#Server-UIAdminUsers), compare against the server-managed username only, so an entry that is an OIDC subject grants nothing at all.
+Pelican scans those lists at startup and logs an error naming every entry that can never match a username, so the lockout appears in your logs rather than as a mysterious login denial.
+Administrator access for people identified by their identity provider comes from [`Server.AdminGroups`](/parameters#Server-AdminGroups) instead, which matches on group names.
+
+### Groups are how authorization is written down
+
+Because users hold no permissions, everything that grants permission is written against a group: collection ACLs, admin lists, and authorization templates all name groups.
+Membership arrives from two directions — Pelican's own records, and the group names your login token asserts, filtered to names this server actually knows.
+The two are unioned, which is why someone added to a group in the web interface sees the effect immediately instead of waiting for their identity provider to catch up.
+
+Two names are synthesized rather than created.
+Every user implicitly belongs to a personal group named `user-` followed by their username, which is how a per-user ACL grant is expressed without a second kind of ACL row.
+`@authenticated` is the virtual target meaning "every signed-in caller", added to your group list whenever you have any identity at all; it begins with `@`, a character identifier validation rejects, so it can never collide with a real group name and nobody can create or join it.
+
+Within a group there are three positions.
+The owner may transfer ownership, delegate an administrator, and delete the group, and is the one member who cannot simply leave.
+The administrator — a user or another group — handles membership and metadata day to day but cannot transfer or delete.
+Members are everyone else and can always leave, which is why membership is never used to express a restriction.
+
+Group names are unique across the server and cannot begin with `user-`.
+Each group also carries an auth-template-eligibility flag, explained under [Where a scope can come from](#where-a-scope-can-come-from).
+See [Managing Users and Groups](/managing-data-access/users-and-groups) for how to create and run one.
+
+### Scopes name what an account may do
+
+A scope is a named capability attached to a user record or a group record, and four of them shape this section.
+`web_ui.access` is the baseline: the account may sign in and use the interface at all.
+`server.user_admin` covers managing other people's accounts, `server.collection_admin` covers creating collections, and `server.admin` is the master scope that implies both — a system administrator is never granted the other two separately.
+
+Scopes are not free-form.
+The management API accepts only scopes from a fixed, user-grantable catalogue, and the effective-scope computation filters its output against that same catalogue.
+That is a deliberate seam: a data-access scope such as `storage.read` is not in the catalogue, so no amount of granting through the management surface can hand one out.
+Data-plane scopes are minted by the issuer, from collection ACLs, and by no other route.
+The full catalogue is on the [Permissions Reference](/managing-data-access/permissions-reference#management-scopes).
+
+### Where a scope can come from
+
+Your effective scopes are not a stored column; they are recomputed on every request from several sources unioned together.
+Direct grants on your user record come first, then grants on any group you belong to through Pelican's own records, then grants on any group your login token asserts by name.
+On top of those sit the operator's configuration lists: the username-matched and group-matched admin settings, plus the built-in `admin` account.
+Finally `server.admin`, from wherever it came, pulls in the two subordinate scopes.
+
+The two kinds of source differ in how you take a permission back.
+Configuration-derived grants are evaluated live against the file and never mirrored into the database, so editing the configuration withdraws them; database grants are withdrawn by revoking the grant.
+Neither undoes the other, and a scope that arrived from configuration will not appear in a user's list of direct grants.
+Two smaller behaviors follow the same "recompute, don't remember" principle.
+New accounts receive the baseline named by [`Server.NewUserDefaultScopes`](/parameters#Server-NewUserDefaultScopes) at creation time only.
+API tokens re-intersect against the creator's *current* effective scopes on every use, so a long-lived credential shrinks as its owner's privileges shrink.
+
+Group creation itself is open.
+Any signed-in user can create a group, because users need groups of their own to write collection ACLs and share ACLs against.
+What a self-created group cannot do is act as bearer authority: [`Issuer.AuthorizationTemplates`](/parameters#Issuer-AuthorizationTemplates) and the [`Server.AdminGroups`](/parameters#Server-AdminGroups) settings match on a group's *name*, so a group you named yourself must not automatically start matching them.
+Each group therefore carries an auth-template-eligibility flag, and only a system administrator can turn it on for an existing group.
+Groups created before group creation was opened to everyone are eligible by default.
+Collection ACLs do not consult the flag — those rows are set on the collection itself, and group names are unique.
+
+## How access to data is granted
+
+### Collections control access inside a namespace you already export
+
+Exporting storage says which prefixes this origin serves and whether reads and writes are permitted there at all.
+A collection is the finer-grained layer on top: a prefix *inside* an already-exported namespace, plus the ACLs saying which groups may read or write it.
+It may be a sub-path rather than the whole export, so one export can carry many collections, and the path is canonicalized before it is checked and stored because that same string is later spliced into token scopes.
+
+A collection cannot widen what the export permits.
+If the export does not allow writes, no ACL row on a collection inside it produces a usable write.
+Collections narrow and delegate; they never enlarge.
+
+Three kinds of authority attach to a collection.
+The owner is one user, responsible for it, and the only principal who can transfer or delete it.
+The admin group runs it day to day — metadata, descriptive fields, ACLs, and reassigning the admin group itself — and can do everything except transfer and delete.
+ACL rows grant `read` or `write` to a named group, optionally until an expiry, after which the row simply stops matching; holding `write` is authority over the collection's data, not over its access control.
+
+Visibility is a separate axis: a public collection has its existence visible to callers who hold no ACL on it, and a private one does not appear in their listing at all.
+Visibility grants no data access, and `@authenticated` — which does grant data access to every signed-in caller — does not make a collection public.
+See [Collections and Shares](/managing-data-access/collections-and-shares) for the tasks.
+
+### Shares delegate access you already hold
+
+Creating a collection needs `server.collection_admin`, and most people who want to share data do not have it and should not need it — which is what shares are for.
+A share is a child collection created by someone who already holds read access on the parent, once the parent's owner has turned sharing on.
+The creator owns the share, so they can write ACLs on it exactly as a collection owner would, without gaining any new privilege on the parent.
+A share's prefix has to be the parent's namespace or a path beneath it, shares start private, and a share of a share is refused.
+
+Access through a share is always the weaker of two things: what the share grants its recipient, and what the share's owner can currently do on the parent collection.
+That intersection is recomputed each time a token is *issued*, so if the share owner is downgraded from write to read — or loses access to the parent altogether — every token minted through the share from that point on is clamped or emptied.
+A share cannot be used to delegate access its owner no longer has.
+
+Refreshing an existing token does not re-run the intersection.
+The issuer re-grants the scopes already stored on the session, so an already-issued token keeps its original access until it expires and a new authorization is performed.
+Plan for access changes to take effect on the next issuance, not immediately.
+
+Shares are not supported when the origin runs a multi-user POSIX backend ([`Origin.Multiuser`](/parameters#Origin-Multiuser)).
+Serving share data means acting as the share's owner, and the multi-user backend cannot safely re-target the operating-system identity it serves a request under.
+Creating a share on such an origin is refused with `409`, and if multi-user mode is turned on after shares already exist, any token carrying `share.access` is rejected outright rather than quietly falling back to the presenter's identity.
+
+## How a request is decided
+
+### How an access token is assembled
+
+When the issuer mints an access token for you, it walks every collection you can reach and turns your role on each one into scopes.
+
+```mermaid
+flowchart TD
+  U["Who you are: username + identities"]
+  G["Your groups: records, login claim,<br/>personal group, @authenticated"]
+  U --> G
+  U --> SC["Scope grants on you and your groups,<br/>plus config-derived grants"]
+  G --> SC
+  G --> ACL["Collection ACL rows that match<br/>-> role: read, write, or owner"]
+  ACL --> ST["Namespace scopes:<br/>storage.read / .modify / .create"]
+  ACL --> SH["If the row is a share: clamp to the<br/>owner's parent role, add share.access"]
+  SC --> TOK["Access token"]
+  ST --> TOK
+  SH --> TOK
+```
+
+Owner or `write` on a collection yields read, modify, and create on that collection's namespace; `read` yields read alone; no role yields nothing, because there is no implicit floor.
+The namespace is made issuer-relative before it goes into a scope, so it lines up with the per-namespace tokens the storage layer validates, and a collection outside this issuer's namespace gets management-plane scopes only.
+The token's group claim echoes the group names that actually matched an ACL, minus `@authenticated` — emitting a virtual target would invite downstream consumers to treat it as a real group.
+
+A token issued for a share carries `share.access:/<share-id>` alongside its storage scopes.
+That scope tells the origin to serve objects under the share's prefix as the share's *owner* rather than as the person presenting the token — which is what makes delegated access work.
+It is minted by the issuer only; it is not a scope you can grant to a user or a group.
+The full role-to-scope mapping is tabulated under [Data access](/managing-data-access/permissions-reference#data-access).
+
+### Five roles, from system administrator to ordinary user
+
+A **system administrator** holds `server.admin` and reaches every management surface: accounts, groups, scope grants, identity links, the Acceptable Use Policy, and every collection.
+It is the only role that can grant a scope, and the only one that can make an existing group eligible for authorization templates and admin lists ([Roles](/managing-data-access/permissions-reference#roles)).
+
+A **user administrator** holds `server.user_admin` and runs the account lifecycle: creating accounts, relabeling them, activating and deactivating them, minting password and onboarding invites, and recording or clearing policy acceptance.
+Their reach stops short of granting scopes, editing identity links, and acting on a system administrator's account ([User administration](/managing-data-access/permissions-reference#user-administration)).
+
+A **collection administrator** holds `server.collection_admin`, which buys exactly one thing nobody else can do: creating a collection.
+Everything after that — running it, writing its ACLs, handing it to a PI — is ordinary collection authority ([Collection administration](/managing-data-access/permissions-reference#collection-administration)).
+
+An **owner**, of a group or of a collection, holds authority that comes from being named on the row rather than from any scope: narrow, but total within its object.
+An admin group can do nearly everything an owner can, minus transfer and delete, which is what makes it safe to delegate ([Group administration](/managing-data-access/permissions-reference#group-administration)).
+
+An **ordinary user** holds `web_ui.access` and nothing else, which is more than it sounds.
+They can create groups and own them, manage their own account, hold ACL grants, and — where sharing is enabled — create and run shares ([Share administration](/managing-data-access/permissions-reference#share-administration)).
+
+### Three checks run on every request
+
+Three checks run in sequence, and knowing which one refused you is usually enough to fix the problem.
+
+The **login gate** establishes who you are and whether your account is still active, resolving your credential to a user record and collecting the group names your login asserts.
+A deactivated account fails here on its next request, without waiting for a token to expire.
+
+The **management-API gate** compares your effective scopes against what the route requires, and the Acceptable Use Policy gate sits alongside it.
+If your server has an Acceptable Use Policy configured, you must accept the current version before you can use the user, group, or self-service management APIs.
+Until you do, those endpoints return `403` with `requires_aup: true` and the version you need to accept, and the web interface sends you to the acceptance page.
+Three things stay reachable so you can get unstuck: reading the policy, accepting it, and signing out.
+Editing the policy is also exempt, so rotating it cannot lock out the administrator who rotated it.
+[Acceptable Use Policy gate](/managing-data-access/permissions-reference#acceptable-use-policy-gate) lists which surfaces are gated and how the requirement is switched off.
+
+The **row-level check** decides whether you may act on this particular record: are you its owner, are you in its admin group, does an ACL row match one of your groups, and is that row still within its expiry.
+This is the layer that clamps a share against its owner's current access, and the layer a `write` ACL passes for data but not for ACL editing.
+
+<Callout type="info">
+Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it.
+A `404` on a collection or group you believe exists usually means you lack access, not that it is missing.
+</Callout>

--- a/docs/app/managing-data-access/access-control-model/page.mdx
+++ b/docs/app/managing-data-access/access-control-model/page.mdx
@@ -92,6 +92,11 @@ A collection cannot widen what the export permits.
 If the export does not allow writes, no grant on a collection inside it produces a usable write.
 Collections narrow and delegate; they never enlarge.
 
+That narrowing is relative to the export, not to other collections.
+Collections do not nest: two whose prefixes overlap are independent records, and their grants are unioned rather than resolved most-specific-first.
+Each grant mints a scope on its own prefix, and a scope covers every path beneath it, so a collection deeper in the tree can widen access to its sub-path but can never restrict what a shallower collection already grants — there is no negative role and no subtraction anywhere in the model.
+So the depth at which a collection is created is a floor on how finely access can be split inside it, and a namespace cannot be edited afterwards.
+
 Three kinds of authority attach to a collection.
 The owner is one user, responsible for it, and the only one who can transfer or delete it.
 The admin group runs it day to day and can do everything except transfer and delete.

--- a/docs/app/managing-data-access/collections-and-shares/page.mdx
+++ b/docs/app/managing-data-access/collections-and-shares/page.mdx
@@ -1,0 +1,372 @@
+import { Callout } from 'nextra/components'
+
+# Collections and Shares
+
+A **collection** is a prefix inside a namespace your origin already exports, together with the groups allowed to read or write it.
+A **share** is a child collection an ordinary user creates to hand part of their own access to someone else.
+This page is the task list for both: how to create a collection, wire up its groups, hand it to the person who is responsible for it, and let that person delegate onward.
+
+The running example throughout is the one the design was built for.
+An origin administrator creates a collection for a principal investigator, Dr. Reyes.
+Dr. Reyes owns it but does not run it day to day — her postdocs do, as the collection's **admin group**.
+The postdocs then give the lab's undergraduates `read` and the graduate students `write`.
+
+If you want the model behind these tasks rather than the tasks themselves, read [How Access Control Works](/managing-data-access/access-control-model).
+For the authoritative "who may do this", see the [Permissions Reference](/managing-data-access/permissions-reference).
+
+## Before you start
+
+Three things need to be true before any of this works.
+
+1. **The export exists.**
+   A collection is access control *inside* an exported namespace, not a way to publish new storage.
+   Export the storage first — see [Serving an Origin](/federating-your-data/origin) — then create a collection at that prefix or below it.
+2. **You hold `server.collection_admin` (or `server.admin`) to create a collection.**
+   Running one afterwards does not require it: the owner and the admin group manage the collection with no management scope at all.
+   See [Collection administration](/managing-data-access/permissions-reference#collection-administration).
+3. **The groups you want to put in the ACL exist**, or you are willing to create them as you go.
+   Any signed-in user can create a group; see [Create a group](/managing-data-access/users-and-groups#create-a-group).
+
+The `pelican-server origin collection` commands ship in the `pelican-server` binary.
+They find your origin by asking the Director (so `Federation.DirectorUrl` has to be configured), then send you through a browser device-code approval to obtain a token — you do not need shell access on the origin host, but you do need a browser and an account on that origin.
+In a federation with more than one origin the commands target the first origin the Director returns, so prefer the web interface when several origins are registered.
+Flags and syntax live in the generated [`pelican-server origin collection`](/commands-reference/pelican-server/origin/collection) reference; request and response bodies live in the [API browser](/api-docs).
+
+## Create a collection
+
+*Requires `server.collection_admin` or `server.admin` — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+
+### Web UI
+
+The **ONBOARD COLLECTION** form does the whole example in one pass: the collection, its owner, and its three groups.
+
+1. In the Origin web interface, open **Collections** in the left sidebar.
+2. Click **ONBOARD COLLECTION**.
+3. Under **Collection**, fill in:
+   - **Name** — a short human-readable name, for example `Reyes Lab`.
+   - **Exported namespace** — pick the exported prefix from the dropdown and type the rest of the path in the box beside it. The full path is shown back to you as you type.
+   - **Description** and **Visibility** (`Private` or `Public`).
+4. Under **Ownership**, choose who owns the collection.
+   The default is you; use **Pick an existing user** to name Dr. Reyes, **Create a new user** if she has no account yet, or **Send an ownership invite** to mint a link she redeems herself.
+5. Under **Access Control**, fill in the three group rows — the `admin` row becomes the collection's admin group, the `write` row and the `read` row become ACL grants.
+   Each row can either create a fresh group or attach one that already exists.
+   Disable any row you do not need.
+6. Click **ONBOARD COLLECTION** at the bottom of the form.
+
+**QUICK CREATE** is the escape hatch: it creates the collection only (**Name**, **Namespace**, **Description**, **Visibility**, and optional **Reader Group** / **Writer Group** / **Admin Group** pickers), leaving ownership and the rest of the ACLs for the edit page.
+
+### CLI
+
+```bash copy
+pelican-server origin collection create \
+  --name "Reyes Lab" \
+  --namespace /CoolScienceOrg/reyes-lab \
+  --description "Storage area for the Reyes lab" \
+  --visibility private
+```
+
+The command prints the new collection, including its ID.
+You need that ID for every later command on this collection.
+
+### API
+
+`POST /api/v1.0/origin_ui/collections`, with the name, namespace, description, visibility and any initial metadata in the body.
+The response carries the new collection's ID.
+See [/api-docs](/api-docs) for the exact shape.
+
+## Choose a namespace for the collection
+
+The namespace is not cosmetic — it is spliced into the storage scopes on every token minted for the collection, so the rules are enforced strictly.
+
+- It has to sit **inside a prefix this origin exports**, either equal to an exported prefix or a path-descendant of one.
+  `/CoolScienceOrg/reyes-lab` is accepted under an export of `/CoolScienceOrg`; it is not accepted under an export of `/CoolScience`, because a prefix only matches at a path boundary.
+- It is **canonicalised before it is checked and before it is stored**, so `/a/b/../c` becomes `/a/c` and both the export check and the eventual token scope see the same value.
+- Whitespace, control characters and `:` are rejected outright.
+
+Several collections can live under one export, which is the usual arrangement: one export of `/CoolScienceOrg`, one collection per lab beneath it.
+
+<Callout type="info">
+A collection can only narrow or subdivide what the export already permits.
+If the export itself is public, a private collection at that prefix does not make the objects unreadable.
+For choosing sensible prefixes in the first place, see [Namespace Prefixes and How To Choose One](/federating-your-data/choosing-namespaces).
+</Callout>
+
+## Grant read or write access to a group
+
+*Requires the collection's owner, a member of its admin group, or `server.collection_admin` — a `write` ACL is not enough to edit ACLs. See [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+
+Grants are written against **groups**, never against individual users.
+To give one person access, put them in a group — every user also has an implicit personal group named `user-<username>` you can name in an ACL directly.
+Roles are `read` and `write`; a grant may carry an expiry, after which it stops matching.
+
+### Web UI
+
+1. Open **Collections**, find the collection, and click the **Edit collection** (pencil) icon on its row.
+2. Scroll to **Access groups**.
+3. In **Add group**, pick the group — `reyes-undergrads` for the read grant.
+4. Set **Role** to `Read` or `Write`.
+5. Click **ADD**.
+6. Repeat for `reyes-grads` with **Role** `Write`.
+
+Existing rows are listed above the picker with their role; the trash icon beside a row revokes it.
+
+### CLI
+
+```bash copy
+pelican-server origin collection acl grant <collection-id> \
+  --group-id reyes-undergrads --role read
+
+pelican-server origin collection acl grant <collection-id> \
+  --group-id reyes-grads --role write
+```
+
+`--group-id` accepts either the group's internal ID or its name; Pelican stores the canonical name on the ACL row either way.
+`--role` accepts `read` or `write`.
+See [`collection acl`](/commands-reference/pelican-server/origin/collection/acl).
+
+### API
+
+`POST /api/v1.0/origin_ui/collections/{id}/acl` with the group and role, and an optional expiry.
+`DELETE` on the same path revokes a row.
+See [/api-docs](/api-docs).
+
+<Callout type="info">
+`owner` is not a role you can grant here.
+Ownership is a field on the collection, and full management authority is the admin group — see the two sections below.
+Older collections may still show a legacy `owner` ACL row; it is safe to revoke once the owner and admin group are set.
+</Callout>
+
+## Grant access to every signed-in user
+
+*Same prerequisite as the section above.*
+
+`@authenticated` is a virtual ACL target that matches every caller who is signed in, regardless of group membership.
+Use it when the answer to "who may read this?" is "anyone with an account on this server".
+
+In the web interface it appears at the top of the **Add group** picker as **All authenticated users**, marked *Virtual group · matches every signed-in caller*.
+Pick it, choose a role, and click **ADD**, exactly as for a real group.
+On the CLI and the API, pass `@authenticated` where you would pass a group.
+
+Two things it does not do.
+It does not make the collection public — visibility controls who can *see that the collection exists*, and is a separate field.
+And it never appears in a token's group claim, because it is not a real group: it cannot be created, joined, or listed as a member.
+Anonymous callers do not match it either; a request with no identity at all is not "authenticated".
+
+## Delegate day-to-day management to an admin group
+
+*Requires the collection's owner, an existing admin-group member, or `server.collection_admin` — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+
+The admin group is how Dr. Reyes stays responsible for the collection without running it.
+Her postdocs' group becomes the admin group, and from then on they add and remove the undergraduate and graduate groups themselves.
+
+Admin-group members can edit the collection's name, description, visibility and sharing setting, read and write its metadata, grant and revoke ACLs, and reassign the admin group.
+They cannot transfer ownership and they cannot delete the collection — both stay with the owner.
+
+### Web UI
+
+1. Open the collection's **Edit collection** page.
+2. In the **Ownership** panel, use the **Admin group (optional)** picker to select `reyes-postdocs`.
+3. Click **SAVE CHANGES**.
+
+Clearing the picker removes the admin group.
+Once one is set, a **Manage admin group →** link appears beside it so you can jump straight to that group's membership page.
+
+### API
+
+`PATCH /api/v1.0/origin_ui/collections/{id}` with the admin group's ID.
+See [/api-docs](/api-docs).
+
+There is no CLI path for this today: `pelican-server origin collection update` covers the descriptive fields only, so the admin group is set from the web interface or the API.
+
+## Hand a collection to its owner
+
+*Requires the current owner or `server.collection_admin`; admin-group members cannot transfer — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+
+Every collection has exactly one owner, and it can be moved but never cleared — a `PATCH` that empties `ownerId` is refused.
+There are two routes, depending on whether the new owner already has an account.
+
+**If they do**, set the owner directly.
+On the collection's **Edit collection** page, pick them in the **Owner** field and click **SAVE CHANGES**.
+If you hold `server.user_admin` the picker lists every user on the server; otherwise it offers only the collection's own people — the current owner, admin-group members, and members of any group in the ACL.
+The API equivalent is `PATCH /api/v1.0/origin_ui/collections/{id}` with the new owner's user ID.
+
+**If they do not**, mint an ownership-transfer invite.
+The recipient signs in (self-enrolling through OIDC if this is their first visit), redeems the link, and becomes the owner at that moment; the previous owner loses ownership simultaneously.
+These links are always single-use.
+
+1. On the **Edit collection** page, scroll to **Transfer via invite link**.
+2. Click **GENERATE TRANSFER LINK**.
+3. Copy the URL with **COPY URL**.
+
+From the CLI:
+
+```bash copy
+pelican-server origin collection ownership-invite create <collection-id>
+```
+
+See [`collection ownership-invite`](/commands-reference/pelican-server/origin/collection/ownership-invite).
+The API equivalent is `POST /api/v1.0/origin_ui/collections/{id}/ownership-invites`.
+
+<Callout type="warning">
+Pelican mints the link and shows you the token exactly once; delivering it to the right person is your job.
+Pelican does not send email.
+</Callout>
+
+## Turn on sharing
+
+*Requires the collection's owner, an admin-group member, or `server.collection_admin` — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+
+Shares are off by default.
+Turning them on lets anyone who holds `read` on the collection delegate part of that access onward — useful when a graduate student has to give an outside collaborator one directory and holds no management scope of their own.
+It creates nothing by itself; it only makes share creation reachable for the collection's readers.
+
+1. Open the collection's **Edit collection** page.
+2. Under **Details**, switch on **Allow users to create shares**.
+3. Click **SAVE CHANGES**.
+
+The API equivalent is `PATCH /api/v1.0/origin_ui/collections/{id}` with the sharing flag.
+There is no CLI flag for this setting today, so it is a web-interface or API task.
+
+<Callout type="warning">
+Shares are not supported when the origin runs a multi-user POSIX backend ([`Origin.Multiuser`](/parameters#Origin-Multiuser)).
+Serving share data means acting as the share's owner, and the multi-user backend cannot safely re-target the operating-system identity it serves a request under.
+Creating a share on such an origin is refused with `409`, and if multi-user mode is turned on after shares already exist, any token carrying `share.access` is rejected outright rather than quietly falling back to the presenter's identity.
+</Callout>
+
+## Create a share
+
+*Requires `read` on the parent collection, with sharing enabled on it — see [Share administration](/managing-data-access/permissions-reference#share-administration).*
+
+A share is a collection, so everything you already know about ACLs applies to it.
+What makes it a share is the parent link, and the constraints that come with it:
+
+- **You own the share, not the parent's owner.** You hold owner authority on the share row and manage it yourself.
+- **The namespace has to equal the parent's or sit beneath it.** Leave it blank to inherit the parent's namespace exactly.
+- **Shares start private**, and sharing is forced off on the new share — you cannot create a share of a share.
+
+Access through a share is always the weaker of two things: what the share grants its recipient, and what the share's owner can currently do on the parent collection.
+That intersection is recomputed each time a token is *issued*, so if the share owner is downgraded from write to read — or loses access to the parent altogether — every token minted through the share from that point on is clamped or emptied.
+A share cannot be used to delegate access its owner no longer has.
+
+<Callout type="warning">
+Refreshing an existing token does not re-run the intersection.
+The issuer re-grants the scopes already stored on the session, so an already-issued token keeps its original access until it expires and a new authorization is performed.
+Plan for access changes to take effect on the next issuance, not immediately.
+</Callout>
+
+### Web UI
+
+1. Open **Collections** and find the parent collection.
+   The share icon appears on its row only when sharing is enabled there.
+2. Click the **Create share** (share) icon.
+3. In the **Create share of …** dialog, fill in **Share name**, an optional **Description**, and optionally a **Namespace (optional)** beneath the parent's — leave it blank to use the parent's namespace.
+4. Choose a **Visibility**.
+5. Click **CREATE SHARE**.
+
+Shares appear in the collections list alongside collections, tagged with a **share** chip.
+
+### API
+
+`POST /api/v1.0/origin_ui/collections/{id}/shares`, where `{id}` is the parent collection.
+`GET` on the same path lists a parent's shares.
+
+There is no `pelican-server origin collection share` command family, so outside the web interface this is an API-only task.
+These two endpoints are also not yet described in the [API browser](/api-docs) — the surrounding collection endpoints are.
+
+## Give people access to a share
+
+*Requires the share's owner (or `server.collection_admin`) — see [Share administration](/managing-data-access/permissions-reference#share-administration).*
+
+Because a share is a collection, you grant access to it exactly as in [Grant read or write access to a group](#grant-read-or-write-access-to-a-group) — same **Access groups** panel on the share's edit page, same `acl grant` command, same endpoint, with the share's ID in place of the collection's.
+`@authenticated` works here too.
+
+The difference is whose identity the data is served as.
+Objects reached through a share are served as the share's *owner*, not as the person presenting the token, which is why the intersection above is enforced — the share owner stays accountable for everything read or written through the share.
+See [Data access](/managing-data-access/permissions-reference#data-access) for the scope the issuer mints to arrange that.
+
+## Revoke access
+
+*Prerequisites vary by lever — see [Collection administration](/managing-data-access/permissions-reference#collection-administration) and [Share administration](/managing-data-access/permissions-reference#share-administration).*
+
+Three levers, in increasing order of blast radius.
+
+1. **Remove the person from the group.**
+   Everything else keeps working; only that person loses the access the group carried.
+   See [Add and remove group members](/managing-data-access/users-and-groups#add-and-remove-group-members).
+2. **Revoke the ACL row**, or let its expiry pass.
+   The whole group loses that role on that collection.
+   Use the trash icon beside the row under **Access groups**, `pelican-server origin collection acl revoke`, or `DELETE /api/v1.0/origin_ui/collections/{id}/acl`.
+3. **Remove a share owner's access to the parent.**
+   This clamps or empties every token minted through every share that person owns, because the intersection is recomputed on each issuance.
+
+All three take effect the next time a token is *issued*, not against tokens already in the field.
+An access token minted before you revoked keeps working until it expires, and the one after it is smaller or empty.
+Deleting a group is the blunt version of lever 2 — it removes every collection ACL row that names that group, everywhere.
+
+<Callout type="warning">
+Refreshing a token does not re-run these checks.
+The issuer re-grants the scopes already stored on the session, so a session that keeps refreshing holds its original data access until that session ends and the holder authorizes again.
+Revocation is not a way to cut off an active session immediately.
+</Callout>
+
+## Delete a collection or share
+
+*Requires the owner or `server.collection_admin`; admin-group members cannot delete — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+
+Deleting a collection removes its ACL rows, its metadata and its member rows along with it.
+Deleting a share is the same operation — a share is a collection — and is done by the share's owner.
+
+### Web UI
+
+On the **Collections** page, click the **Delete collection** (trash) icon on the row.
+The icon is shown to callers who can edit the row, which is a slightly wider set than those who can delete it, so an admin-group member may see it and get an error.
+
+### CLI
+
+```bash copy
+pelican-server origin collection delete <collection-id>
+```
+
+### API
+
+`DELETE /api/v1.0/origin_ui/collections/{id}`.
+
+<Callout type="warning">
+Deleting a collection does not delete any objects under its namespace.
+It removes the access-control record; the data stays exactly where the export put it, governed by the export alone.
+</Callout>
+
+## Troubleshooting
+
+**`403 you must hold server.collection_admin (or server.admin) to create a collection`**
+Signing in is enough to *reach* the collections API, but not to create a collection.
+Ask a system administrator to grant you `server.collection_admin`, or to create the collection and transfer it to you.
+
+**`Namespace '…' is not within a prefix exported by this origin`**
+The path is outside every export, or it looks like a match but is not one at a path boundary (`/data/foo` is not inside an export of `/data/foobar`).
+Check the origin's exports, then re-check after canonicalisation — `/a/b/../c` is stored and validated as `/a/c`.
+
+**`409 Sharing is not enabled on this collection`**
+The parent collection's owner has not switched on **Allow users to create shares**.
+See [Turn on sharing](#turn-on-sharing).
+
+**`409 Shares are not supported on multi-user origin backends`**
+This origin runs a multi-user POSIX backend, where serving data as the share's owner is not possible.
+Grant access on the collection itself instead of creating a share.
+
+**`404 collection not found` on a collection you are sure exists**
+Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it.
+A `404` on a collection or group you believe exists usually means you lack access, not that it is missing.
+This is also what a non-owner sees when they try to transfer ownership or mint an ownership invite.
+
+**`cannot create a share of an existing share`**
+Shares are one hop deep.
+Create the share from the original collection, or ask its owner to grant the person access directly.
+
+**`ownerId cannot be empty; transfer to a real user instead`**
+Ownership can move but not be cleared.
+Name a replacement owner, or mint an ownership-transfer invite.
+
+**A `write` ACL holder cannot change the ACLs.**
+That is intentional: `write` covers the data and the collection's descriptive fields, not who else gets in.
+Put them in the admin group if they should manage access.

--- a/docs/app/managing-data-access/collections-and-shares/page.mdx
+++ b/docs/app/managing-data-access/collections-and-shares/page.mdx
@@ -1,12 +1,12 @@
 import { Callout } from 'nextra/components'
 
-# Collections and Shares
+# Managing Access to a Collection
 
 A **collection** is a prefix inside a namespace your origin already exports, together with the groups allowed to read or write it.
 A **share** is a child collection an ordinary user creates to hand part of their own access to someone else.
-This page is the task list for both: how to create a collection, wire up its groups, hand it to the person who is responsible for it, and let that person delegate onward.
+This page is the main task list for this section: how to create a collection, decide which groups can read or write it, hand it to the person responsible for it, and let that person pass access on to their own collaborators.
 
-The running example throughout is the one the design was built for.
+One example runs through this page.
 An origin administrator creates a collection for a principal investigator, Dr. Reyes.
 Dr. Reyes owns it but does not run it day to day — her postdocs do, as the collection's **admin group**.
 The postdocs then give the lab's undergraduates `read` and the graduate students `write`.
@@ -24,7 +24,7 @@ Three things need to be true before any of this works.
 2. **You hold `server.collection_admin` (or `server.admin`) to create a collection.**
    Running one afterwards does not require it: the owner and the admin group manage the collection with no management scope at all.
    See [Collection administration](/managing-data-access/permissions-reference#collection-administration).
-3. **The groups you want to put in the ACL exist**, or you are willing to create them as you go.
+3. **The groups you want to give access to exist**, or you are willing to create them as you go.
    Any signed-in user can create a group; see [Create a group](/managing-data-access/users-and-groups#create-a-group).
 
 The `pelican-server origin collection` commands ship in the `pelican-server` binary.
@@ -48,12 +48,12 @@ The **ONBOARD COLLECTION** form does the whole example in one pass: the collecti
    - **Description** and **Visibility** (`Private` or `Public`).
 4. Under **Ownership**, choose who owns the collection.
    The default is you; use **Pick an existing user** to name Dr. Reyes, **Create a new user** if she has no account yet, or **Send an ownership invite** to mint a link she redeems herself.
-5. Under **Access Control**, fill in the three group rows — the `admin` row becomes the collection's admin group, the `write` row and the `read` row become ACL grants.
+5. Under **Access Control**, fill in the three group rows — the `admin` row becomes the collection's admin group, the `write` row and the `read` row become access grants.
    Each row can either create a fresh group or attach one that already exists.
    Disable any row you do not need.
 6. Click **ONBOARD COLLECTION** at the bottom of the form.
 
-**QUICK CREATE** is the escape hatch: it creates the collection only (**Name**, **Namespace**, **Description**, **Visibility**, and optional **Reader Group** / **Writer Group** / **Admin Group** pickers), leaving ownership and the rest of the ACLs for the edit page.
+**QUICK CREATE** is the escape hatch: it creates the collection only (**Name**, **Namespace**, **Description**, **Visibility**, and optional **Reader Group** / **Writer Group** / **Admin Group** pickers), leaving ownership and the rest of the access grants for the edit page.
 
 ### CLI
 
@@ -93,10 +93,10 @@ For choosing sensible prefixes in the first place, see [Namespace Prefixes and H
 
 ## Grant read or write access to a group
 
-*Requires the collection's owner, a member of its admin group, or `server.collection_admin` — a `write` ACL is not enough to edit ACLs. See [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+*Requires the collection's owner, a member of its admin group, or `server.collection_admin` — a `write` grant is not enough to change who else has access. See [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
 Grants are written against **groups**, never against individual users.
-To give one person access, put them in a group — every user also has an implicit personal group named `user-<username>` you can name in an ACL directly.
+To give one person access, put them in a group — every user also has an implicit personal group named `user-<username>` you can grant to directly.
 Roles are `read` and `write`; a grant may carry an expiry, after which it stops matching.
 
 ### Web UI
@@ -120,27 +120,28 @@ pelican-server origin collection acl grant <collection-id> \
   --group-id reyes-grads --role write
 ```
 
-`--group-id` accepts either the group's internal ID or its name; Pelican stores the canonical name on the ACL row either way.
+`--group-id` accepts either the group's internal ID or its name; Pelican stores the canonical name on the grant either way.
+The CLI and API call a collection's set of grants its **ACL** (access control list), which is why the subcommand is `acl grant`.
 `--role` accepts `read` or `write`.
 See [`collection acl`](/commands-reference/pelican-server/origin/collection/acl).
 
 ### API
 
 `POST /api/v1.0/origin_ui/collections/{id}/acl` with the group and role, and an optional expiry.
-`DELETE` on the same path revokes a row.
+`DELETE` on the same path revokes a grant.
 See [/api-docs](/api-docs).
 
 <Callout type="info">
 `owner` is not a role you can grant here.
 Ownership is a field on the collection, and full management authority is the admin group — see the two sections below.
-Older collections may still show a legacy `owner` ACL row; it is safe to revoke once the owner and admin group are set.
+Older collections may still show a legacy `owner` grant; it is safe to revoke once the owner and admin group are set.
 </Callout>
 
 ## Grant access to every signed-in user
 
 *Same prerequisite as the section above.*
 
-`@authenticated` is a virtual ACL target that matches every caller who is signed in, regardless of group membership.
+`@authenticated` is a virtual target that matches every caller who is signed in, regardless of group membership.
 Use it when the answer to "who may read this?" is "anyone with an account on this server".
 
 In the web interface it appears at the top of the **Add group** picker as **All authenticated users**, marked *Virtual group · matches every signed-in caller*.
@@ -159,7 +160,7 @@ Anonymous callers do not match it either; a request with no identity at all is n
 The admin group is how Dr. Reyes stays responsible for the collection without running it.
 Her postdocs' group becomes the admin group, and from then on they add and remove the undergraduate and graduate groups themselves.
 
-Admin-group members can edit the collection's name, description, visibility and sharing setting, read and write its metadata, grant and revoke ACLs, and reassign the admin group.
+Admin-group members can edit the collection's name, description, visibility and sharing setting, read and write its metadata, grant and revoke access, and reassign the admin group.
 They cannot transfer ownership and they cannot delete the collection — both stay with the owner.
 
 ### Web UI
@@ -178,7 +179,7 @@ See [/api-docs](/api-docs).
 
 There is no CLI path for this today: `pelican-server origin collection update` covers the descriptive fields only, so the admin group is set from the web interface or the API.
 
-## Hand a collection to its owner
+## Transfer ownership of a collection
 
 *Requires the current owner or `server.collection_admin`; admin-group members cannot transfer — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
@@ -187,7 +188,7 @@ There are two routes, depending on whether the new owner already has an account.
 
 **If they do**, set the owner directly.
 On the collection's **Edit collection** page, pick them in the **Owner** field and click **SAVE CHANGES**.
-If you hold `server.user_admin` the picker lists every user on the server; otherwise it offers only the collection's own people — the current owner, admin-group members, and members of any group in the ACL.
+If you hold `server.user_admin` the picker lists every user on the server; otherwise it offers only the collection's own people — the current owner, admin-group members, and members of any group already granted access.
 The API equivalent is `PATCH /api/v1.0/origin_ui/collections/{id}` with the new owner's user ID.
 
 **If they do not**, mint an ownership-transfer invite.
@@ -237,10 +238,10 @@ Creating a share on such an origin is refused with `409`, and if multi-user mode
 
 *Requires `read` on the parent collection, with sharing enabled on it — see [Share administration](/managing-data-access/permissions-reference#share-administration).*
 
-A share is a collection, so everything you already know about ACLs applies to it.
+A share is a collection, so everything you already know about granting access applies to it.
 What makes it a share is the parent link, and the constraints that come with it:
 
-- **You own the share, not the parent's owner.** You hold owner authority on the share row and manage it yourself.
+- **You own the share, not the parent's owner.** You hold owner authority on the share and manage it yourself.
 - **The namespace has to equal the parent's or sit beneath it.** Leave it blank to inherit the parent's namespace exactly.
 - **Shares start private**, and sharing is forced off on the new share — you cannot create a share of a share.
 
@@ -293,7 +294,7 @@ Three levers, in increasing order of blast radius.
 1. **Remove the person from the group.**
    Everything else keeps working; only that person loses the access the group carried.
    See [Add and remove group members](/managing-data-access/users-and-groups#add-and-remove-group-members).
-2. **Revoke the ACL row**, or let its expiry pass.
+2. **Revoke the grant**, or let its expiry pass.
    The whole group loses that role on that collection.
    Use the trash icon beside the row under **Access groups**, `pelican-server origin collection acl revoke`, or `DELETE /api/v1.0/origin_ui/collections/{id}/acl`.
 3. **Remove a share owner's access to the parent.**
@@ -301,7 +302,7 @@ Three levers, in increasing order of blast radius.
 
 All three take effect the next time a token is *issued*, not against tokens already in the field.
 An access token minted before you revoked keeps working until it expires, and the one after it is smaller or empty.
-Deleting a group is the blunt version of lever 2 — it removes every collection ACL row that names that group, everywhere.
+Deleting a group is the blunt version of lever 2 — it removes every collection grant that names that group, everywhere.
 
 <Callout type="warning">
 Refreshing a token does not re-run these checks.
@@ -313,13 +314,13 @@ Revocation is not a way to cut off an active session immediately.
 
 *Requires the owner or `server.collection_admin`; admin-group members cannot delete — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
-Deleting a collection removes its ACL rows, its metadata and its member rows along with it.
+Deleting a collection removes its grants, its metadata and its list of member objects along with it.
 Deleting a share is the same operation — a share is a collection — and is done by the share's owner.
 
 ### Web UI
 
 On the **Collections** page, click the **Delete collection** (trash) icon on the row.
-The icon is shown to callers who can edit the row, which is a slightly wider set than those who can delete it, so an admin-group member may see it and get an error.
+The icon is shown to callers who can edit the collection, which is a slightly wider set than those who can delete it, so an admin-group member may see it and get an error.
 
 ### CLI
 
@@ -367,6 +368,6 @@ Create the share from the original collection, or ask its owner to grant the per
 Ownership can move but not be cleared.
 Name a replacement owner, or mint an ownership-transfer invite.
 
-**A `write` ACL holder cannot change the ACLs.**
-That is intentional: `write` covers the data and the collection's descriptive fields, not who else gets in.
+**A `write` grant does not let you change who else has access.**
+`write` covers the data and the collection's descriptive fields, not who else gets in.
 Put them in the admin group if they should manage access.

--- a/docs/app/managing-data-access/collections-and-shares/page.mdx
+++ b/docs/app/managing-data-access/collections-and-shares/page.mdx
@@ -18,16 +18,16 @@ One story runs through this page, so that every task has a reason behind it inst
 
 **Riptide University** runs a Pelican origin in front of its research storage, already exporting the prefix `/riptide-university`.
 The **Reyes Lab** studies nearshore currents, and has just come back from a field season with several terabytes of instrument data that its collaborators need to reach.
-Over the sections below, the lab's collection gets created, handed to the people who run it, opened up to students, and eventually shared with a collaborator at another institution.
+Over the sections below, the lab's collection gets created, handed to the people who run it, and opened up to students — and one student's own thesis material is delegated to an outside examiner.
 
 | Person | Role in the story | Group |
 | --- | --- | --- |
 | Dana Cho | Origin administrator, Riptide University Research Computing. Holds `server.collection_admin`. | — |
 | Dr. Elena Reyes | Principal investigator. Owns the collection and answers for it. | — |
 | Dr. Priya Raman | Postdoc. Runs the collection day to day. | `reyes-postdocs` — the admin group |
-| Wes Danforth | Graduate student. Processes each new deployment. | `reyes-grads` — `write` |
+| Wes Danforth | Graduate student. Processes each new deployment; finishing a thesis this year. | `reyes-grads` — `write` |
 | Tomás Vela and Bea Nkemelu | Undergraduates on a senior project. Read the processed data, never overwrite it. | `reyes-undergrads` — `read` |
-| Dr. Hollis Park | Collaborator at Cape Meridian Marine Lab, with no Reyes Lab affiliation at all. | `park-lab` — `read`, through a share |
+| Dr. Hollis Park | External thesis committee member at Cape Meridian Marine Lab, with no Reyes Lab affiliation at all. | `user-hpark` — `read`, through Wes's share |
 
 ## Before you start
 
@@ -36,11 +36,13 @@ Three things need to be true before any of this works.
 1. **The export exists.**
    A collection is access control *inside* an exported namespace, not a way to publish new storage.
    Export the storage first — see [Serving an Origin](/federating-your-data/origin) — then create a collection at that prefix or below it.
-   Riptide University's storage is exported at `/riptide-university` before Dana touches the Collections page.
+
+   > Riptide University's storage is exported at `/riptide-university` long before Dana touches the Collections page.
 2. **You hold `server.collection_admin` (or `server.admin`) to create a collection.**
    Running one afterwards does not require it: the owner and the admin group manage the collection with no management scope at all.
-   That is the whole point of the handoff below — Dana needs the scope once, and Dr. Reyes and Dr. Raman never need it.
    See [Collection administration](/managing-data-access/permissions-reference#collection-administration).
+
+   > That is the whole point of the handoff below: Dana needs the scope once, and Dr. Reyes and Dr. Raman never need it at all.
 3. **The groups you want to give access to exist**, or you are willing to create them as you go.
    Any signed-in user can create a group; see [Create a group](/managing-data-access/users-and-groups#create-a-group).
 
@@ -60,52 +62,34 @@ The **ONBOARD COLLECTION** form does the whole thing in one pass: the collection
 1. In the Origin web interface, open **Collections** in the left sidebar.
 2. Click **ONBOARD COLLECTION**.
 3. Under **Collection**, fill in:
-   - **Name** — a short human-readable name, for example `Reyes Lab`.
-   - **Exported namespace** — pick the exported prefix from the dropdown and type the rest of the path in the box beside it. Dana picks `/riptide-university` and types `reyes-lab`. The full path is shown back as you type.
-   - **Description** and **Visibility** (`Private` or `Public`). Dana writes "Nearshore current data, Reyes Lab" and leaves it `Private`.
+   - **Name** — a short human-readable name.
+   - **Exported prefix** — pick the exported prefix from the dropdown and type the rest of the path in the box beside it. The full path is shown back as you type. *If only one namespace is served from this origin you won't have a dropdown.*
+   - **Description** and **Visibility** (`Private` or `Public`).
+
+   > Dana names it `Reyes Lab`, picks `/riptide-university namespace from the dropdown and types prefix `reyes-lab/nearshore-current` beside it, describes it as "Nearshore current data, Reyes Lab", and leaves it `Private`.
+
 4. Under **Ownership**, choose who owns the collection.
-   The default is you; use **Pick an existing user** to name Dr. Reyes, **Create a new user** if she has no account yet, or **Send an ownership invite** to mint a link she redeems herself.
-   Dana has never seen Dr. Reyes sign in, so this becomes an ownership invite — see [Transfer ownership of a collection](#transfer-ownership-of-a-collection).
+   The default is you; use **Pick an existing user** to name them, **Create a new user** if they have no account yet, or **Send an ownership invite** to mint a link they redeem themselves.
+
+   > Dr. Reyes has never signed in to the origin, so Dana reaches for an ownership invite — see [Transfer ownership of a collection](#transfer-ownership-of-a-collection).
 5. Under **Access Control**, fill in the three group rows — the `admin` row becomes the collection's admin group, the `write` row and the `read` row become access grants.
    Each row can either create a fresh group or attach one that already exists.
 
    > Dana creates `reyes-postdocs` as the admin group and `reyes-grads` with `write`, and leaves the `read` row disabled for now because the undergraduates have not joined yet.
 6. Click **ONBOARD COLLECTION** at the bottom of the form.
 
-One form, and Dana is done: the lab now runs its own access control, and Research Computing is out of the loop for everything that follows.
+> One form, and Dana is done: the lab now runs its own access control, and Research Computing is out of the loop for everything that follows.
 
 **QUICK CREATE** is the escape hatch: it creates the collection only (**Name**, **Namespace**, **Description**, **Visibility**, and optional **Reader Group** / **Writer Group** / **Admin Group** pickers), leaving ownership and the rest of the access grants for the edit page.
 
-## Choose a namespace for the collection
-
-> Dana's first attempt was `/riptide/reyes-lab`, which the form refused.
-> The export is `/riptide-university`, and `/riptide` is not a shorter way of saying it — a prefix only matches at a path boundary.
-
-The namespace is not cosmetic — it is spliced into the storage scopes on every token minted for the collection, so the rules are enforced strictly.
-
-- It has to sit **inside a prefix this origin exports**, either equal to an exported prefix or a path-descendant of one.
-  `/riptide-university/reyes-lab` is accepted under an export of `/riptide-university`; it is not accepted under an export of `/riptide`, because a prefix only matches at a path boundary.
-- It is **canonicalised before it is checked and before it is stored**, so `/a/b/../c` becomes `/a/c` and both the export check and the eventual token scope see the same value.
-- Whitespace, control characters and `:` are rejected outright.
-
-Several collections can live under one export, which is the usual arrangement: one export of `/riptide-university`, one collection per lab beneath it.
-The Reyes Lab is one of nine collections Dana has onboarded under that export this year.
-
-<Callout type="info">
-A collection can only narrow or subdivide what the export already permits.
-If the export itself is public, a private collection at that prefix does not make the objects unreadable.
-For choosing sensible prefixes in the first place, see [Namespace Prefixes and How To Choose One](/federating-your-data/choosing-namespaces).
-</Callout>
-
 ## Grant read or write access to a group
 
-*Requires the collection's owner, a member of its admin group, or `server.collection_admin` — a `write` grant is not enough to change who else has access. See [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+*Requires a member of the collection's admin group, the collection's owner, or `server.collection_admin` — a `write` grant is not enough to change who else has access. See [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
 > Two weeks into the semester, Tomás Vela and Bea Nkemelu join the lab for a senior project.
 > They need to read the processed deployment files, and they must not be able to overwrite them — one accidental upload over a calibrated dataset would cost the lab a month.
 > Dr. Raman puts both of them in `reyes-undergrads` and grants that group `read`.
 > Wes Danforth, who uploads each new deployment, is already in `reyes-grads`, which gets `write`.
-> Dr. Raman does all of it from the admin group, without asking Research Computing for anything.
 
 Grants are written against **groups**, never against individual users.
 To give one person access, put them in a group — every user also has an implicit personal group named `user-<username>` you can grant to directly.
@@ -113,37 +97,14 @@ Roles are `read` and `write`; a grant may carry an expiry, after which it stops 
 
 1. Open **Collections**, find the collection, and click the **Edit collection** (pencil) icon on its row.
 2. Scroll to **Access groups**.
-3. In **Add group**, pick the group — `reyes-undergrads` for the read grant.
+3. In **Add group**, pick the group.
 4. Set **Role** to `Read` or `Write`.
 5. Click **ADD**.
-6. Repeat for `reyes-grads` with **Role** `Write`.
+6. Repeat for each further group you want to grant.
+
+   > Dr. Raman adds `reyes-undergrads` with **Role** `Read`, then repeats the three steps for `reyes-grads` with **Role** `Write`.
 
 Existing rows are listed above the picker with their role; the trash icon beside a row revokes it.
-
-<Callout type="info">
-`owner` is not a role you can grant here.
-Ownership is a field on the collection, and full management authority is the admin group — see the two sections below.
-Older collections may still show a legacy `owner` grant; it is safe to revoke once the owner and admin group are set.
-</Callout>
-
-## Grant access to every signed-in user
-
-*Same prerequisite as the section above.*
-
-> The lab produces one derived product — a weekly tide-gauge summary — that any Riptide student or staff member should be able to pull for a class project, while the raw instrument data stays restricted.
-> Dana onboards a second collection at `/riptide-university/reyes-lab/public-summaries` with the same admin group, and Dr. Raman grants `@authenticated` `read` on it.
-> Nobody has to maintain a campus-wide group, and the raw data above it is untouched.
-
-`@authenticated` is a virtual target that matches every caller who is signed in, regardless of group membership.
-Use it when the answer to "who may read this?" is "anyone with an account on this server".
-
-In the web interface it appears at the top of the **Add group** picker as **All authenticated users**, marked *Virtual group · matches every signed-in caller*.
-Pick it, choose a role, and click **ADD**, exactly as for a real group.
-
-Two things it does not do.
-It does not make the collection public — visibility controls who can *see that the collection exists*, and is a separate field.
-And it never appears in a token's group claim, because it is not a real group: it cannot be created, joined, or listed as a member.
-Anonymous callers do not match it either; a request with no identity at all is not "authenticated".
 
 ## Delegate day-to-day management to an admin group
 
@@ -157,8 +118,10 @@ Admin-group members can edit the collection's name, description, visibility and 
 They cannot transfer ownership and they cannot delete the collection — both stay with the owner.
 
 1. Open the collection's **Edit collection** page.
-2. In the **Ownership** panel, use the **Admin group (optional)** picker to select `reyes-postdocs`.
+2. In the **Ownership** panel, use the **Admin group (optional)** picker to select the group.
 3. Click **SAVE CHANGES**.
+
+   > Dr. Reyes picks `reyes-postdocs`, and from then on Dr. Raman's group handles the student groups.
 
 Clearing the picker removes the admin group.
 Once one is set, a **Manage admin group →** link appears beside it so you can jump straight to that group's membership page.
@@ -172,34 +135,29 @@ Once one is set, a **Manage admin group →** link appears beside it so you can 
 > Dr. Reyes signs in for the first time, redeems it, and owns the collection from that moment; Dana's ownership ends in the same instant.
 > Three years later, when Dr. Reyes moves to another university and Dr. Raman takes over the project, the same page moves ownership again — this time directly, because Dr. Raman already has an account.
 
-Every collection has exactly one owner, and it can be moved but never cleared — a `PATCH` that empties `ownerId` is refused.
+Every collection has exactly one owner, and it can be moved but never cleared.
 There are two routes, depending on whether the new owner already has an account.
 
-**If they do**, set the owner directly.
+### If the owner has an account
+
 On the collection's **Edit collection** page, pick them in the **Owner** field and click **SAVE CHANGES**.
+
 If you hold `server.user_admin` the picker lists every user on the server; otherwise it offers only the collection's own people — the current owner, admin-group members, and members of any group already granted access.
 
-**If they do not**, mint an ownership-transfer invite.
+### If the owner does not have an account
+
+Mint an ownership-transfer invite.
 The recipient signs in (self-enrolling through OIDC if this is their first visit), redeems the link, and becomes the owner at that moment; the previous owner loses ownership simultaneously.
 These links are always single-use.
 
 1. On the **Edit collection** page, scroll to **Transfer via invite link**.
 2. Click **GENERATE TRANSFER LINK**.
 3. Copy the URL with **COPY URL**.
-
-<Callout type="warning">
-Pelican mints the link and shows you the token exactly once; delivering it to the right person is your job.
-Pelican does not send email.
-</Callout>
+4. Send this link to the new owner of the collection.
 
 ## Turn on sharing
 
 *Requires the collection's owner, an admin-group member, or `server.collection_admin` — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
-
-> Dr. Hollis Park at Cape Meridian Marine Lab wants the March deployment — one directory, not the lab's whole archive, and Dr. Park has no Riptide affiliation to hang a group membership on.
-> Wes Danforth, who ran that deployment, is the obvious person to arrange it, and Wes holds no management scope whatsoever.
-> Dr. Reyes switches sharing on for the collection.
-> That does not give Dr. Park anything yet; it means Wes can now hand out part of the access Wes already has, without anyone granting Wes new privileges to do it.
 
 Shares are off by default.
 Turning them on lets anyone who holds `read` on the collection delegate part of that access onward.
@@ -211,34 +169,27 @@ It creates nothing by itself; it only makes share creation reachable for the col
 
 <Callout type="warning">
 Shares are not supported when the origin runs a multi-user POSIX backend ([`Origin.Multiuser`](/parameters#Origin-Multiuser)).
-Serving share data means acting as the share's owner, and the multi-user backend cannot safely re-target the operating-system identity it serves a request under.
-Creating a share on such an origin is refused with `409`, and if multi-user mode is turned on after shares already exist, any token carrying `share.access` is rejected outright rather than quietly falling back to the presenter's identity.
 </Callout>
 
 ## Create a share
 
 *Requires `read` on the parent collection, with sharing enabled on it — see [Share administration](/managing-data-access/permissions-reference#share-administration).*
 
-> Wes creates a share named `Park Lab — Deployment 12`, scoped to `/riptide-university/reyes-lab/deployments/2026-03`.
-> Wes owns it, so Wes manages it, and Dr. Park sees exactly that one deployment and nothing else in the lab's archive.
-> The arrangement is also self-limiting: if Wes graduates and drops off the `reyes-grads` grant, the share stops issuing usable tokens by itself, with nobody having to remember it exists.
+> The graduate student Wes has a set of interns working on an experimental data transformation.
+> Wes creates a share that his interns can access and write data too under a folder he created for them.
+> When Wes graduates his interns will automatically lose access to this space when Wes does.
 
 A share is a collection, so everything you already know about granting access applies to it.
 What makes it a share is the parent link, and the constraints that come with it:
 
 - **You own the share, not the parent's owner.** You hold owner authority on the share and manage it yourself.
+- **It is bound to you.** Data read through it is served as you, and its access is re-intersected with your own access to the parent on every issuance — so a share can never outgrow the person who made it, and it fades as they do.
 - **The namespace has to equal the parent's or sit beneath it.** Leave it blank to inherit the parent's namespace exactly.
 - **Shares start private**, and sharing is forced off on the new share — you cannot create a share of a share.
 
 Access through a share is always the weaker of two things: what the share grants its recipient, and what the share's owner can currently do on the parent collection.
 That intersection is recomputed each time a token is *issued*, so if the share owner is downgraded from write to read — or loses access to the parent altogether — every token minted through the share from that point on is clamped or emptied.
 A share cannot be used to delegate access its owner no longer has.
-
-<Callout type="warning">
-Refreshing an existing token does not re-run the intersection.
-The issuer re-grants the scopes already stored on the session, so an already-issued token keeps its original access until it expires and a new authorization is performed.
-Plan for access changes to take effect on the next issuance, not immediately.
-</Callout>
 
 To create one:
 
@@ -255,15 +206,12 @@ Shares appear in the collections list alongside collections, tagged with a **sha
 
 *Requires the share's owner (or `server.collection_admin`) — see [Share administration](/managing-data-access/permissions-reference#share-administration).*
 
-> Dr. Park's postdocs need the deployment too, so Wes grants the `park-lab` group `read` on the share rather than naming Dr. Park alone.
-> Cape Meridian then manages its own end: when someone joins or leaves Dr. Park's lab, that is a membership change at Cape Meridian, and Wes never hears about it.
+> Wes grants `read` to intern Sophia alone, through the implicit personal group `user-sophia` — one reader, no group to keep current.
 
 Because a share is a collection, you grant access to it exactly as in [Grant read or write access to a group](#grant-read-or-write-access-to-a-group) — same **Access groups** panel on the share's edit page, with the share's ID in place of the collection's.
-`@authenticated` works here too.
 
 The difference is whose identity the data is served as.
 Objects reached through a share are served as the share's *owner*, not as the person presenting the token, which is why the intersection above is enforced — the share owner stays accountable for everything read or written through the share.
-So every byte Cape Meridian reads through this share is read as Wes.
 See [Data access](/managing-data-access/permissions-reference#data-access) for the scope the issuer mints to arrange that.
 
 ## Revoke access
@@ -273,7 +221,7 @@ See [Data access](/managing-data-access/permissions-reference#data-access) for t
 > Three things end in the same May, and each one calls for a different lever.
 > Bea graduates while Tomás stays on for a master's — Dr. Raman removes Bea from `reyes-undergrads` and touches nothing else.
 > The senior project itself wraps up, so the `reyes-undergrads` read grant comes off the collection entirely.
-> And Wes finishes the degree and drops to `read` on the parent, which quietly clamps the Cape Meridian share to read as well, without anyone editing the share.
+> And Wes defends and leaves, so the `reyes-grads` grant goes — which empties the intern share on its next issuance, without anyone editing the share.
 
 Three levers, in increasing order of blast radius.
 
@@ -290,19 +238,9 @@ All three take effect the next time a token is *issued*, not against tokens alre
 An access token minted before you revoked keeps working until it expires, and the one after it is smaller or empty.
 Deleting a group is the blunt version of lever 2 — it removes every collection grant that names that group, everywhere.
 
-<Callout type="warning">
-Refreshing a token does not re-run these checks.
-The issuer re-grants the scopes already stored on the session, so a session that keeps refreshing holds its original data access until that session ends and the holder authorizes again.
-Revocation is not a way to cut off an active session immediately.
-</Callout>
-
 ## Delete a collection or share
 
 *Requires the owner or `server.collection_admin`; admin-group members cannot delete — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
-
-> The Deployment 12 paper comes out and the collaboration is finished, so Wes deletes the Cape Meridian share — Wes owns it, so Wes is the one who can.
-> Years later the whole dataset is archived with a DOI elsewhere and Dr. Raman, now the owner, deletes the collection.
-> The four terabytes do not go anywhere: deleting the collection removes the access-control record, and the objects remain under `/riptide-university`, governed by Dana's export alone.
 
 Deleting a collection removes its grants, its metadata and its list of member objects along with it.
 Deleting a share is the same operation — a share is a collection — and is done by the share's owner.
@@ -358,38 +296,3 @@ The two share endpoints are also not yet described in the [API browser](/api-doc
 
 On the command line and the API, `@authenticated` goes wherever you would pass a group name, and `--group-id` accepts either a group's internal ID or its name — Pelican stores the canonical name on the grant either way.
 The command line and the API call a collection's set of grants its **ACL** (access control list), which is why the subcommand is `acl grant`; see [`collection acl`](/commands-reference/pelican-server/origin/collection/acl).
-
-## Troubleshooting
-
-**`403 you must hold server.collection_admin (or server.admin) to create a collection`**
-Signing in is enough to *reach* the collections API, but not to create a collection.
-Ask a system administrator to grant you `server.collection_admin`, or to create the collection and transfer it to you — which is exactly the route Dana and Dr. Reyes take above.
-
-**`Namespace '…' is not within a prefix exported by this origin`**
-The path is outside every export, or it looks like a match but is not one at a path boundary (`/riptide/reyes-lab` is not inside an export of `/riptide-university`).
-Check the origin's exports, then re-check after canonicalisation — `/a/b/../c` is stored and validated as `/a/c`.
-
-**`409 Sharing is not enabled on this collection`**
-The parent collection's owner has not switched on **Allow users to create shares**.
-See [Turn on sharing](#turn-on-sharing).
-
-**`409 Shares are not supported on multi-user origin backends`**
-This origin runs a multi-user POSIX backend, where serving data as the share's owner is not possible.
-Grant access on the collection itself instead of creating a share.
-
-**`404 collection not found` on a collection you are sure exists**
-Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it.
-A `404` on a collection or group you believe exists usually means you lack access, not that it is missing.
-This is also what a non-owner sees when they try to transfer ownership or mint an ownership invite.
-
-**`cannot create a share of an existing share`**
-Shares are one hop deep.
-Create the share from the original collection, or ask its owner to grant the person access directly.
-
-**`ownerId cannot be empty; transfer to a real user instead`**
-Ownership can move but not be cleared.
-Name a replacement owner, or mint an ownership-transfer invite.
-
-**A `write` grant does not let you change who else has access.**
-`write` covers the data and the collection's descriptive fields, not who else gets in.
-Wes can upload a deployment and cannot add anybody to the lab; put someone in the admin group if they should manage access.

--- a/docs/app/managing-data-access/collections-and-shares/page.mdx
+++ b/docs/app/managing-data-access/collections-and-shares/page.mdx
@@ -6,13 +6,28 @@ A **collection** is a prefix inside a namespace your origin already exports, tog
 A **share** is a child collection an ordinary user creates to hand part of their own access to someone else.
 This page is the main task list for this section: how to create a collection, decide which groups can read or write it, hand it to the person responsible for it, and let that person pass access on to their own collaborators.
 
-One example runs through this page.
-An origin administrator creates a collection for a principal investigator, Dr. Reyes.
-Dr. Reyes owns it but does not run it day to day — her postdocs do, as the collection's **admin group**.
-The postdocs then give the lab's undergraduates `read` and the graduate students `write`.
+Every task here is written for the origin's **web interface**, because that is the one place all of it can be done.
+Most of it can also be scripted; see [Doing this from the command line or the API](#doing-this-from-the-command-line-or-the-api) at the end of the page.
 
 If you want the model behind these tasks rather than the tasks themselves, read [How Access Control Works](/managing-data-access/access-control-model).
 For the authoritative "who may do this", see the [Permissions Reference](/managing-data-access/permissions-reference).
+
+## The lab in the examples
+
+One story runs through this page, so that every task has a reason behind it instead of just a form to fill in.
+
+**Riptide University** runs a Pelican origin in front of its research storage, already exporting the prefix `/riptide-university`.
+The **Reyes Lab** studies nearshore currents, and has just come back from a field season with several terabytes of instrument data that its collaborators need to reach.
+Over the sections below, the lab's collection gets created, handed to the people who run it, opened up to students, and eventually shared with a collaborator at another institution.
+
+| Person | Role in the story | Group |
+| --- | --- | --- |
+| Dana Cho | Origin administrator, Riptide University Research Computing. Holds `server.collection_admin`. | — |
+| Dr. Elena Reyes | Principal investigator. Owns the collection and answers for it. | — |
+| Dr. Priya Raman | Postdoc. Runs the collection day to day. | `reyes-postdocs` — the admin group |
+| Wes Danforth | Graduate student. Processes each new deployment. | `reyes-grads` — `write` |
+| Tomás Vela and Bea Nkemelu | Undergraduates on a senior project. Read the processed data, never overwrite it. | `reyes-undergrads` — `read` |
+| Dr. Hollis Park | Collaborator at Cape Meridian Marine Lab, with no Reyes Lab affiliation at all. | `park-lab` — `read`, through a share |
 
 ## Before you start
 
@@ -21,69 +36,60 @@ Three things need to be true before any of this works.
 1. **The export exists.**
    A collection is access control *inside* an exported namespace, not a way to publish new storage.
    Export the storage first — see [Serving an Origin](/federating-your-data/origin) — then create a collection at that prefix or below it.
+   Riptide University's storage is exported at `/riptide-university` before Dana touches the Collections page.
 2. **You hold `server.collection_admin` (or `server.admin`) to create a collection.**
    Running one afterwards does not require it: the owner and the admin group manage the collection with no management scope at all.
+   That is the whole point of the handoff below — Dana needs the scope once, and Dr. Reyes and Dr. Raman never need it.
    See [Collection administration](/managing-data-access/permissions-reference#collection-administration).
 3. **The groups you want to give access to exist**, or you are willing to create them as you go.
    Any signed-in user can create a group; see [Create a group](/managing-data-access/users-and-groups#create-a-group).
 
-The `pelican-server origin collection` commands ship in the `pelican-server` binary.
-They find your origin by asking the Director (so `Federation.DirectorUrl` has to be configured), then send you through a browser device-code approval to obtain a token — you do not need shell access on the origin host, but you do need a browser and an account on that origin.
-In a federation with more than one origin the commands target the first origin the Director returns, so prefer the web interface when several origins are registered.
-Flags and syntax live in the generated [`pelican-server origin collection`](/commands-reference/pelican-server/origin/collection) reference; request and response bodies live in the [API browser](/api-docs).
+Beyond that you need your origin's web URL and an account on that origin.
+Sign in and you will find **Collections** in the left sidebar.
 
 ## Create a collection
 
 *Requires `server.collection_admin` or `server.admin` — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
-### Web UI
+> Dr. Reyes emails Research Computing: the lab's spring field season produced four terabytes of current-meter data, three institutions want to work on it, and right now it is sitting on a departmental disk.
+> Dana Cho picks up the ticket.
+> The storage is already exported at `/riptide-university`, so there is no new hardware and no new export to arrange — what the lab actually needs is a collection: a named prefix with an owner and a list of who may read and write it.
 
-The **ONBOARD COLLECTION** form does the whole example in one pass: the collection, its owner, and its three groups.
+The **ONBOARD COLLECTION** form does the whole thing in one pass: the collection, its owner, and its three groups.
 
 1. In the Origin web interface, open **Collections** in the left sidebar.
 2. Click **ONBOARD COLLECTION**.
 3. Under **Collection**, fill in:
    - **Name** — a short human-readable name, for example `Reyes Lab`.
-   - **Exported namespace** — pick the exported prefix from the dropdown and type the rest of the path in the box beside it. The full path is shown back to you as you type.
-   - **Description** and **Visibility** (`Private` or `Public`).
+   - **Exported namespace** — pick the exported prefix from the dropdown and type the rest of the path in the box beside it. Dana picks `/riptide-university` and types `reyes-lab`. The full path is shown back as you type.
+   - **Description** and **Visibility** (`Private` or `Public`). Dana writes "Nearshore current data, Reyes Lab" and leaves it `Private`.
 4. Under **Ownership**, choose who owns the collection.
    The default is you; use **Pick an existing user** to name Dr. Reyes, **Create a new user** if she has no account yet, or **Send an ownership invite** to mint a link she redeems herself.
+   Dana has never seen Dr. Reyes sign in, so this becomes an ownership invite — see [Transfer ownership of a collection](#transfer-ownership-of-a-collection).
 5. Under **Access Control**, fill in the three group rows — the `admin` row becomes the collection's admin group, the `write` row and the `read` row become access grants.
    Each row can either create a fresh group or attach one that already exists.
-   Disable any row you do not need.
+
+   > Dana creates `reyes-postdocs` as the admin group and `reyes-grads` with `write`, and leaves the `read` row disabled for now because the undergraduates have not joined yet.
 6. Click **ONBOARD COLLECTION** at the bottom of the form.
+
+One form, and Dana is done: the lab now runs its own access control, and Research Computing is out of the loop for everything that follows.
 
 **QUICK CREATE** is the escape hatch: it creates the collection only (**Name**, **Namespace**, **Description**, **Visibility**, and optional **Reader Group** / **Writer Group** / **Admin Group** pickers), leaving ownership and the rest of the access grants for the edit page.
 
-### CLI
-
-```bash copy
-pelican-server origin collection create \
-  --name "Reyes Lab" \
-  --namespace /CoolScienceOrg/reyes-lab \
-  --description "Storage area for the Reyes lab" \
-  --visibility private
-```
-
-The command prints the new collection, including its ID.
-You need that ID for every later command on this collection.
-
-### API
-
-`POST /api/v1.0/origin_ui/collections`, with the name, namespace, description, visibility and any initial metadata in the body.
-The response carries the new collection's ID.
-See [/api-docs](/api-docs) for the exact shape.
-
 ## Choose a namespace for the collection
+
+> Dana's first attempt was `/riptide/reyes-lab`, which the form refused.
+> The export is `/riptide-university`, and `/riptide` is not a shorter way of saying it — a prefix only matches at a path boundary.
 
 The namespace is not cosmetic — it is spliced into the storage scopes on every token minted for the collection, so the rules are enforced strictly.
 
 - It has to sit **inside a prefix this origin exports**, either equal to an exported prefix or a path-descendant of one.
-  `/CoolScienceOrg/reyes-lab` is accepted under an export of `/CoolScienceOrg`; it is not accepted under an export of `/CoolScience`, because a prefix only matches at a path boundary.
+  `/riptide-university/reyes-lab` is accepted under an export of `/riptide-university`; it is not accepted under an export of `/riptide`, because a prefix only matches at a path boundary.
 - It is **canonicalised before it is checked and before it is stored**, so `/a/b/../c` becomes `/a/c` and both the export check and the eventual token scope see the same value.
 - Whitespace, control characters and `:` are rejected outright.
 
-Several collections can live under one export, which is the usual arrangement: one export of `/CoolScienceOrg`, one collection per lab beneath it.
+Several collections can live under one export, which is the usual arrangement: one export of `/riptide-university`, one collection per lab beneath it.
+The Reyes Lab is one of nine collections Dana has onboarded under that export this year.
 
 <Callout type="info">
 A collection can only narrow or subdivide what the export already permits.
@@ -95,11 +101,15 @@ For choosing sensible prefixes in the first place, see [Namespace Prefixes and H
 
 *Requires the collection's owner, a member of its admin group, or `server.collection_admin` — a `write` grant is not enough to change who else has access. See [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
+> Two weeks into the semester, Tomás Vela and Bea Nkemelu join the lab for a senior project.
+> They need to read the processed deployment files, and they must not be able to overwrite them — one accidental upload over a calibrated dataset would cost the lab a month.
+> Dr. Raman puts both of them in `reyes-undergrads` and grants that group `read`.
+> Wes Danforth, who uploads each new deployment, is already in `reyes-grads`, which gets `write`.
+> Dr. Raman does all of it from the admin group, without asking Research Computing for anything.
+
 Grants are written against **groups**, never against individual users.
 To give one person access, put them in a group — every user also has an implicit personal group named `user-<username>` you can grant to directly.
 Roles are `read` and `write`; a grant may carry an expiry, after which it stops matching.
-
-### Web UI
 
 1. Open **Collections**, find the collection, and click the **Edit collection** (pencil) icon on its row.
 2. Scroll to **Access groups**.
@@ -109,27 +119,6 @@ Roles are `read` and `write`; a grant may carry an expiry, after which it stops 
 6. Repeat for `reyes-grads` with **Role** `Write`.
 
 Existing rows are listed above the picker with their role; the trash icon beside a row revokes it.
-
-### CLI
-
-```bash copy
-pelican-server origin collection acl grant <collection-id> \
-  --group-id reyes-undergrads --role read
-
-pelican-server origin collection acl grant <collection-id> \
-  --group-id reyes-grads --role write
-```
-
-`--group-id` accepts either the group's internal ID or its name; Pelican stores the canonical name on the grant either way.
-The CLI and API call a collection's set of grants its **ACL** (access control list), which is why the subcommand is `acl grant`.
-`--role` accepts `read` or `write`.
-See [`collection acl`](/commands-reference/pelican-server/origin/collection/acl).
-
-### API
-
-`POST /api/v1.0/origin_ui/collections/{id}/acl` with the group and role, and an optional expiry.
-`DELETE` on the same path revokes a grant.
-See [/api-docs](/api-docs).
 
 <Callout type="info">
 `owner` is not a role you can grant here.
@@ -141,12 +130,15 @@ Older collections may still show a legacy `owner` grant; it is safe to revoke on
 
 *Same prerequisite as the section above.*
 
+> The lab produces one derived product — a weekly tide-gauge summary — that any Riptide student or staff member should be able to pull for a class project, while the raw instrument data stays restricted.
+> Dana onboards a second collection at `/riptide-university/reyes-lab/public-summaries` with the same admin group, and Dr. Raman grants `@authenticated` `read` on it.
+> Nobody has to maintain a campus-wide group, and the raw data above it is untouched.
+
 `@authenticated` is a virtual target that matches every caller who is signed in, regardless of group membership.
 Use it when the answer to "who may read this?" is "anyone with an account on this server".
 
 In the web interface it appears at the top of the **Add group** picker as **All authenticated users**, marked *Virtual group · matches every signed-in caller*.
 Pick it, choose a role, and click **ADD**, exactly as for a real group.
-On the CLI and the API, pass `@authenticated` where you would pass a group.
 
 Two things it does not do.
 It does not make the collection public — visibility controls who can *see that the collection exists*, and is a separate field.
@@ -157,13 +149,12 @@ Anonymous callers do not match it either; a request with no identity at all is n
 
 *Requires the collection's owner, an existing admin-group member, or `server.collection_admin` — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
-The admin group is how Dr. Reyes stays responsible for the collection without running it.
-Her postdocs' group becomes the admin group, and from then on they add and remove the undergraduate and graduate groups themselves.
+> Dr. Reyes spends six weeks a year on a research vessel with a satellite link she would rather not use for access-control tickets.
+> She stays the owner — the collection is the lab's, and hers to answer for — but she has no intention of adding a student to a group at 3 a.m. ship time.
+> `reyes-postdocs` is the admin group — Dana set it during onboarding, and this is the page to change it on — which makes Dr. Raman's group the one that adds and removes the student groups from then on, while transfer and deletion stay with Dr. Reyes.
 
 Admin-group members can edit the collection's name, description, visibility and sharing setting, read and write its metadata, grant and revoke access, and reassign the admin group.
 They cannot transfer ownership and they cannot delete the collection — both stay with the owner.
-
-### Web UI
 
 1. Open the collection's **Edit collection** page.
 2. In the **Ownership** panel, use the **Admin group (optional)** picker to select `reyes-postdocs`.
@@ -172,16 +163,14 @@ They cannot transfer ownership and they cannot delete the collection — both st
 Clearing the picker removes the admin group.
 Once one is set, a **Manage admin group →** link appears beside it so you can jump straight to that group's membership page.
 
-### API
-
-`PATCH /api/v1.0/origin_ui/collections/{id}` with the admin group's ID.
-See [/api-docs](/api-docs).
-
-There is no CLI path for this today: `pelican-server origin collection update` covers the descriptive fields only, so the admin group is set from the web interface or the API.
-
 ## Transfer ownership of a collection
 
 *Requires the current owner or `server.collection_admin`; admin-group members cannot transfer — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
+
+> Dana created the collection before Dr. Reyes had ever signed in to the origin, which made Dana the initial owner — an accident of sequencing, not a decision anyone wanted to keep.
+> Dana mints a transfer link and pastes it into the ticket reply.
+> Dr. Reyes signs in for the first time, redeems it, and owns the collection from that moment; Dana's ownership ends in the same instant.
+> Three years later, when Dr. Reyes moves to another university and Dr. Raman takes over the project, the same page moves ownership again — this time directly, because Dr. Raman already has an account.
 
 Every collection has exactly one owner, and it can be moved but never cleared — a `PATCH` that empties `ownerId` is refused.
 There are two routes, depending on whether the new owner already has an account.
@@ -189,7 +178,6 @@ There are two routes, depending on whether the new owner already has an account.
 **If they do**, set the owner directly.
 On the collection's **Edit collection** page, pick them in the **Owner** field and click **SAVE CHANGES**.
 If you hold `server.user_admin` the picker lists every user on the server; otherwise it offers only the collection's own people — the current owner, admin-group members, and members of any group already granted access.
-The API equivalent is `PATCH /api/v1.0/origin_ui/collections/{id}` with the new owner's user ID.
 
 **If they do not**, mint an ownership-transfer invite.
 The recipient signs in (self-enrolling through OIDC if this is their first visit), redeems the link, and becomes the owner at that moment; the previous owner loses ownership simultaneously.
@@ -198,15 +186,6 @@ These links are always single-use.
 1. On the **Edit collection** page, scroll to **Transfer via invite link**.
 2. Click **GENERATE TRANSFER LINK**.
 3. Copy the URL with **COPY URL**.
-
-From the CLI:
-
-```bash copy
-pelican-server origin collection ownership-invite create <collection-id>
-```
-
-See [`collection ownership-invite`](/commands-reference/pelican-server/origin/collection/ownership-invite).
-The API equivalent is `POST /api/v1.0/origin_ui/collections/{id}/ownership-invites`.
 
 <Callout type="warning">
 Pelican mints the link and shows you the token exactly once; delivering it to the right person is your job.
@@ -217,16 +196,18 @@ Pelican does not send email.
 
 *Requires the collection's owner, an admin-group member, or `server.collection_admin` — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
+> Dr. Hollis Park at Cape Meridian Marine Lab wants the March deployment — one directory, not the lab's whole archive, and Dr. Park has no Riptide affiliation to hang a group membership on.
+> Wes Danforth, who ran that deployment, is the obvious person to arrange it, and Wes holds no management scope whatsoever.
+> Dr. Reyes switches sharing on for the collection.
+> That does not give Dr. Park anything yet; it means Wes can now hand out part of the access Wes already has, without anyone granting Wes new privileges to do it.
+
 Shares are off by default.
-Turning them on lets anyone who holds `read` on the collection delegate part of that access onward — useful when a graduate student has to give an outside collaborator one directory and holds no management scope of their own.
+Turning them on lets anyone who holds `read` on the collection delegate part of that access onward.
 It creates nothing by itself; it only makes share creation reachable for the collection's readers.
 
 1. Open the collection's **Edit collection** page.
 2. Under **Details**, switch on **Allow users to create shares**.
 3. Click **SAVE CHANGES**.
-
-The API equivalent is `PATCH /api/v1.0/origin_ui/collections/{id}` with the sharing flag.
-There is no CLI flag for this setting today, so it is a web-interface or API task.
 
 <Callout type="warning">
 Shares are not supported when the origin runs a multi-user POSIX backend ([`Origin.Multiuser`](/parameters#Origin-Multiuser)).
@@ -237,6 +218,10 @@ Creating a share on such an origin is refused with `409`, and if multi-user mode
 ## Create a share
 
 *Requires `read` on the parent collection, with sharing enabled on it — see [Share administration](/managing-data-access/permissions-reference#share-administration).*
+
+> Wes creates a share named `Park Lab — Deployment 12`, scoped to `/riptide-university/reyes-lab/deployments/2026-03`.
+> Wes owns it, so Wes manages it, and Dr. Park sees exactly that one deployment and nothing else in the lab's archive.
+> The arrangement is also self-limiting: if Wes graduates and drops off the `reyes-grads` grant, the share stops issuing usable tokens by itself, with nobody having to remember it exists.
 
 A share is a collection, so everything you already know about granting access applies to it.
 What makes it a share is the parent link, and the constraints that come with it:
@@ -255,7 +240,7 @@ The issuer re-grants the scopes already stored on the session, so an already-iss
 Plan for access changes to take effect on the next issuance, not immediately.
 </Callout>
 
-### Web UI
+To create one:
 
 1. Open **Collections** and find the parent collection.
    The share icon appears on its row only when sharing is enabled there.
@@ -266,28 +251,29 @@ Plan for access changes to take effect on the next issuance, not immediately.
 
 Shares appear in the collections list alongside collections, tagged with a **share** chip.
 
-### API
-
-`POST /api/v1.0/origin_ui/collections/{id}/shares`, where `{id}` is the parent collection.
-`GET` on the same path lists a parent's shares.
-
-There is no `pelican-server origin collection share` command family, so outside the web interface this is an API-only task.
-These two endpoints are also not yet described in the [API browser](/api-docs) — the surrounding collection endpoints are.
-
 ## Give people access to a share
 
 *Requires the share's owner (or `server.collection_admin`) — see [Share administration](/managing-data-access/permissions-reference#share-administration).*
 
-Because a share is a collection, you grant access to it exactly as in [Grant read or write access to a group](#grant-read-or-write-access-to-a-group) — same **Access groups** panel on the share's edit page, same `acl grant` command, same endpoint, with the share's ID in place of the collection's.
+> Dr. Park's postdocs need the deployment too, so Wes grants the `park-lab` group `read` on the share rather than naming Dr. Park alone.
+> Cape Meridian then manages its own end: when someone joins or leaves Dr. Park's lab, that is a membership change at Cape Meridian, and Wes never hears about it.
+
+Because a share is a collection, you grant access to it exactly as in [Grant read or write access to a group](#grant-read-or-write-access-to-a-group) — same **Access groups** panel on the share's edit page, with the share's ID in place of the collection's.
 `@authenticated` works here too.
 
 The difference is whose identity the data is served as.
 Objects reached through a share are served as the share's *owner*, not as the person presenting the token, which is why the intersection above is enforced — the share owner stays accountable for everything read or written through the share.
+So every byte Cape Meridian reads through this share is read as Wes.
 See [Data access](/managing-data-access/permissions-reference#data-access) for the scope the issuer mints to arrange that.
 
 ## Revoke access
 
 *Prerequisites vary by lever — see [Collection administration](/managing-data-access/permissions-reference#collection-administration) and [Share administration](/managing-data-access/permissions-reference#share-administration).*
+
+> Three things end in the same May, and each one calls for a different lever.
+> Bea graduates while Tomás stays on for a master's — Dr. Raman removes Bea from `reyes-undergrads` and touches nothing else.
+> The senior project itself wraps up, so the `reyes-undergrads` read grant comes off the collection entirely.
+> And Wes finishes the degree and drops to `read` on the parent, which quietly clamps the Cape Meridian share to read as well, without anyone editing the share.
 
 Three levers, in increasing order of blast radius.
 
@@ -296,7 +282,7 @@ Three levers, in increasing order of blast radius.
    See [Add and remove group members](/managing-data-access/users-and-groups#add-and-remove-group-members).
 2. **Revoke the grant**, or let its expiry pass.
    The whole group loses that role on that collection.
-   Use the trash icon beside the row under **Access groups**, `pelican-server origin collection acl revoke`, or `DELETE /api/v1.0/origin_ui/collections/{id}/acl`.
+   Use the trash icon beside the row under **Access groups**.
 3. **Remove a share owner's access to the parent.**
    This clamps or empties every token minted through every share that person owns, because the intersection is recomputed on each issuance.
 
@@ -314,37 +300,73 @@ Revocation is not a way to cut off an active session immediately.
 
 *Requires the owner or `server.collection_admin`; admin-group members cannot delete — see [Collection administration](/managing-data-access/permissions-reference#collection-administration).*
 
+> The Deployment 12 paper comes out and the collaboration is finished, so Wes deletes the Cape Meridian share — Wes owns it, so Wes is the one who can.
+> Years later the whole dataset is archived with a DOI elsewhere and Dr. Raman, now the owner, deletes the collection.
+> The four terabytes do not go anywhere: deleting the collection removes the access-control record, and the objects remain under `/riptide-university`, governed by Dana's export alone.
+
 Deleting a collection removes its grants, its metadata and its list of member objects along with it.
 Deleting a share is the same operation — a share is a collection — and is done by the share's owner.
 
-### Web UI
-
 On the **Collections** page, click the **Delete collection** (trash) icon on the row.
 The icon is shown to callers who can edit the collection, which is a slightly wider set than those who can delete it, so an admin-group member may see it and get an error.
-
-### CLI
-
-```bash copy
-pelican-server origin collection delete <collection-id>
-```
-
-### API
-
-`DELETE /api/v1.0/origin_ui/collections/{id}`.
 
 <Callout type="warning">
 Deleting a collection does not delete any objects under its namespace.
 It removes the access-control record; the data stays exactly where the export put it, governed by the export alone.
 </Callout>
 
+## Doing this from the command line or the API
+
+The web interface is the only surface that covers every task above, but it is not the only one.
+Reach for these when you are onboarding collections in bulk, or scripting the same handoff for thirty labs instead of one.
+
+**The command line.**
+The `pelican-server origin collection` commands ship in the `pelican-server` binary.
+They find your origin by asking the Director (so [`Federation.DirectorUrl`](/parameters#Federation-DirectorUrl) has to be configured), then send you through a browser device-code approval to obtain a token — you do not need shell access on the origin host, but you do need a browser and an account on that origin.
+In a federation with more than one origin the commands target the first origin the Director returns, so prefer the web interface when several origins are registered.
+Flags and syntax live in the generated [`pelican-server origin collection`](/commands-reference/pelican-server/origin/collection) reference.
+
+```bash copy
+pelican-server origin collection create \
+  --name "Reyes Lab" \
+  --namespace /riptide-university/reyes-lab \
+  --description "Nearshore current data, Reyes Lab" \
+  --visibility private
+```
+
+The command prints the new collection, including its ID, which every later command on that collection needs.
+
+**The API.**
+Every endpoint sits under `/api/v1.0/origin_ui/collections`, and takes a login cookie or an API token whose creator holds the scope the task calls for.
+Request and response bodies live in the [API browser](/api-docs).
+
+Coverage is not equal across the three, so here is what each one can actually do:
+
+| Task | Command line | API |
+| --- | --- | --- |
+| [Create a collection](#create-a-collection) | [`collection create`](/commands-reference/pelican-server/origin/collection/create) | `POST /collections` |
+| [Grant or revoke access](#grant-read-or-write-access-to-a-group) | [`collection acl grant`](/commands-reference/pelican-server/origin/collection/acl/grant) / [`revoke`](/commands-reference/pelican-server/origin/collection/acl/revoke) | `POST` / `DELETE /collections/{id}/acl` |
+| [Set the admin group](#delegate-day-to-day-management-to-an-admin-group) | — | `PATCH /collections/{id}` |
+| [Transfer ownership](#transfer-ownership-of-a-collection) | [`collection ownership-invite create`](/commands-reference/pelican-server/origin/collection/ownership-invite) (invite only) | `PATCH /collections/{id}`, or `POST /collections/{id}/ownership-invites` |
+| [Turn on sharing](#turn-on-sharing) | — | `PATCH /collections/{id}` |
+| [Create a share](#create-a-share) | — | `POST /collections/{id}/shares` |
+| [Delete a collection or share](#delete-a-collection-or-share) | [`collection delete`](/commands-reference/pelican-server/origin/collection/delete) | `DELETE /collections/{id}` |
+
+A dash means the web interface is the only option today.
+`pelican-server origin collection update` covers the descriptive fields only, which is why the admin group and the sharing switch have no command-line path.
+The two share endpoints are also not yet described in the [API browser](/api-docs), though the surrounding collection endpoints are.
+
+On the command line and the API, `@authenticated` goes wherever you would pass a group name, and `--group-id` accepts either a group's internal ID or its name — Pelican stores the canonical name on the grant either way.
+The command line and the API call a collection's set of grants its **ACL** (access control list), which is why the subcommand is `acl grant`; see [`collection acl`](/commands-reference/pelican-server/origin/collection/acl).
+
 ## Troubleshooting
 
 **`403 you must hold server.collection_admin (or server.admin) to create a collection`**
 Signing in is enough to *reach* the collections API, but not to create a collection.
-Ask a system administrator to grant you `server.collection_admin`, or to create the collection and transfer it to you.
+Ask a system administrator to grant you `server.collection_admin`, or to create the collection and transfer it to you — which is exactly the route Dana and Dr. Reyes take above.
 
 **`Namespace '…' is not within a prefix exported by this origin`**
-The path is outside every export, or it looks like a match but is not one at a path boundary (`/data/foo` is not inside an export of `/data/foobar`).
+The path is outside every export, or it looks like a match but is not one at a path boundary (`/riptide/reyes-lab` is not inside an export of `/riptide-university`).
 Check the origin's exports, then re-check after canonicalisation — `/a/b/../c` is stored and validated as `/a/c`.
 
 **`409 Sharing is not enabled on this collection`**
@@ -370,4 +392,4 @@ Name a replacement owner, or mint an ownership-transfer invite.
 
 **A `write` grant does not let you change who else has access.**
 `write` covers the data and the collection's descriptive fields, not who else gets in.
-Put them in the admin group if they should manage access.
+Wes can upload a deployment and cannot add anybody to the lab; put someone in the admin group if they should manage access.

--- a/docs/app/managing-data-access/page.mdx
+++ b/docs/app/managing-data-access/page.mdx
@@ -1,0 +1,147 @@
+export const metadata = {
+  asIndexPage: true,
+}
+
+import { Callout } from 'nextra/components'
+
+# Managing Data Access
+
+Pelican requires authorization for writing data and optionally for reading data.
+This section describes what kinds of access can be granted and situations it may be useful.
+
+## Requirements
+
+1. An Origin service, with a operational web interface
+2. A Namespace Prefix export configured in the Origin
+
+To create or delete a "collection" (see below), you must be a collections administrator (includes Origin administrators).
+
+## Process
+
+Key to the access model is the concept of a "collection".
+A collection:
+
+* has an "owner"
+* maps to a Namespace Prefix
+* determines who has access, and the level of access
+
+### Delegation
+
+The main benefit to this collection model is the ability to delegate the administration of the collection to others.
+
+1. A collections administrator creates a "collection" and designates a "collection owner".
+2. The collection owner may delegate management of the collection to another individual or to an "admin group".
+3. The collection owner or designated admin can further grant read or write access to other individuals or groups.
+
+### Collection management
+
+A collections administrator, the collection owner, or a member of the designated admin group may
+
+* edit the collection settings (name, description, etc.)
+* designate a different collection admin (individual or group)
+* grant read or write access to the collection to other groups
+
+### Users and groups
+
+The Origin service has the concept of users and groups.
+
+A **user** may log into the Origin's web interface to interact with the collections system.
+A **group** consists of one or more users.
+
+**Access permissions for a collection can only be assigned to a group, not a user.**
+
+An Origin configured with an OIDC provider will automatically provision users as they log into the Origin.
+Otherwise, an admin or different user can send an invite that will create a local account for the user.
+
+## Example
+
+<Callout type="note">
+  This example covers the full scope of what is possible, not what is required to implement.
+</Callout>
+
+To illustrate how the process works, consider the following fictional example.
+
+### Background
+
+**Dr. Reyes** is a research professor at Riptide University, whose lab focuses on collecting and analyzing experimental data.
+The researchers in the lab use a variety of national computing resources for the analysis and want to leverage the OSDF for the data movement.
+
+**Sysadmin Brian** was tasked with deploying the Origin service and related infrastructure, but does not have the effort to manage low-level access permissions.
+
+Dr. Reyes delegates day-to-day management of her lab, including the data, to her **lab manager Christina**.
+That means Christina should be the one responsible for granting and revoking access to the data, though Dr. Reyes is still the ultimate authority.
+
+There are two students working on the project: **Grad student Danny** is responsible for collecting the data, so he will need to be able to write to the data storage, and **undergrad student Andrew** needs to be able to read the data for his analyses.
+
+Here is a summary of the stakeholders in the story and their access requirements
+
+* **Sysadmin "Brian"** - deploys the Origin service.
+* **Research professor "Dr. Reyes"** - the ultimate authority on access for her lab's data.
+* **Lab manager "Christina"** - day-to-day management of lab, read and write access to the data.
+* **Grad student "Danny"** - read and write access to the data.
+* **Undergrad student "Andrew"** - read (but not write) access to the data.
+
+### Process
+
+#### Creating the collection
+
+1. Sysadmin Brian deploys the Origin, exposing the storage under `/riptide-university/reyes-lab`.
+2. Sysadmin Brian creates a collection with
+ * Name: `Reyes Lab`
+* Namespace: `/riptide-university/reyes-lab`
+* Owner: `Dr. Reyes`
+3. Since Dr. Reyes hasn't used the system yet, Sysadmin Brian generates an invite link and shares it.
+4. Dr. Reyes accepts the invitation and creates an account in the Origin service, via the browser.
+
+At this point, Sysadmin Brian is no longer involved in the data access management.
+
+#### Administering the collection
+
+1. In the Origin's browser interface, Dr. Reyes navigates to the collections menu and selects her `Reyes Lab` collection.
+2. Dr. Reyes then assigns her lab manager Christina as the admin of the `Reyes Lab` collection.
+3. Lab manager Christina similarly receives an invitation and creates an account in the Origin service, via the browser.
+
+At this point, either Dr. Reyes or Christina can administer the collection.
+
+#### Creating user groups
+
+1. Christina creates a group `reyes_researchers` (this will be for write access).
+2. Christina generates an invite link using the interface, and sends it to grad student Danny.
+3. Christina repeats the process to create another group `reyes_students` (for read access).
+4. Christina generates a separate invite link for this group and sends it to undergrad student Andrew.
+
+Once Danny and Andrew follow their invite links, they'll be members of their respective groups and have the corresponding access permissions.
+
+<Callout type="note">
+  Since Christina created the groups, she is the owner as well as a member of the groups.
+</Callout>
+
+#### Granting access
+
+1. Christina edits the `Reyes Lab` collection to add the `reyes_researchers` group as having `Write` access.
+2. Christina then adds the `reyes_students` group as having `Read` access.
+
+#### Accessing the collection
+
+As members of the `reyes_researchers` group, Christina and Danny are now able to read and write to the `/riptide-university/reyes-lab` namespace.
+
+As a member of the `reyes_students` group, Andrew is now able to read (but not write) to the namespace.
+
+## Shares
+
+A "share" grants read-only access to a collection or subset of a collection.
+
+* **Anyone with read access to a collection can create a share**
+* The receipient of a share can **not** propagate access to others
+
+The admin of a collection can enable the ability to create a "share".
+
+### Example (continued)
+
+Let's say that undergrad student Andrew wants to use some of the Reyes Lab research data for a class project.
+Christina creates and populates a `/riptide-university/reyes-lab/andrews-project` namespace with some example data.
+
+To share the project data with his classmates, Andrew creates a "share" targeting the designated namespace and with "public" visibility.
+
+Now, anyone can use a Pelican Client to read the data at `/riptide-university/reyes-lab/andrews-project`.
+No invites, no accounts, and no bugging the Origin admin to make a public namespace!

--- a/docs/app/managing-data-access/permissions-reference/page.mdx
+++ b/docs/app/managing-data-access/permissions-reference/page.mdx
@@ -35,7 +35,7 @@ import { Callout } from 'nextra/components'
 */}
 
 This page is the authoritative answer to "who is allowed to do this, and what does the server return when they are not?"
-Instructions for carrying out the tasks themselves live in [Managing Users and Groups](/managing-data-access/users-and-groups) and [Collections and Shares](/managing-data-access/collections-and-shares); the reasoning behind the model lives in [How Access Control Works](/managing-data-access/access-control-model).
+Instructions for carrying out the tasks themselves live in [Managing Users and Groups](/managing-data-access/users-and-groups) and [Managing Access to a Collection](/managing-data-access/collections-and-shares); the reasoning behind the model lives in [How Access Control Works](/managing-data-access/access-control-model).
 
 In the tables below, `yes` and `no` state whether that role may perform the action, and `—` marks a combination that cannot arise.
 **Ordinary user** means an account that holds no management scope and no ownership or administrator role on the record in question.
@@ -54,7 +54,7 @@ In the tables below, `yes` and `no` state whether that role may perform the acti
 ## Management scopes
 
 These are the only scopes the management API accepts on a grant.
-A data-plane scope (`storage.*`, `collection.*`, `share.access`) can never be handed to a user or a group through this surface; the issuer mints those onto tokens directly.
+A data-plane scope (`storage.*`, `collection.*`, `share.access`) can never be handed to a user or a group through the management API; the issuer mints those onto tokens directly.
 `GET /api/v1.0/scopes` returns the same catalogue to any signed-in caller.
 
 | Scope | What it permits | Notes |
@@ -90,7 +90,7 @@ An API token re-intersects its stored scopes against its creator's *current* eff
 
 ## User administration
 
-The whole `/api/v1.0/users` surface requires `server.admin` or `server.user_admin` at the route, plus AUP compliance.
+Every `/api/v1.0/users` endpoint requires `server.admin` or `server.user_admin` at the route, plus AUP compliance.
 Ordinary users reach none of it; their equivalents live under `/api/v1.0/me`.
 
 | Action | System admin | User admin | Ordinary user |
@@ -150,13 +150,14 @@ Listing a group's scope grants is described as open to anyone who can see the gr
 
 Also normative:
 
-- Deleting a group also deletes its invite links, its membership rows, and every collection ACL row naming it.
+- Deleting a group also deletes its invite links, its memberships, and every collection ACL entry naming it.
 - Group names beginning `user-` are reserved for the implicit personal group and are rejected at creation and at rename.
 - Adding someone who is already a member succeeds and changes nothing.
 
 ## Collection administration
 
-Collections sit behind authentication only — signing in is enough to reach the endpoints, and authorization is decided per row.
+Collections sit behind authentication only — signing in is enough to reach the endpoints, and authorization is decided per collection.
+A collection's **access control list** (**ACL**) is the set of entries naming which group holds `read` or `write` on it.
 A role on a collection maps to capabilities as follows.
 
 | Role | Capabilities |
@@ -193,7 +194,7 @@ Also normative:
 - A collection's owner can be changed but never cleared; clearing it returns `400` with `ownerId cannot be empty`.
 - A collection's namespace has to sit inside a prefix this origin already exports, and is canonicalised before both the prefix check and storage.
 - A collection cannot widen what its export permits.
-- Refusals on this surface are reported as `404`, not `403`; see [Response codes](#response-codes).
+- Refusals here are reported as `404`, not `403`; see [Response codes](#response-codes).
 
 ## Share administration
 
@@ -204,7 +205,7 @@ Also normative:
 | Who owns the new share | The caller who created it, not the parent's owner. |
 | Share of a share | Refused. |
 | Share namespace | Equal to, or a path-descendant of, the parent's namespace. Defaults to the parent's namespace. |
-| Share defaults | Visibility is private unless set to public; sharing is forced off on the new row. |
+| Share defaults | Visibility is private unless set to public; sharing is forced off on the new share. |
 | Managing the share | The share is itself a collection, so [Collection administration](#collection-administration) applies to it, with the share's creator holding owner authority. |
 | Effective access through the share | The weaker of the recipient's role on the share and the share owner's current role on the parent, computed when a token is issued. |
 | Token contents | `share.access:/<share-id>` plus the clamped storage scopes. Management-plane `collection.*` scopes are not clamped. |
@@ -245,7 +246,7 @@ A token issued for a share carries `share.access:/<share-id>` alongside its stor
 That scope tells the origin to serve objects under the share's prefix as the share's *owner* rather than as the person presenting the token — which is what makes delegated access work.
 It is minted by the issuer only; it is not a scope you can grant to a user or a group.
 
-When matching ACL rows for a caller, Pelican expands the caller's group list with the memberships recorded on the server, the implicit `user-<username>` personal group, and `@authenticated` when the caller has any identity at all.
+When matching ACL entries for a caller, Pelican expands the caller's group list with the memberships recorded on the server, the implicit `user-<username>` personal group, and `@authenticated` when the caller has any identity at all.
 
 ## Acceptable Use Policy gate
 
@@ -279,7 +280,7 @@ Full request and response schemas are in the [API browser](/api-docs).
 | `204 No Content` | The change was applied. These endpoints return no body. |
 | `400 Bad Request` | A malformed body, a missing required field, or a name or namespace that failed validation. Also `ownerId cannot be empty` on a collection. |
 | `401 Unauthorized` | No valid session or token — or the account was deactivated or deleted after the credential was issued, which is checked on every request. |
-| `403 Forbidden` | You are authenticated but hold neither the scope nor the row-level authority the action needs. Also returned for a cross-origin cookie-authenticated write, which is rejected as a CSRF risk. |
+| `403 Forbidden` | You are authenticated but hold neither the scope nor the ownership or ACL access the action needs. Also returned for a cross-origin cookie-authenticated write, which is rejected as a CSRF risk. |
 | `403 Forbidden` with `requires_aup: true` and `aup_version` | You have not accepted the current Acceptable Use Policy. See [Acceptable Use Policy gate](#acceptable-use-policy-gate). |
 | `404 Not Found` | The record does not exist, **or** it exists and you are not allowed to see it. Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it. A `404` on a collection or group you believe exists usually means you lack access, not that it is missing. |
 | `409 Conflict` | `Sharing is not enabled on this collection`, or `Shares are not supported on multi-user origin backends`. |
@@ -302,7 +303,7 @@ An entry that is an OIDC subject rather than a Pelican username grants nothing, 
 
 - [How Access Control Works](/managing-data-access/access-control-model) — the model behind these tables.
 - [Managing Users and Groups](/managing-data-access/users-and-groups) — how to carry out the user and group tasks.
-- [Collections and Shares](/managing-data-access/collections-and-shares) — how to carry out the collection and share tasks.
+- [Managing Access to a Collection](/managing-data-access/collections-and-shares) — how to carry out the collection and share tasks.
 - [API browser](/api-docs) — request and response schemas for every endpoint named here.
 - [`pelican-server server user`](/commands-reference/pelican-server/server/user) and [`pelican-server server group`](/commands-reference/pelican-server/server/group) — generated CLI reference.
 - [`pelican-server origin collection`](/commands-reference/pelican-server/origin/collection) — generated CLI reference for collections.

--- a/docs/app/managing-data-access/permissions-reference/page.mdx
+++ b/docs/app/managing-data-access/permissions-reference/page.mdx
@@ -1,0 +1,309 @@
+import { Callout } from 'nextra/components'
+
+# Permissions Reference
+
+{/*
+  MAINTAINER NOTE — this page is a hand-transcribed matrix of guards that
+  live in code. When any of the following change, re-check every table here
+  before merging:
+
+    web_ui/ui.go              route groups and their middleware chains
+    web_ui/authentication.go  AuthHandler, AdminAuthHandler,
+                              UserAdminAuthHandler, RequireAUPCompliance,
+                              Check{Admin,UserAdmin,CollectionAdmin}
+    web_ui/scopes.go          EffectiveScopesForIdentity (config-derived
+                              grants, the server.admin implication)
+    web_ui/groups.go          per-target guards on /users/* and /groups/*
+    web_ui/me.go              the self-service surface
+    web_ui/password_invite.go password-invite and password-clear guards
+    web_ui/aup.go             AUP source resolution and version
+    database/collection.go    CanSeeGroup, CanManageGroup, isGroupOwnerOnly,
+                              validateACL, CallerIsCollectionOwner[OrAdmin],
+                              DeleteUser, DeleteGroup, CreateShare, MinRole,
+                              EffectiveCollectionRole
+    database/scopes.go        EffectiveScopes, DefaultUserScopesFromConfig
+    database/identifiers.go   ValidateIdentifier, ValidateDisplayName,
+                              CleanNamespacePath
+    origin/collections.go     callerIsCollectionAdmin and the per-handler
+                              admin-bypass flags
+    oa4mp/proxy.go            what a minted access token ends up carrying
+    token_scopes/token_scopes.go and docs/scopes.yaml  the scope catalogue
+
+  Where a route comment and a database-layer guard disagree, this page
+  documents the intersection (the behaviour a caller actually observes).
+  Those places are marked with a warning callout in the rendered page.
+*/}
+
+This page is the authoritative answer to "who is allowed to do this, and what does the server return when they are not?"
+Instructions for carrying out the tasks themselves live in [Managing Users and Groups](/managing-data-access/users-and-groups) and [Collections and Shares](/managing-data-access/collections-and-shares); the reasoning behind the model lives in [How Access Control Works](/managing-data-access/access-control-model).
+
+In the tables below, `yes` and `no` state whether that role may perform the action, and `—` marks a combination that cannot arise.
+**Ordinary user** means an account that holds no management scope and no ownership or administrator role on the record in question.
+
+## Roles
+
+| Role | How you become one | Reach |
+|---|---|---|
+| System administrator | Holds `server.admin`: a direct grant, membership of an auth-template-eligible group named in [`Server.AdminGroups`](/parameters#Server-AdminGroups), a username in [`Server.UIAdminUsers`](/parameters#Server-UIAdminUsers), or the built-in `admin` account. | Every management surface on this server. Implies `server.user_admin` and `server.collection_admin`. |
+| User administrator | Holds `server.user_admin`: a direct grant, or a match in [`Server.UserAdminUsers`](/parameters#Server-UserAdminUsers) / [`Server.UserAdminGroups`](/parameters#Server-UserAdminGroups). | The user surface and group listing. Cannot grant scopes, cannot manage linked identities, and cannot act on a system administrator's account. |
+| Collection administrator | Holds `server.collection_admin`: a direct grant, or a match in [`Server.CollectionAdminUsers`](/parameters#Server-CollectionAdminUsers) / [`Server.CollectionAdminGroups`](/parameters#Server-CollectionAdminGroups). | Creates collections, and sees and manages every collection on the server. |
+| Collection owner / group owner | Named as the owner on the collection or group row. | Full authority on that one record, including the transfer and delete operations nobody else gets. |
+| Collection admin-group member / group administrator | A member of the group named as the collection's admin group, or the user or group delegated as a group's administrator. | Day-to-day management of that one record. Never transfer, never delete. |
+| Ordinary user | Any account that signs in successfully. New accounts receive [`Server.NewUserDefaultScopes`](/parameters#Server-NewUserDefaultScopes), which by default is `web_ui.access`. | Their own account, groups they create or belong to, and collections and shares they are named on. |
+
+## Management scopes
+
+These are the only scopes the management API accepts on a grant.
+A data-plane scope (`storage.*`, `collection.*`, `share.access`) can never be handed to a user or a group through this surface; the issuer mints those onto tokens directly.
+`GET /api/v1.0/scopes` returns the same catalogue to any signed-in caller.
+
+| Scope | What it permits | Notes |
+|---|---|---|
+| `web_ui.access` | Sign in to the web interface and the cookie-authenticated APIs. | Granted to new accounts by default. Granting it explicitly also lets API tokens carry web-interface access. |
+| `server.admin` | Every user, group, collection, and server setting. | Implies `server.user_admin` and `server.collection_admin`. |
+| `server.user_admin` | Create and manage non-administrator users, mint password-set and onboarding invites, and see every group. | Does not include scope grants, identity linking, or any action targeting a system administrator. |
+| `server.collection_admin` | Create collections, and see and manage every collection and its ACLs. | Does not include the user or group surfaces. |
+| `pelican.log_read` | Read the server's recent log buffer, through the log viewer or the `/api/v1.0/logs` endpoints. | Separable from `server.admin` rather than implied by it, because it exposes everything the server logs. |
+| `monitoring.query` | Read the server's metrics through its Prometheus-compatible query endpoint. | Login cookies carry this only for system administrators; other holders reach the endpoint with a bearer or API token. |
+| `pelican.transfer` | Submit, view, and cancel transfer jobs through the transfer API. | Not granted by default. |
+
+## Sources of a scope
+
+A caller's effective scope set is recomputed on every request as the union of the sources below.
+It is never read from the presented credential, which is why revoking a grant or a membership takes effect on the next request rather than when a token expires.
+
+| Source | Where it lives | How to take it back |
+|---|---|---|
+| A direct grant on the user | The server database | Revoke the grant. System administrators only. |
+| A grant on a group the user is recorded as a member of | The server database | Revoke the group's grant, or remove the user from the group. |
+| A grant on a group whose name the user's login credential asserts | The server database, matched by group name; asserted names with no matching group are ignored | Revoke the group's grant, or stop the identity provider asserting the name. |
+| The configuration admin lists — `Server.UIAdminUsers`, `Server.AdminGroups`, `Server.UserAdminUsers`, `Server.UserAdminGroups`, `Server.CollectionAdminUsers`, `Server.CollectionAdminGroups` — and the built-in `admin` username | The configuration file; evaluated live and never mirrored into the database | Edit the configuration file. Revoking a database grant has no effect on these. |
+| The `server.admin` implication | Applied after both sources above | Take back `server.admin`. |
+
+Two filters apply to the result.
+Group matches against the configuration lists and against [`Issuer.AuthorizationTemplates`](/parameters#Issuer-AuthorizationTemplates) are restricted to groups flagged auth-template-eligible.
+The whole set is then filtered to the catalogue in [Management scopes](#management-scopes), so a scope that is not user-grantable can never arrive by this path.
+
+Two further rules govern the edges.
+New accounts are granted `Server.NewUserDefaultScopes` at creation, and later edits to that setting do not apply retroactively.
+An API token re-intersects its stored scopes against its creator's *current* effective set on every use, so a token cannot outlive the authority it was minted from.
+
+## User administration
+
+The whole `/api/v1.0/users` surface requires `server.admin` or `server.user_admin` at the route, plus AUP compliance.
+Ordinary users reach none of it; their equivalents live under `/api/v1.0/me`.
+
+| Action | System admin | User admin | Ordinary user |
+|---|---|---|---|
+| List users, read any user | yes | yes | no |
+| Create a user | yes | yes | no |
+| Rename or relabel a user | yes | yes, except on a system administrator's account | no |
+| Activate or deactivate a user | yes | yes, except on a system administrator's account | no |
+| Delete a user | yes | only their own account — see below | no |
+| Mint a password-set invite | yes | yes, except on a system administrator's account | no |
+| Clear a user's password | yes | yes, except on a system administrator's account | own account only, and only if a password is already set |
+| Record a user's AUP acceptance | yes | yes | own acceptance only |
+| Clear a user's AUP acceptance | yes | yes, except on a system administrator's account | no |
+| List a user's direct scope grants | yes | yes | own effective scopes only |
+| Grant or revoke a user's scope | yes | no | no |
+| List a user's linked identities | yes | yes | own identities only |
+| Add or remove a linked identity | yes | no | may unlink their own secondary identities only |
+| Mint a user-onboarding invite | yes | yes | no |
+| Edit own display name | yes | yes | yes |
+| Rotate own password | only if one is already set | only if one is already set | only if one is already set |
+
+<Callout type="warning">
+The route comment on user deletion says a user administrator may delete users, but the database layer refuses unless the caller is a system administrator or the target is the caller themselves.
+The behaviour you will observe is that a holder of `server.user_admin` can delete only their own account; every other target returns `403`.
+Deactivating an account is the operation a user administrator can actually perform, and it revokes live sessions on the next request.
+</Callout>
+
+## Group administration
+
+Two helpers decide most of this surface.
+**Visible to** you means: you are a system administrator, the group's owner, its administrator, a recorded member, or your login credential asserts the group's name.
+**Manageable by** you means: you are a system administrator, the group's owner, or its administrator.
+User administrators are in neither helper — their extra reach over ordinary users is that they see every group in the listing.
+
+| Action | System admin | User admin | Group owner | Group administrator | Member | Ordinary user |
+|---|---|---|---|---|---|---|
+| Create a group | yes | yes | — | — | — | yes |
+| Set auth-template eligibility at creation | yes | yes | — | — | — | the request field is forced off |
+| List groups | all | all | visible only | visible only | visible only | visible only |
+| Read one group, list its members | if visible, else `404` | if visible, else `404` | yes | yes | yes | if visible |
+| Edit display name or description | yes | no | yes | yes | no | no |
+| Rename a group | yes | no | no | no | no | no |
+| Change auth-template eligibility after creation | yes | no | no | no | no | no |
+| Add or remove members | yes | no | yes | yes | no | no |
+| Create, list, or revoke invite links | yes | no | yes | yes | no | no |
+| Transfer ownership, set the administrator | yes | no | yes | no | no | no |
+| Delete a group | yes | no | yes | no | no | no |
+| Leave a group | as a member, yes | as a member, yes | no — transfer ownership first | yes | yes | yes |
+| List a group's scope grants | yes | yes | yes | yes | yes | yes |
+| Grant or revoke a group's scope | yes | no | no | no | no | no |
+
+<Callout type="warning">
+Two rows diverge from what the route comments imply.
+Auth-template eligibility is settable by a user administrator **at group creation** only; changing it afterwards requires `server.admin`.
+Listing a group's scope grants is described as open to anyone who can see the group, but the handler performs no visibility check: any signed-in, AUP-compliant caller who knows a group's internal ID can read that group's grants.
+</Callout>
+
+Also normative:
+
+- Deleting a group also deletes its invite links, its membership rows, and every collection ACL row naming it.
+- Group names beginning `user-` are reserved for the implicit personal group and are rejected at creation and at rename.
+- Adding someone who is already a member succeeds and changes nothing.
+
+## Collection administration
+
+Collections sit behind authentication only — signing in is enough to reach the endpoints, and authorization is decided per row.
+A role on a collection maps to capabilities as follows.
+
+| Role | Capabilities |
+|---|---|
+| `read` | Read the collection, its metadata, and its objects. |
+| `write` | The above, plus edit the collection's descriptive fields, its metadata, and read its ACL list. |
+| Owner or admin-group member | The above, plus grant and revoke ACLs and reassign the admin group. |
+| Owner only | The above, plus transfer ownership and delete the collection. |
+
+| Action | System / collection admin | Collection owner | Admin-group member | Group with `write` | Group with `read` | Ordinary user |
+|---|---|---|---|---|---|---|
+| Create a collection | yes | — | — | — | — | no (`403`), unless presenting a bearer token that carries an explicit `collection.create` scope |
+| See a collection in the listing | all | own | yes | yes | yes | public collections only |
+| Read one collection | any | yes | yes | yes | yes | public only |
+| Edit name, description, visibility, sharing | yes | yes | yes | yes | no | no |
+| Read the collection's metadata | only with a role on the collection — see below | yes | yes | yes | yes | no |
+| Write or delete metadata | yes | yes | yes | yes | no | no |
+| Read the ACL list | yes | yes | yes | yes | no | no |
+| Grant or revoke an ACL | yes | yes | yes | no | no | no |
+| Reassign the admin group | yes | yes | yes | no | no | no |
+| Transfer ownership, by patch or by invite | yes | yes | no | no | no | no |
+| Redeem an ownership invite | — | — | — | — | — | any authenticated holder of the link |
+| Delete a collection | yes | yes | no | no | no | no |
+| List candidate owners | yes | yes | yes | yes | yes | public collections only |
+
+<Callout type="warning">
+Reading a collection's metadata is the one collection operation with no administrator bypass and no public-visibility fallback.
+A holder of `server.collection_admin` who is not the owner, not in the admin group, and not on an ACL gets `404` on the metadata endpoint even though the collection itself is readable to them, and metadata on a public collection is not readable without a role on that collection.
+Every other collection operation honours the administrator bypass.
+</Callout>
+
+Also normative:
+
+- A collection's owner can be changed but never cleared; clearing it returns `400` with `ownerId cannot be empty`.
+- A collection's namespace has to sit inside a prefix this origin already exports, and is canonicalised before both the prefix check and storage.
+- A collection cannot widen what its export permits.
+- Refusals on this surface are reported as `404`, not `403`; see [Response codes](#response-codes).
+
+## Share administration
+
+| Question | Answer |
+|---|---|
+| Who may create a share | A caller with `read` or better on the parent collection, when the parent has sharing enabled and [`Origin.Multiuser`](/parameters#Origin-Multiuser) is off. |
+| Refusals | `409` when the origin runs a multi-user backend, `409` when sharing is not enabled on the parent, `404` when you have no access to the parent. |
+| Who owns the new share | The caller who created it, not the parent's owner. |
+| Share of a share | Refused. |
+| Share namespace | Equal to, or a path-descendant of, the parent's namespace. Defaults to the parent's namespace. |
+| Share defaults | Visibility is private unless set to public; sharing is forced off on the new row. |
+| Managing the share | The share is itself a collection, so [Collection administration](#collection-administration) applies to it, with the share's creator holding owner authority. |
+| Effective access through the share | The weaker of the recipient's role on the share and the share owner's current role on the parent, computed when a token is issued. |
+| Token contents | `share.access:/<share-id>` plus the clamped storage scopes. Management-plane `collection.*` scopes are not clamped. |
+| A share token at a multi-user origin | Refused outright, with no fallback to the presenter's identity. |
+
+The intersection is recomputed each time a token is *issued*: if the share owner is downgraded from write to read — or loses access to the parent altogether — every token minted through the share from that point on is clamped or emptied.
+
+<Callout type="warning">
+Refreshing an existing token does not re-run the intersection.
+The issuer re-grants the scopes already stored on the session, so an already-issued token keeps its original access until it expires and a new authorization is performed.
+Access changes take effect on the next issuance, not immediately.
+</Callout>
+
+<Callout type="warning">
+Shares are not supported when the origin runs a multi-user POSIX backend (`Origin.Multiuser`).
+Serving share data means acting as the share's owner, and the multi-user backend cannot safely re-target the operating-system identity it serves a request under.
+Creating a share on such an origin is refused with `409`, and if multi-user mode is turned on after shares already exist, any token carrying `share.access` is rejected outright rather than quietly falling back to the presenter's identity.
+</Callout>
+
+## Data access
+
+An access token's data-plane scopes are derived from the caller's role on each collection they can reach, keyed by that collection's namespace.
+
+| Role on the collection | Data-plane scopes minted for its namespace |
+|---|---|
+| Owner or `write` | `storage.read`, `storage.modify`, `storage.create` |
+| `read` | `storage.read` |
+| None | nothing |
+
+Management-plane scopes are minted alongside them, keyed by collection ID rather than namespace: owner yields `collection.read`, `collection.modify` and `collection.delete`; `write` yields `collection.read` and `collection.modify`; `read` yields `collection.read`.
+
+The collection's namespace is made issuer-relative before it is spliced into a scope.
+A collection outside the issuer's namespace receives management-plane scopes only.
+
+The group names that matched an ACL are echoed in the token's group claim, with `@authenticated` excluded — it is a virtual ACL target rather than a real group, and never appears in a token.
+
+A token issued for a share carries `share.access:/<share-id>` alongside its storage scopes.
+That scope tells the origin to serve objects under the share's prefix as the share's *owner* rather than as the person presenting the token — which is what makes delegated access work.
+It is minted by the issuer only; it is not a scope you can grant to a user or a group.
+
+When matching ACL rows for a caller, Pelican expands the caller's group list with the memberships recorded on the server, the implicit `user-<username>` personal group, and `@authenticated` when the caller has any identity at all.
+
+## Acceptable Use Policy gate
+
+If your server has an Acceptable Use Policy configured, you must accept the current version before you can use the user, group, or self-service management APIs.
+Until you do, those endpoints return `403` with `requires_aup: true` and the version you need to accept, and the web interface sends you to the acceptance page.
+Three things stay reachable so you can get unstuck: reading the policy, accepting it, and signing out.
+Editing the policy is also exempt, so rotating it cannot lock out the administrator who rotated it.
+
+The collections and shares API is not behind this gate.
+Neither is redeeming a collection-ownership invite — becoming an owner does not by itself grant management-policy authority.
+
+| Behind the gate | Exempt from the gate |
+|---|---|
+| Everything under `/api/v1.0/groups` | `GET /api/v1.0/me` and `POST /api/v1.0/me/aup` |
+| Everything under `/api/v1.0/users` | `GET /api/v1.0/aup` and `GET /api/v1.0/aup/:version`, both unauthenticated |
+| Everything under `/api/v1.0/me` other than the two exempt routes | `PUT /api/v1.0/aup` and `GET /api/v1.0/aup/versions`, both system-administrator-only |
+| `POST /api/v1.0/invites/redeem` | `POST /api/v1.0/invites/redeem/collection-ownership` |
+| `POST /api/v1.0/invites/onboarding` | `POST /api/v1.0/invites/redeem/password` and `GET /api/v1.0/invites/info`, both unauthenticated |
+| | The whole `/api/v1.0/origin_ui/collections` surface, including shares |
+| | `GET /api/v1.0/scopes` |
+
+[`Server.AUPFile`](/parameters#Server-AUPFile) set to `none` removes the requirement entirely.
+
+## Response codes
+
+One row per meaning, not per endpoint.
+Full request and response schemas are in the [API browser](/api-docs).
+
+| Code | What it means |
+|---|---|
+| `204 No Content` | The change was applied. These endpoints return no body. |
+| `400 Bad Request` | A malformed body, a missing required field, or a name or namespace that failed validation. Also `ownerId cannot be empty` on a collection. |
+| `401 Unauthorized` | No valid session or token — or the account was deactivated or deleted after the credential was issued, which is checked on every request. |
+| `403 Forbidden` | You are authenticated but hold neither the scope nor the row-level authority the action needs. Also returned for a cross-origin cookie-authenticated write, which is rejected as a CSRF risk. |
+| `403 Forbidden` with `requires_aup: true` and `aup_version` | You have not accepted the current Acceptable Use Policy. See [Acceptable Use Policy gate](#acceptable-use-policy-gate). |
+| `404 Not Found` | The record does not exist, **or** it exists and you are not allowed to see it. Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it. A `404` on a collection or group you believe exists usually means you lack access, not that it is missing. |
+| `409 Conflict` | `Sharing is not enabled on this collection`, or `Shares are not supported on multi-user origin backends`. |
+
+## Identifier rules
+
+| Field | Rule |
+|---|---|
+| Username, group name | 2 to 64 characters from `A-Z`, `a-z`, `0-9`, `.`, `_`, `@` and `-`; has to start with a letter or a digit. `/` is rejected, and so is any occurrence of `..`. |
+| Group name, additionally | Cannot start with `user-`, which is reserved for the implicit personal group every user belongs to. |
+| Display name | Optional; up to 128 characters of any printable Unicode, with ASCII control characters rejected. Never used for an authorization decision. |
+| Internal ID | Generated by the server. It appears in URLs and API paths as a routing handle and is not a credential. |
+| Collection or share namespace | An absolute `/`-rooted path with no whitespace, no control characters, and no `:`. Canonicalised before it is checked against the export prefix and before it is stored, so the path that is checked is the path that ends up in a token scope. |
+| ACL target | A group name, or the virtual target `@authenticated`. The leading `@` is rejected by identifier validation, so the virtual target can never collide with a real group name. |
+
+Configuration admin lists match on the username only.
+An entry that is an OIDC subject rather than a Pelican username grants nothing, and the server logs an error naming it at startup.
+
+## Where to go next
+
+- [How Access Control Works](/managing-data-access/access-control-model) — the model behind these tables.
+- [Managing Users and Groups](/managing-data-access/users-and-groups) — how to carry out the user and group tasks.
+- [Collections and Shares](/managing-data-access/collections-and-shares) — how to carry out the collection and share tasks.
+- [API browser](/api-docs) — request and response schemas for every endpoint named here.
+- [`pelican-server server user`](/commands-reference/pelican-server/server/user) and [`pelican-server server group`](/commands-reference/pelican-server/server/group) — generated CLI reference.
+- [`pelican-server origin collection`](/commands-reference/pelican-server/origin/collection) — generated CLI reference for collections.
+- [Parameters](/parameters) — the admin-list settings, `Server.NewUserDefaultScopes`, `Server.AUPFile`, and `Origin.Multiuser`.

--- a/docs/app/managing-data-access/permissions-reference/page.mdx
+++ b/docs/app/managing-data-access/permissions-reference/page.mdx
@@ -194,6 +194,7 @@ Also normative:
 - A collection's owner can be changed but never cleared; clearing it returns `400` with `ownerId cannot be empty`.
 - A collection's namespace has to sit inside a prefix this origin already exports, and is canonicalised before both the prefix check and storage.
 - A collection cannot widen what its export permits.
+- A collection's prefixes are unioned, not resolved most-specific-first: a deeper collection can widen access to its sub-path but cannot restrict what a shallower collection grants. Nothing rejects the overlap at creation, and a namespace carries no uniqueness constraint.
 - Refusals here are reported as `404`, not `403`; see [Response codes](#response-codes).
 
 ## Share administration

--- a/docs/app/managing-data-access/users-and-groups/page.mdx
+++ b/docs/app/managing-data-access/users-and-groups/page.mdx
@@ -2,7 +2,9 @@ import { Callout } from 'nextra/components'
 
 # Managing Users and Groups
 
-This page collects the day-to-day tasks an administrator performs on a Pelican server's user and group records, plus the handful of things every signed-in user does for themselves.
+Access to a collection is granted to a **group**, never to a person directly — so before you can give someone access, they need an account on this server and a group to put them in.
+This page covers both: creating and running groups, the account tasks an administrator does around them, and the handful of things every signed-in user does for themselves.
+For the granting itself, see [Managing Access to a Collection](/managing-data-access/collections-and-shares).
 For the model behind these tasks — what a user is, what a group is, and how a scope reaches a caller — read [How Access Control Works](/managing-data-access/access-control-model).
 For the authoritative "who may do this", read the [Permissions Reference](/managing-data-access/permissions-reference).
 
@@ -119,7 +121,7 @@ Deactivating is the reversible option.
 Setting a user's status to `inactive` stops the account from authenticating; because authorization is recomputed on every request, live sessions stop working on the next request rather than when a token expires.
 
 Deleting is not reversible.
-Along with the user record, Pelican removes the account's group memberships and every collection ACL row written against its personal `user-<username>` group.
+Along with the account, Pelican removes its group memberships and every collection access grant written against its personal `user-<username>` group.
 
 Deletion is available on all three surfaces.
 The web interface has no activate/deactivate control, so status changes are a CLI or API task.
@@ -152,14 +154,14 @@ Those attempts return `403` with `user administrators cannot modify system admin
 
 *Any signed-in user can create a group — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
 
-Group creation is open to everyone because users need groups of their own to write collection ACLs and share ACLs against.
+Group creation is open to everyone because users need groups of their own to grant access on their collections and shares.
 What a self-created group cannot do is act as bearer authority; see [Make a group usable in authorization templates and admin lists](#make-a-group-usable-in-authorization-templates-and-admin-lists) below.
 
-The group **name** is the machine-readable handle that ACLs and policy strings match on.
+The group **name** is the machine-readable name that access grants and policy settings match on.
 It is 2 to 64 characters drawn from letters, digits, `.`, `_`, `@`, and `-`, has to start with a letter or digit, may not contain `/` or `..`, and may not start with `user-` — that prefix is reserved for the implicit personal group every account carries.
 The **display name** and **description** are free-form labels and never take part in an authorization decision.
 
-Once the group exists, use it in a collection ACL: see [Grant read or write access to a group](/managing-data-access/collections-and-shares#grant-read-or-write-access-to-a-group).
+Once the group exists, use it to grant access to a collection: see [Grant read or write access to a group](/managing-data-access/collections-and-shares#grant-read-or-write-access-to-a-group).
 
 ### Web UI
 
@@ -194,7 +196,7 @@ Holding `server.user_admin` alone does not let you edit a group's membership.
 3. To remove someone, click the remove icon beside their row and confirm.
 
 The **ADD MEMBER** picker reads the server-wide user list, so it appears only for system administrators; a group owner or administrator who is not one invites people with a link instead.
-Removing a member never relinquishes ownership — the owner stays the owner even after their membership row is deleted.
+Removing a member never relinquishes ownership — the owner stays the owner even after their membership is deleted.
 
 ### CLI
 
@@ -244,7 +246,7 @@ The recipient redeems at `POST /api/v1.0/invites/redeem`.
 
 *Requires group ownership or `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
 
-A group has exactly one owner, and the owner is the only principal who can hand the group to someone else, name an administrator, or delete it — and the only one who cannot leave it.
+A group has exactly one owner, and the owner is the only one who can hand the group to someone else, name an administrator, or delete it — and the only one who cannot leave it.
 Transfer ownership first if you want out.
 
 A group administrator handles membership and metadata day to day, and may be a single user or another group, so you can point one team's admin at a second team.
@@ -273,7 +275,7 @@ pelican-server server group set-ownership <group-id> --admin-id <id> --admin-typ
 
 [`Issuer.AuthorizationTemplates`](/parameters#Issuer-AuthorizationTemplates) and the `Server.*AdminGroups` settings — [`Server.AdminGroups`](/parameters#Server-AdminGroups) and [`Server.UserAdminGroups`](/parameters#Server-UserAdminGroups) among them — match on a group's *name*, and they only trust a name that carries the auth-template-eligibility flag.
 Set the flag on a group before you name it in one of those settings; without it, the entry matches nothing.
-Collection ACLs do not consult the flag, so a group used only in an ACL never needs it.
+Collection access grants do not consult the flag, so a group used only for collection access never needs it.
 For why the flag exists, see [Where a scope can come from](/managing-data-access/access-control-model#where-a-scope-can-come-from).
 
 You can set the flag at creation time if you hold `server.admin` or `server.user_admin`.

--- a/docs/app/managing-data-access/users-and-groups/page.mdx
+++ b/docs/app/managing-data-access/users-and-groups/page.mdx
@@ -1,0 +1,403 @@
+import { Callout } from 'nextra/components'
+
+# Managing Users and Groups
+
+This page collects the day-to-day tasks an administrator performs on a Pelican server's user and group records, plus the handful of things every signed-in user does for themselves.
+For the model behind these tasks — what a user is, what a group is, and how a scope reaches a caller — read [How Access Control Works](/managing-data-access/access-control-model).
+For the authoritative "who may do this", read the [Permissions Reference](/managing-data-access/permissions-reference).
+
+## Before you start
+
+Every section below opens with a one-line prerequisite naming the scope the task calls for.
+Beyond that, what you need depends on the method.
+
+- **Web interface:** your server's web URL and an account holding that scope.
+- **Command line:** a shell on the server host. The `pelican-server server user` and `pelican-server server group` commands drive the local server's admin API with a token they mint from the server's own issuer key, so they only work where that key is readable, and they read `Server.ExternalWebUrl` to find the API. Full flag lists live in the generated reference for [`server user`](/commands-reference/pelican-server/server/user) and [`server group`](/commands-reference/pelican-server/server/group).
+- **API:** a login cookie or an API token whose creator holds that scope. The Swagger browser at [`/api-docs`](/api-docs) carries every request and response shape; this page never repeats them.
+
+<Callout type="info">
+Several tasks below produce an invite link.
+Pelican mints the link and shows you the token exactly once; delivering it to the right person is your job.
+Pelican does not send email.
+</Callout>
+
+## Add a user
+
+*Requires `server.admin` or `server.user_admin` — see [User administration](/managing-data-access/permissions-reference#user-administration).*
+
+Most accounts appear by themselves the first time someone signs in through your configured OIDC provider.
+Create one by hand when you want to pre-provision: add the person to groups, grant a scope, or hand them a password before they have ever logged in.
+
+A **local account** needs only a username; the person sets a password later by redeeming an invite.
+An **OIDC-linked account** also carries a subject and issuer pair, and the next login matching that pair claims it.
+
+### Web UI
+
+1. Go to **Settings** → **Users** and click **ADD USER**.
+2. Choose **Local (username + password)** or **External (OIDC)**.
+3. Fill in **Username** and, optionally, **Display name**. For an external user, also fill in **Sub** and **Issuer** from your identity provider.
+4. Click **CREATE USER**.
+5. For a local account, the page offers **GENERATE PASSWORD-SET INVITE**. Click it and copy the URL, or click **SKIP FOR NOW** and mint the invite later.
+
+### CLI
+
+```bash copy
+# Local account — hand out a password invite afterwards
+pelican-server server user create --username alice --display-name "Alice Chen"
+
+# OIDC account, subject known in advance
+pelican-server server user create --username alice \
+    --sub abc-123 --issuer https://oidc.example.org/
+```
+
+### API
+
+`POST /api/v1.0/users` with a `username`, optionally a `displayName`, and — for an OIDC account — both `sub` and `issuer`.
+
+New accounts are granted the scopes named in [`Server.NewUserDefaultScopes`](/parameters#Server-NewUserDefaultScopes).
+Later edits to that setting do not apply to accounts that already exist.
+
+## Let a user set a password
+
+*Requires `server.admin` or `server.user_admin` — see [User administration](/managing-data-access/permissions-reference#user-administration).*
+
+Administrators never see or choose a password.
+Instead you mint a single-use, time-bounded invite and hand over the link; the person picks their own password when they redeem it.
+The link's lifetime comes from [`Server.GroupInviteLinkExpiration`](/parameters#Server-GroupInviteLinkExpiration) unless you override it.
+
+### Web UI
+
+1. Go to **Settings** → **Users** and click the edit icon on the user's row.
+2. Under **Password setup**, click **GENERATE PASSWORD-SET INVITE**.
+3. Copy the URL from the box that appears and deliver it. It is shown only once.
+4. To disable password login on a compromised account, click **CLEAR LOCAL PASSWORD** under **Local password** and confirm.
+
+The same panel lists every invite ever issued for that user, so you can see whether one is already outstanding before minting another.
+
+### CLI
+
+```bash copy
+pelican-server server user invite-password <user-id>
+pelican-server server user list-password-invites <user-id>
+pelican-server server user clear-password <user-id>
+```
+
+### API
+
+`POST /api/v1.0/users/:id/password-invite` mints the link, `GET /api/v1.0/users/:id/password-invites` lists them, and `DELETE /api/v1.0/users/:id/password` clears the password.
+
+A user who already has a password can rotate or remove it themselves from their profile page, but a user with none cannot grow one on their own — an admin-minted invite is the only path.
+
+## Creating an onboarding link
+
+*Requires `server.admin` or `server.user_admin` — see [User administration](/managing-data-access/permissions-reference#user-administration).*
+
+Use an onboarding link when you want to invite someone whose OIDC subject you do not know in advance.
+The link creates no account up front; the recipient signs in through your identity provider first, and the identity they used claims a new account when they redeem.
+There is no web-interface control for this link today, so it is a CLI or API task.
+
+### CLI
+
+```bash copy
+pelican-server server user invite-onboard
+```
+
+The command prints the token, its expiry, and a redemption URL to hand over.
+
+### API
+
+`POST /api/v1.0/invites/onboarding`.
+
+The recipient signs in, opens the **Redeem invite** page, pastes the token if the URL did not carry it, and clicks **CONTINUE**.
+An onboarding link names no group, so redeeming it simply establishes the account.
+
+## Deactivate or delete a user
+
+*Requires `server.admin` or `server.user_admin`, with limits — see [User administration](/managing-data-access/permissions-reference#user-administration).*
+
+Deactivating is the reversible option.
+Setting a user's status to `inactive` stops the account from authenticating; because authorization is recomputed on every request, live sessions stop working on the next request rather than when a token expires.
+
+Deleting is not reversible.
+Along with the user record, Pelican removes the account's group memberships and every collection ACL row written against its personal `user-<username>` group.
+
+Deletion is available on all three surfaces.
+The web interface has no activate/deactivate control, so status changes are a CLI or API task.
+
+### Web UI
+
+Go to **Settings** → **Users** and use the **Delete** control on the user's row.
+
+### CLI
+
+```bash copy
+pelican-server server user set-status <user-id> --status inactive
+pelican-server server user delete <user-id>
+```
+
+### API
+
+`PUT /api/v1.0/users/:id/status` with a `status` of `active` or `inactive`, and `DELETE /api/v1.0/users/:id`.
+
+<Callout type="warning">
+A user administrator can deactivate another account but cannot currently delete one.
+The route admits `server.user_admin`, and the check that runs afterwards refuses unless the caller is a system administrator or the target is the caller's own account.
+A user administrator who tries gets a `403`; ask a system administrator to perform the deletion, or deactivate instead.
+</Callout>
+
+A user administrator also cannot rename, deactivate, delete, or mint a password invite for a system administrator's account.
+Those attempts return `403` with `user administrators cannot modify system admin accounts`.
+
+## Create a group
+
+*Any signed-in user can create a group — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+
+Group creation is open to everyone because users need groups of their own to write collection ACLs and share ACLs against.
+What a self-created group cannot do is act as bearer authority; see [Make a group usable in authorization templates and admin lists](#make-a-group-usable-in-authorization-templates-and-admin-lists) below.
+
+The group **name** is the machine-readable handle that ACLs and policy strings match on.
+It is 2 to 64 characters drawn from letters, digits, `.`, `_`, `@`, and `-`, has to start with a letter or digit, may not contain `/` or `..`, and may not start with `user-` — that prefix is reserved for the implicit personal group every account carries.
+The **display name** and **description** are free-form labels and never take part in an authorization decision.
+
+Once the group exists, use it in a collection ACL: see [Grant read or write access to a group](/managing-data-access/collections-and-shares#grant-read-or-write-access-to-a-group).
+
+### Web UI
+
+1. Open **Groups** from the sidebar, or **Settings** → **Groups**.
+2. Click **CREATE GROUP**.
+3. Fill in **Group Name** and, optionally, **Description**.
+4. Leave **Add me as a member of this group** checked if you want to be a member as well as the owner. Creating a group makes you its owner but does not make you a member.
+5. Click **CREATE**.
+
+### CLI
+
+```bash copy
+pelican-server server group create --name cms-analysis --description "CMS analysis team"
+```
+
+### API
+
+`POST /api/v1.0/groups`.
+
+## Add and remove group members
+
+*Requires group ownership, a group administrator delegation, or `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+
+The person you add needs an account on this server already.
+Adding someone who is already a member succeeds and changes nothing.
+Holding `server.user_admin` alone does not let you edit a group's membership.
+
+### Web UI
+
+1. Open **Groups** and expand the group, or open its detail page.
+2. Under **Members**, click **ADD MEMBER**, pick the user, and click **ADD MEMBER** again in the dialog.
+3. To remove someone, click the remove icon beside their row and confirm.
+
+The **ADD MEMBER** picker reads the server-wide user list, so it appears only for system administrators; a group owner or administrator who is not one invites people with a link instead.
+Removing a member never relinquishes ownership — the owner stays the owner even after their membership row is deleted.
+
+### CLI
+
+```bash copy
+pelican-server server group add-member <group-id> --user-id <user-id>
+pelican-server server group remove-member <group-id> --user-id <user-id>
+pelican-server server group list-members <group-id>
+```
+
+### API
+
+`POST /api/v1.0/groups/:id/members`, `DELETE /api/v1.0/groups/:id/members/:userId`, and `GET /api/v1.0/groups/:id/members`.
+
+## Invite people to a group with a link
+
+*Requires group ownership, a group administrator delegation, or `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+
+An invite link is how a group owner brings in people they cannot look up.
+A single-use link admits one person; a multi-use link admits everyone who holds it until it expires or you revoke it.
+Expiry defaults to [`Server.GroupInviteLinkExpiration`](/parameters#Server-GroupInviteLinkExpiration).
+
+The recipient has to be signed in and, if your server has an Acceptable Use Policy, AUP-compliant before they can redeem — nobody gets conscripted into a group as a side effect of following a link.
+
+### Web UI
+
+1. Open the group's detail page. The **Invite links** panel appears for owners and group administrators only.
+2. Set **Single use** on or off, and set **Expires in** to a Go duration such as `168h`, `24h`, or `30m`.
+3. Click **GENERATE INVITE LINK** and copy the URL. It is shown only once.
+4. To withdraw a link, click the revoke icon on its row.
+
+Listed links show a short token ID rather than the token itself, which is safe to quote in a ticket or an audit log.
+
+### CLI
+
+```bash copy
+pelican-server server group invite create <group-id> --single-use --expires-in 24h
+pelican-server server group invite list <group-id>
+pelican-server server group invite revoke <group-id> <link-id>
+```
+
+### API
+
+`POST /api/v1.0/groups/:id/invites`, `GET /api/v1.0/groups/:id/invites`, and `DELETE /api/v1.0/groups/:id/invites/:linkId`.
+The recipient redeems at `POST /api/v1.0/invites/redeem`.
+
+## Transfer group ownership or delegate a group administrator
+
+*Requires group ownership or `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+
+A group has exactly one owner, and the owner is the only principal who can hand the group to someone else, name an administrator, or delete it — and the only one who cannot leave it.
+Transfer ownership first if you want out.
+
+A group administrator handles membership and metadata day to day, and may be a single user or another group, so you can point one team's admin at a second team.
+An administrator cannot transfer ownership and cannot delete the group.
+
+### Web UI
+
+1. Open the group's detail page and find the **Ownership** section.
+2. Click the edit icon beside **Owner**, pick the new owner, and save.
+3. Click the edit icon beside **Administrator**, choose **None**, **User**, or **Group**, pick the target, and save.
+
+### CLI
+
+```bash copy
+pelican-server server group set-ownership <group-id> --owner-id <user-id>
+pelican-server server group set-ownership <group-id> --admin-id <id> --admin-type group
+```
+
+### API
+
+`PUT /api/v1.0/groups/:id/ownership` with `ownerId`, `adminId`, and `adminType` as needed.
+
+## Make a group usable in authorization templates and admin lists
+
+*Turning the flag on for an existing group requires `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+
+[`Issuer.AuthorizationTemplates`](/parameters#Issuer-AuthorizationTemplates) and the `Server.*AdminGroups` settings — [`Server.AdminGroups`](/parameters#Server-AdminGroups) and [`Server.UserAdminGroups`](/parameters#Server-UserAdminGroups) among them — match on a group's *name*, and they only trust a name that carries the auth-template-eligibility flag.
+Set the flag on a group before you name it in one of those settings; without it, the entry matches nothing.
+Collection ACLs do not consult the flag, so a group used only in an ACL never needs it.
+For why the flag exists, see [Where a scope can come from](/managing-data-access/access-control-model#where-a-scope-can-come-from).
+
+You can set the flag at creation time if you hold `server.admin` or `server.user_admin`.
+Changing it afterwards is system-admin-only, so a user administrator who tries gets a `403`.
+There is no CLI flag for eligibility, which makes this a web-interface or API task.
+
+### Web UI
+
+- **At creation:** in the **Create New Group** dialog, tick **Auth-template eligible**. The checkbox is rendered only for callers who can set it.
+- **Afterwards:** open the group's detail page and flip the **Auth template** switch. Everyone else sees the current state as a read-only `eligible` or `ineligible` chip.
+
+### API
+
+`PATCH /api/v1.0/groups/:id` with `authTemplateEligible`.
+
+<Callout type="warning">
+The web interface renders the **Auth template** switch for user administrators as well as system administrators, but the server accepts the change only from a system administrator.
+A user administrator who flips the switch sees the request fail.
+</Callout>
+
+The same `PATCH` endpoint is where a group's display name and description are edited, and where a system administrator renames a group.
+The web interface has no control for those fields today; use `pelican-server server group update` or the API.
+
+## Grant a management scope to a user or group
+
+*Requires `server.admin` — see [Management scopes](/managing-data-access/permissions-reference#management-scopes).*
+
+A `server.user_admin` holder can read scope grants but cannot create or revoke them, because granting a scope to yourself is exactly the self-elevation the split is there to prevent.
+Granting a scope to a group elevates every member of that group, now and in the future, so prefer a direct grant on a user unless you want the membership list to control the privilege.
+
+Two listings answer different questions.
+`GET /api/v1.0/users/:id/scopes` returns only the rows granted directly to that user.
+`GET /api/v1.0/me/scopes` returns your own *effective* set — direct grants, plus everything inherited from your groups and from the operator's admin-list configuration.
+Config-derived grants never appear in the direct listing; you take those back by editing the configuration file, not by revoking a row.
+See [Sources of a scope](/managing-data-access/permissions-reference#sources-of-a-scope) for every path a grant can arrive by and how to withdraw each one.
+
+### Web UI
+
+1. For a user: **Settings** → **Users**, edit the user, and scroll to **Scopes**. For a group: open the group's detail page and find its scopes panel. Both panels are rendered for system administrators only.
+2. Pick an entry from **Pick a scope to grant** — the picker offers only scopes the management API will accept — and click **GRANT**.
+3. To revoke, click the × on the scope's chip.
+
+### CLI
+
+```bash copy
+pelican-server server user scope list <user-id>
+pelican-server server user scope grant <user-id> --scope server.user_admin
+pelican-server server group scope revoke <group-id> <scope>
+```
+
+### API
+
+`POST` and `DELETE` on `/api/v1.0/users/:id/scopes` and `/api/v1.0/groups/:id/scopes`.
+
+## Manage your own account
+
+*Any signed-in user.*
+
+Everything here targets the caller and needs no administrative scope.
+The `pelican-server` commands act as a server administrator rather than as you, so self-service is a web-interface or API task.
+
+### Web UI
+
+Open the user menu and choose **Profile**.
+
+- **Display name** — edit the field and click **SAVE**. Your username is read-only; changing it is an administrator's job.
+- **Local password** — **RESET PASSWORD** asks for your current password and a new one; **REMOVE PASSWORD** disables username-and-password login while leaving linked OIDC identities working. Both appear only when a password is already set.
+- **Effective scopes** — the full set the server computes for you right now.
+- **Linked identities** — unlink a secondary identity with the unlink icon. Your primary identity is marked `managed by admin`.
+- **Your groups** — click **LEAVE**, then **CONFIRM LEAVE**. You cannot leave a group you own; transfer ownership first.
+
+### API
+
+`GET /api/v1.0/me`, `PATCH /api/v1.0/me`, `PUT` and `DELETE` on `/api/v1.0/me/password`, `GET /api/v1.0/me/groups`, `DELETE /api/v1.0/me/groups/:id`, `GET` and `DELETE` on `/api/v1.0/me/identities`, and `GET /api/v1.0/me/scopes`.
+
+## Accept the Acceptable Use Policy
+
+If your server has an Acceptable Use Policy configured, you must accept the current version before you can use the user, group, or self-service management APIs.
+Until you do, those endpoints return `403` with `requires_aup: true` and the version you need to accept, and the web interface sends you to the acceptance page.
+Three things stay reachable so you can get unstuck: reading the policy, accepting it, and signing out.
+Editing the policy is also exempt, so rotating it cannot lock out the administrator who rotated it.
+
+**To accept it as a user:** the interface takes you to the **Acceptable Use Policy** page on its own and returns you afterwards to where you were headed.
+Read the policy and click **I AGREE**.
+
+**To edit the policy** — *requires `server.admin`* — go to **Settings** → **AUP**, edit the Markdown on the left, optionally fill in **Last updated (footer)**, and click **SAVE AS NEW ACTIVE VERSION**.
+Saving rotates the version, which re-prompts every user on the server on their next visit.
+
+**To re-prompt one user** — *requires `server.admin` or `server.user_admin`* — go to **Settings** → **Users**, edit the user, and click **CLEAR AUP ACCEPTANCE**.
+The CLI equivalents are `pelican-server server user aup clear <user-id>` and `pelican-server server user aup record <user-id> --version <version>`.
+
+To switch the requirement off entirely, set [`Server.AUPFile`](/parameters#Server-AUPFile) to `none`.
+
+## Troubleshooting
+
+**`403` with `requires_aup: true`.**
+You have not accepted the current Acceptable Use Policy.
+Open the acceptance page, read the policy, and click **I AGREE**; see [Accept the Acceptable Use Policy](#accept-the-acceptable-use-policy) and the [Acceptable Use Policy gate](/managing-data-access/permissions-reference#acceptable-use-policy-gate).
+
+**`403` when granting or revoking a scope.**
+Scope grants are system-admin-only.
+Holding `server.user_admin` lets you list grants but not change them.
+
+**`403` when deleting another user.**
+A user administrator can only delete their own account.
+Deactivate the account instead, or ask a system administrator.
+
+**`403 user administrators cannot modify system admin accounts`.**
+A `server.user_admin` holder cannot rename, deactivate, delete, or mint a password invite for an account that holds `server.admin`.
+
+**`404` on a group you believe exists.**
+Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it.
+A `404` on a collection or group you believe exists usually means you lack access, not that it is missing.
+
+**A group name is rejected.**
+Names are 2 to 64 characters of letters, digits, `.`, `_`, `@`, and `-`, must start with a letter or digit, and may not contain `/` or `..`.
+`user-` is reserved.
+See [Identifier rules](/managing-data-access/permissions-reference#identifier-rules).
+
+**An entry in an admin list grants nothing.**
+[`Server.UIAdminUsers`](/parameters#Server-UIAdminUsers) and [`Server.UserAdminUsers`](/parameters#Server-UserAdminUsers) match on usernames, not on OIDC subjects; [`Server.AdminGroups`](/parameters#Server-AdminGroups) and [`Server.UserAdminGroups`](/parameters#Server-UserAdminGroups) match on group names.
+An OIDC subject placed in one of the user lists never matches anything.
+A group named in one of the group lists only counts if the group is auth-template eligible.
+
+**A user cannot change their own password.**
+The self-service rotate and remove controls refuse on an account with no password set.
+Mint a password-set invite instead; see [Let a user set a password](#let-a-user-set-a-password).

--- a/docs/app/managing-data-access/users-and-groups/page.mdx
+++ b/docs/app/managing-data-access/users-and-groups/page.mdx
@@ -2,42 +2,47 @@ import { Callout } from 'nextra/components'
 
 # Managing Users and Groups
 
-Access to a collection is granted to a **group**, never to a person directly — so before you can give someone access, they need an account on this server and a group to put them in.
-This page covers both: creating and running groups, the account tasks an administrator does around them, and the handful of things every signed-in user does for themselves.
-For the granting itself, see [Managing Access to a Collection](/managing-data-access/collections-and-shares).
-For the model behind these tasks — what a user is, what a group is, and how a scope reaches a caller — read [How Access Control Works](/managing-data-access/access-control-model).
-For the authoritative "who may do this", read the [Permissions Reference](/managing-data-access/permissions-reference).
+The origin grants access to [**collections**](/managing-data-access/collections-and-shares) based on **group membership**; so, to provide an individual with a
+access to data, the origin's administrator - or the delegated [user administrator](/managing-data-access/permissions-reference#user-administration) - must configure
+user accounts and manage group membership.  This page provides short guides for the administrator to
+
+* Adding a user to the origin: Creating the account and (optionally) setting a password.
+* Deactivating a user: Removing their access to the origin and its data
+* Creating a group and managing membership: Adding, inviting, or removing users from a group
+* Delegating group management: Controlling who has permission to make membership
+* Authorizing other access beyond data: Allowing users or groups to view monitoring data or become user administrators themselves.
+
+Additionally, there is a guide, applicable to any user, on managing their own account.
+For the model behind these tasks (what a user is, what a group is, and how a scope reaches a caller) read [How Access Control Works](/managing-data-access/access-control-model).
+For more details, read the [Permissions Reference](/managing-data-access/permissions-reference).
 
 ## Before you start
 
-Every section below opens with a one-line prerequisite naming the scope the task calls for.
-Beyond that, what you need depends on the method.
+Each guide below uses the origin's **web interface**; to follow along, you must know the origin's URL and have an existing account with the user administrator
+privilege (`server.admin` or `server.user_admin`; see [User administration](/managing-data-access/permissions-reference#user-administration)).
+At the end of the guide, an equivalent **command line** example is given for more advanced administrators.  The command line examples
+assume you are logged into the origin's host or container and have read access to the origin's keys (typically in `/etc/pelican/issuer-keys/`)
+to authorize the action.
 
-- **Web interface:** your server's web URL and an account holding that scope.
-- **Command line:** a shell on the server host. The `pelican-server server user` and `pelican-server server group` commands drive the local server's admin API with a token they mint from the server's own issuer key, so they only work where that key is readable, and they read `Server.ExternalWebUrl` to find the API. Full flag lists live in the generated reference for [`server user`](/commands-reference/pelican-server/server/user) and [`server group`](/commands-reference/pelican-server/server/group).
-- **API:** a login cookie or an API token whose creator holds that scope. The Swagger browser at [`/api-docs`](/api-docs) carries every request and response shape; this page never repeats them.
+Additionally, one can use direct **API** access to invoke the command over the REST interface; the documentation at [`/api-docs`](/api-docs) carries every request and response shape but
+API access is not otherwise covered here.
 
 <Callout type="info">
 Several tasks below produce an invite link.
-Pelican mints the link and shows you the token exactly once; delivering it to the right person is your job.
+Pelican creates the link and displays it exactly once; it is the administrator's responsibility to send it securely to the target user.
 Pelican does not send email.
 </Callout>
 
 ## Add a user
 
-*Requires `server.admin` or `server.user_admin` — see [User administration](/managing-data-access/permissions-reference#user-administration).*
+Most origins are integrated with Single Sign On (SSO) and are set to auto-create an account the first time a user logs in via SSO.  However, an
+administrator can pre-create an account, enabling logins via a password reset link or through providing SSO information.
 
-Most accounts appear by themselves the first time someone signs in through your configured OIDC provider.
-Create one by hand when you want to pre-provision: add the person to groups, grant a scope, or hand them a password before they have ever logged in.
+Pre-creating allows one to add the person to groups or grant a permissions before the first login.
 
-A **local account** needs only a username; the person sets a password later by redeeming an invite.
-An **OIDC-linked account** also carries a subject and issuer pair, and the next login matching that pair claims it.
-
-### Web UI
-
-1. Go to **Settings** → **Users** and click **ADD USER**.
-2. Choose **Local (username + password)** or **External (OIDC)**.
-3. Fill in **Username** and, optionally, **Display name**. For an external user, also fill in **Sub** and **Issuer** from your identity provider.
+1. In the browser, go to **Settings** → **Users** and click **ADD USER**.
+2. Choose **Local (username + password)** or **External (OIDC)**.  The latter only appears if the origin has SSO enabled.
+3. Fill in **Username** and, optionally, **Display name**. For a SSO-based user, also fill in **Sub** ("subject"; typically, it's the SSO username) and **Issuer** (URL of the SSO) from your identity provider.
 4. Click **CREATE USER**.
 5. For a local account, the page offers **GENERATE PASSWORD-SET INVITE**. Click it and copy the URL, or click **SKIP FOR NOW** and mint the invite later.
 
@@ -52,27 +57,16 @@ pelican-server server user create --username alice \
     --sub abc-123 --issuer https://oidc.example.org/
 ```
 
-### API
-
-`POST /api/v1.0/users` with a `username`, optionally a `displayName`, and — for an OIDC account — both `sub` and `issuer`.
-
-New accounts are granted the scopes named in [`Server.NewUserDefaultScopes`](/parameters#Server-NewUserDefaultScopes).
-Later edits to that setting do not apply to accounts that already exist.
-
 ## Let a user set a password
 
-*Requires `server.admin` or `server.user_admin` — see [User administration](/managing-data-access/permissions-reference#user-administration).*
-
-Administrators never see or choose a password.
-Instead you mint a single-use, time-bounded invite and hand over the link; the person picks their own password when they redeem it.
-The link's lifetime comes from [`Server.GroupInviteLinkExpiration`](/parameters#Server-GroupInviteLinkExpiration) unless you override it.
-
-### Web UI
+Administrators never set passwords for users; instead they mint a single-use, time-bounded invite and hand over the link (typically,
+emailing it to an individual).  The person sets their own password when they redeem it.
+The link lifetime defaults to the value of [`Server.GroupInviteLinkExpiration`](/parameters#Server-GroupInviteLinkExpiration).
 
 1. Go to **Settings** → **Users** and click the edit icon on the user's row.
 2. Under **Password setup**, click **GENERATE PASSWORD-SET INVITE**.
 3. Copy the URL from the box that appears and deliver it. It is shown only once.
-4. To disable password login on a compromised account, click **CLEAR LOCAL PASSWORD** under **Local password** and confirm.
+4. To disable password login, click **CLEAR LOCAL PASSWORD** under **Local password** and confirm.
 
 The same panel lists every invite ever issued for that user, so you can see whether one is already outstanding before minting another.
 
@@ -84,19 +78,16 @@ pelican-server server user list-password-invites <user-id>
 pelican-server server user clear-password <user-id>
 ```
 
-### API
-
-`POST /api/v1.0/users/:id/password-invite` mints the link, `GET /api/v1.0/users/:id/password-invites` lists them, and `DELETE /api/v1.0/users/:id/password` clears the password.
-
-A user who already has a password can rotate or remove it themselves from their profile page, but a user with none cannot grow one on their own — an admin-minted invite is the only path.
-
 ## Creating an onboarding link
 
-*Requires `server.admin` or `server.user_admin` — see [User administration](/managing-data-access/permissions-reference#user-administration).*
+Use an onboarding link when you want to invite someone to use the origin whose SSO identity is not currently known; while some SSO's use human-friendly usernames,
+the default provider for Pelican (CILogon) randomly generates names.  A CILogon name may be of the form `http://cilogon.org/serverA/users/67294` and not known to
+the user or administrator.
 
-Use an onboarding link when you want to invite someone whose OIDC subject you do not know in advance.
-The link creates no account up front; the recipient signs in through your identity provider first, and the identity they used claims a new account when they redeem.
-There is no web-interface control for this link today, so it is a CLI or API task.
+By using an onboarding link, the new account is associated with the SSO account of the individual who clicked on the link.
+After clicking on the link, the recipient signs in through the identity provider first, and then accepts the invite.
+
+[TODO: the generated text claimed there is no such UI.  This is wrong; add instructions/screenshots here.]
 
 ### CLI
 
@@ -106,29 +97,16 @@ pelican-server server user invite-onboard
 
 The command prints the token, its expiry, and a redemption URL to hand over.
 
-### API
-
-`POST /api/v1.0/invites/onboarding`.
-
-The recipient signs in, opens the **Redeem invite** page, pastes the token if the URL did not carry it, and clicks **CONTINUE**.
-An onboarding link names no group, so redeeming it simply establishes the account.
-
 ## Deactivate or delete a user
 
-*Requires `server.admin` or `server.user_admin`, with limits — see [User administration](/managing-data-access/permissions-reference#user-administration).*
-
-Deactivating is the reversible option.
-Setting a user's status to `inactive` stops the account from authenticating; because authorization is recomputed on every request, live sessions stop working on the next request rather than when a token expires.
+Deactivating is reversible: deactivate when you want to stop the account from being used.
+Because authorization is recomputed periodically, live sessions stop working shortly after deactivation (exact time differs based on configuration; by
+default, it is 15 minutes).
 
 Deleting is not reversible.
-Along with the account, Pelican removes its group memberships and every collection access grant written against its personal `user-<username>` group.
+Along with the account, Pelican removes group memberships.  There is no "undelete" functionality.
 
-Deletion is available on all three surfaces.
-The web interface has no activate/deactivate control, so status changes are a CLI or API task.
-
-### Web UI
-
-Go to **Settings** → **Users** and use the **Delete** control on the user's row.
+To delete, go to **Settings** → **Users** and use the **Delete** control on the user's row.
 
 ### CLI
 
@@ -137,33 +115,17 @@ pelican-server server user set-status <user-id> --status inactive
 pelican-server server user delete <user-id>
 ```
 
-### API
-
-`PUT /api/v1.0/users/:id/status` with a `status` of `active` or `inactive`, and `DELETE /api/v1.0/users/:id`.
-
-<Callout type="warning">
-A user administrator can deactivate another account but cannot currently delete one.
-The route admits `server.user_admin`, and the check that runs afterwards refuses unless the caller is a system administrator or the target is the caller's own account.
-A user administrator who tries gets a `403`; ask a system administrator to perform the deletion, or deactivate instead.
-</Callout>
-
-A user administrator also cannot rename, deactivate, delete, or mint a password invite for a system administrator's account.
-Those attempts return `403` with `user administrators cannot modify system admin accounts`.
-
 ## Create a group
 
-*Any signed-in user can create a group — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+*Any signed-in user can create a group; see [Group administration](/managing-data-access/permissions-reference#group-administration).*
 
-Group creation is open to everyone because users need groups of their own to grant access on their collections and shares.
-What a self-created group cannot do is act as bearer authority; see [Make a group usable in authorization templates and admin lists](#make-a-group-usable-in-authorization-templates-and-admin-lists) below.
+Group creation is open to any user, allowing them to grant access to their own collections and shares.
+Groups created by unprivileged users, however, cannot be used for Pelican's authorization templates mechanism or be referenced from the configuration variables granting administrator access.
 
-The group **name** is the machine-readable name that access grants and policy settings match on.
-It is 2 to 64 characters drawn from letters, digits, `.`, `_`, `@`, and `-`, has to start with a letter or digit, may not contain `/` or `..`, and may not start with `user-` — that prefix is reserved for the implicit personal group every account carries.
-The **display name** and **description** are free-form labels and never take part in an authorization decision.
+The group **name** is the machine-readable name (such as `reyes-lab-writers`); it is 2 to 64 characters drawn from letters, digits, `.`, `_`, `@`, and `-` and must start with a letter or digit.
+The **display name** and **description** are free-form labels for human readability.
 
 Once the group exists, use it to grant access to a collection: see [Grant read or write access to a group](/managing-data-access/collections-and-shares#grant-read-or-write-access-to-a-group).
-
-### Web UI
 
 1. Open **Groups** from the sidebar, or **Settings** → **Groups**.
 2. Click **CREATE GROUP**.
@@ -177,26 +139,19 @@ Once the group exists, use it to grant access to a collection: see [Grant read o
 pelican-server server group create --name cms-analysis --description "CMS analysis team"
 ```
 
-### API
-
-`POST /api/v1.0/groups`.
-
 ## Add and remove group members
 
-*Requires group ownership, a group administrator delegation, or `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+*Requires group ownership/administrator privilege or server user administration privilege.*
 
-The person you add needs an account on this server already.
-Adding someone who is already a member succeeds and changes nothing.
-Holding `server.user_admin` alone does not let you edit a group's membership.
-
-### Web UI
+Each group has an owner (individual user account); optionally, there may be an "administrator group".  Either the owner or a member of the administrator group can manage group membership
 
 1. Open **Groups** and expand the group, or open its detail page.
 2. Under **Members**, click **ADD MEMBER**, pick the user, and click **ADD MEMBER** again in the dialog.
 3. To remove someone, click the remove icon beside their row and confirm.
 
-The **ADD MEMBER** picker reads the server-wide user list, so it appears only for system administrators; a group owner or administrator who is not one invites people with a link instead.
-Removing a member never relinquishes ownership — the owner stays the owner even after their membership is deleted.
+For administrators, the **ADD MEMBER** drop-down shows all users at the server.  Otherwise, it only shows users in groups the owner is a member of.
+
+Removing a member does not relinquish ownership; the owner remains the owner even after their membership is deleted.
 
 ### CLI
 
@@ -206,28 +161,22 @@ pelican-server server group remove-member <group-id> --user-id <user-id>
 pelican-server server group list-members <group-id>
 ```
 
-### API
-
-`POST /api/v1.0/groups/:id/members`, `DELETE /api/v1.0/groups/:id/members/:userId`, and `GET /api/v1.0/groups/:id/members`.
-
 ## Invite people to a group with a link
 
-*Requires group ownership, a group administrator delegation, or `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+*Requires group ownership/administrator privilege or server user administration privilege; see [Group administration](/managing-data-access/permissions-reference#group-administration).*
 
 An invite link is how a group owner brings in people they cannot look up.
 A single-use link admits one person; a multi-use link admits everyone who holds it until it expires or you revoke it.
-Expiry defaults to [`Server.GroupInviteLinkExpiration`](/parameters#Server-GroupInviteLinkExpiration).
+Expiration time defaults to [`Server.GroupInviteLinkExpiration`](/parameters#Server-GroupInviteLinkExpiration).
 
-The recipient has to be signed in and, if your server has an Acceptable Use Policy, AUP-compliant before they can redeem — nobody gets conscripted into a group as a side effect of following a link.
-
-### Web UI
+The recipient must sign in to their user account and, if your server has an Acceptable Use Policy (AUP) policy, agree to the AUP.  Once signed in, the user may accept the invite to join the group.
 
 1. Open the group's detail page. The **Invite links** panel appears for owners and group administrators only.
-2. Set **Single use** on or off, and set **Expires in** to a Go duration such as `168h`, `24h`, or `30m`.
+2. Set **Single use** on or off, and set **Expires in** to a duration such as `168h`, `24h`, or `30m`.
 3. Click **GENERATE INVITE LINK** and copy the URL. It is shown only once.
 4. To withdraw a link, click the revoke icon on its row.
 
-Listed links show a short token ID rather than the token itself, which is safe to quote in a ticket or an audit log.
+Listed links show a short ID rather than the token; the ID is safe to quote in a ticket or an audit log.
 
 ### CLI
 
@@ -237,22 +186,14 @@ pelican-server server group invite list <group-id>
 pelican-server server group invite revoke <group-id> <link-id>
 ```
 
-### API
-
-`POST /api/v1.0/groups/:id/invites`, `GET /api/v1.0/groups/:id/invites`, and `DELETE /api/v1.0/groups/:id/invites/:linkId`.
-The recipient redeems at `POST /api/v1.0/invites/redeem`.
-
 ## Transfer group ownership or delegate a group administrator
 
-*Requires group ownership or `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+*Requires group ownership or server administration privilege; see [Group administration](/managing-data-access/permissions-reference#group-administration).*
 
-A group has exactly one owner, and the owner is the only one who can hand the group to someone else, name an administrator, or delete it — and the only one who cannot leave it.
-Transfer ownership first if you want out.
+A group has exactly one owner; only the owner can transfer ownership, name an administrator group, or delete it.
 
-A group administrator handles membership and metadata day to day, and may be a single user or another group, so you can point one team's admin at a second team.
+A group administrator manages group membership on behalf of the owner.
 An administrator cannot transfer ownership and cannot delete the group.
-
-### Web UI
 
 1. Open the group's detail page and find the **Ownership** section.
 2. Click the edit icon beside **Owner**, pick the new owner, and save.
@@ -265,54 +206,24 @@ pelican-server server group set-ownership <group-id> --owner-id <user-id>
 pelican-server server group set-ownership <group-id> --admin-id <id> --admin-type group
 ```
 
-### API
-
-`PUT /api/v1.0/groups/:id/ownership` with `ownerId`, `adminId`, and `adminType` as needed.
-
 ## Make a group usable in authorization templates and admin lists
 
-*Turning the flag on for an existing group requires `server.admin` — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
+*Turning the flag on for an existing group requires server administrator privileges — see [Group administration](/managing-data-access/permissions-reference#group-administration).*
 
-[`Issuer.AuthorizationTemplates`](/parameters#Issuer-AuthorizationTemplates) and the `Server.*AdminGroups` settings — [`Server.AdminGroups`](/parameters#Server-AdminGroups) and [`Server.UserAdminGroups`](/parameters#Server-UserAdminGroups) among them — match on a group's *name*, and they only trust a name that carries the auth-template-eligibility flag.
-Set the flag on a group before you name it in one of those settings; without it, the entry matches nothing.
-Collection access grants do not consult the flag, so a group used only for collection access never needs it.
-For why the flag exists, see [Where a scope can come from](/managing-data-access/access-control-model#where-a-scope-can-come-from).
+[`Issuer.AuthorizationTemplates`](/parameters#Issuer-AuthorizationTemplates) and the `Server.*AdminGroups` settings provide groups with special privileges to access data or administer the server.
+Since unprivileged users can groups as well, the administrator must mark groups as compatible with these settings; this is the special `auth-template-eligibility` flag.
+For more information, see [Where a scope can come from?](/managing-data-access/access-control-model#where-a-scope-can-come-from).
 
-You can set the flag at creation time if you hold `server.admin` or `server.user_admin`.
-Changing it afterwards is system-admin-only, so a user administrator who tries gets a `403`.
-There is no CLI flag for eligibility, which makes this a web-interface or API task.
-
-### Web UI
+You can set the flag at creation time if you are a server administrator.
 
 - **At creation:** in the **Create New Group** dialog, tick **Auth-template eligible**. The checkbox is rendered only for callers who can set it.
 - **Afterwards:** open the group's detail page and flip the **Auth template** switch. Everyone else sees the current state as a read-only `eligible` or `ineligible` chip.
 
-### API
+## Grant a scope to a user or group
 
-`PATCH /api/v1.0/groups/:id` with `authTemplateEligible`.
+*Requires server administrator privilege; see [Management scopes](/managing-data-access/permissions-reference#management-scopes).*
 
-<Callout type="warning">
-The web interface renders the **Auth template** switch for user administrators as well as system administrators, but the server accepts the change only from a system administrator.
-A user administrator who flips the switch sees the request fail.
-</Callout>
-
-The same `PATCH` endpoint is where a group's display name and description are edited, and where a system administrator renames a group.
-The web interface has no control for those fields today; use `pelican-server server group update` or the API.
-
-## Grant a management scope to a user or group
-
-*Requires `server.admin` — see [Management scopes](/managing-data-access/permissions-reference#management-scopes).*
-
-A `server.user_admin` holder can read scope grants but cannot create or revoke them, because granting a scope to yourself is exactly the self-elevation the split is there to prevent.
-Granting a scope to a group elevates every member of that group, now and in the future, so prefer a direct grant on a user unless you want the membership list to control the privilege.
-
-Two listings answer different questions.
-`GET /api/v1.0/users/:id/scopes` returns only the rows granted directly to that user.
-`GET /api/v1.0/me/scopes` returns your own *effective* set — direct grants, plus everything inherited from your groups and from the operator's admin-list configuration.
-Config-derived grants never appear in the direct listing; you take those back by editing the configuration file, not by revoking a row.
-See [Sources of a scope](/managing-data-access/permissions-reference#sources-of-a-scope) for every path a grant can arrive by and how to withdraw each one.
-
-### Web UI
+Scopes provide specific permissions to a user or group beyond data access.  Scopes may allow access to monitoring, collection management, or user management.
 
 1. For a user: **Settings** → **Users**, edit the user, and scroll to **Scopes**. For a group: open the group's detail page and find its scopes panel. Both panels are rendered for system administrators only.
 2. Pick an entry from **Pick a scope to grant** — the picker offers only scopes the management API will accept — and click **GRANT**.
@@ -326,18 +237,9 @@ pelican-server server user scope grant <user-id> --scope server.user_admin
 pelican-server server group scope revoke <group-id> <scope>
 ```
 
-### API
-
-`POST` and `DELETE` on `/api/v1.0/users/:id/scopes` and `/api/v1.0/groups/:id/scopes`.
-
 ## Manage your own account
 
 *Any signed-in user.*
-
-Everything here targets the caller and needs no administrative scope.
-The `pelican-server` commands act as a server administrator rather than as you, so self-service is a web-interface or API task.
-
-### Web UI
 
 Open the user menu and choose **Profile**.
 
@@ -347,59 +249,3 @@ Open the user menu and choose **Profile**.
 - **Linked identities** — unlink a secondary identity with the unlink icon. Your primary identity is marked `managed by admin`.
 - **Your groups** — click **LEAVE**, then **CONFIRM LEAVE**. You cannot leave a group you own; transfer ownership first.
 
-### API
-
-`GET /api/v1.0/me`, `PATCH /api/v1.0/me`, `PUT` and `DELETE` on `/api/v1.0/me/password`, `GET /api/v1.0/me/groups`, `DELETE /api/v1.0/me/groups/:id`, `GET` and `DELETE` on `/api/v1.0/me/identities`, and `GET /api/v1.0/me/scopes`.
-
-## Accept the Acceptable Use Policy
-
-If your server has an Acceptable Use Policy configured, you must accept the current version before you can use the user, group, or self-service management APIs.
-Until you do, those endpoints return `403` with `requires_aup: true` and the version you need to accept, and the web interface sends you to the acceptance page.
-Three things stay reachable so you can get unstuck: reading the policy, accepting it, and signing out.
-Editing the policy is also exempt, so rotating it cannot lock out the administrator who rotated it.
-
-**To accept it as a user:** the interface takes you to the **Acceptable Use Policy** page on its own and returns you afterwards to where you were headed.
-Read the policy and click **I AGREE**.
-
-**To edit the policy** — *requires `server.admin`* — go to **Settings** → **AUP**, edit the Markdown on the left, optionally fill in **Last updated (footer)**, and click **SAVE AS NEW ACTIVE VERSION**.
-Saving rotates the version, which re-prompts every user on the server on their next visit.
-
-**To re-prompt one user** — *requires `server.admin` or `server.user_admin`* — go to **Settings** → **Users**, edit the user, and click **CLEAR AUP ACCEPTANCE**.
-The CLI equivalents are `pelican-server server user aup clear <user-id>` and `pelican-server server user aup record <user-id> --version <version>`.
-
-To switch the requirement off entirely, set [`Server.AUPFile`](/parameters#Server-AUPFile) to `none`.
-
-## Troubleshooting
-
-**`403` with `requires_aup: true`.**
-You have not accepted the current Acceptable Use Policy.
-Open the acceptance page, read the policy, and click **I AGREE**; see [Accept the Acceptable Use Policy](#accept-the-acceptable-use-policy) and the [Acceptable Use Policy gate](/managing-data-access/permissions-reference#acceptable-use-policy-gate).
-
-**`403` when granting or revoking a scope.**
-Scope grants are system-admin-only.
-Holding `server.user_admin` lets you list grants but not change them.
-
-**`403` when deleting another user.**
-A user administrator can only delete their own account.
-Deactivate the account instead, or ask a system administrator.
-
-**`403 user administrators cannot modify system admin accounts`.**
-A `server.user_admin` holder cannot rename, deactivate, delete, or mint a password invite for an account that holds `server.admin`.
-
-**`404` on a group you believe exists.**
-Endpoints that would otherwise confirm a record exists return `404` rather than `403` when you are not allowed to see it.
-A `404` on a collection or group you believe exists usually means you lack access, not that it is missing.
-
-**A group name is rejected.**
-Names are 2 to 64 characters of letters, digits, `.`, `_`, `@`, and `-`, must start with a letter or digit, and may not contain `/` or `..`.
-`user-` is reserved.
-See [Identifier rules](/managing-data-access/permissions-reference#identifier-rules).
-
-**An entry in an admin list grants nothing.**
-[`Server.UIAdminUsers`](/parameters#Server-UIAdminUsers) and [`Server.UserAdminUsers`](/parameters#Server-UserAdminUsers) match on usernames, not on OIDC subjects; [`Server.AdminGroups`](/parameters#Server-AdminGroups) and [`Server.UserAdminGroups`](/parameters#Server-UserAdminGroups) match on group names.
-An OIDC subject placed in one of the user lists never matches anything.
-A group named in one of the group lists only counts if the group is auth-template eligible.
-
-**A user cannot change their own password.**
-The self-service rotate and remove controls refuse on an account with no password set.
-Mint a password-set invite instead; see [Let a user set a password](#let-a-user-set-a-password).

--- a/docs/app/managing-data-access/users-and-groups/page.mdx
+++ b/docs/app/managing-data-access/users-and-groups/page.mdx
@@ -46,17 +46,6 @@ Pre-creating allows one to add the person to groups or grant a permissions befor
 4. Click **CREATE USER**.
 5. For a local account, the page offers **GENERATE PASSWORD-SET INVITE**. Click it and copy the URL, or click **SKIP FOR NOW** and mint the invite later.
 
-### CLI
-
-```bash copy
-# Local account — hand out a password invite afterwards
-pelican-server server user create --username alice --display-name "Alice Chen"
-
-# OIDC account, subject known in advance
-pelican-server server user create --username alice \
-    --sub abc-123 --issuer https://oidc.example.org/
-```
-
 ## Let a user set a password
 
 Administrators never set passwords for users; instead they mint a single-use, time-bounded invite and hand over the link (typically,
@@ -70,32 +59,20 @@ The link lifetime defaults to the value of [`Server.GroupInviteLinkExpiration`](
 
 The same panel lists every invite ever issued for that user, so you can see whether one is already outstanding before minting another.
 
-### CLI
-
-```bash copy
-pelican-server server user invite-password <user-id>
-pelican-server server user list-password-invites <user-id>
-pelican-server server user clear-password <user-id>
-```
-
-## Creating an onboarding link
+## Creating a group onboarding link
 
 Use an onboarding link when you want to invite someone to use the origin whose SSO identity is not currently known; while some SSO's use human-friendly usernames,
 the default provider for Pelican (CILogon) randomly generates names.  A CILogon name may be of the form `http://cilogon.org/serverA/users/67294` and not known to
 the user or administrator.
 
-By using an onboarding link, the new account is associated with the SSO account of the individual who clicked on the link.
+By using an onboarding link, a new account is created and associated with the SSO account of the individual who clicked on the link.
 After clicking on the link, the recipient signs in through the identity provider first, and then accepts the invite.
 
-[TODO: the generated text claimed there is no such UI.  This is wrong; add instructions/screenshots here.]
-
-### CLI
-
-```bash copy
-pelican-server server user invite-onboard
-```
-
-The command prints the token, its expiry, and a redemption URL to hand over.
+1. Open **Groups** from the sidebar, or **Settings** → **Groups**.
+2. Search and Click to expand the Group you wish to onboard the user to.
+3. Navigate the **Invite Links** section
+4. Toggle **Single Use** if you want just one person to use this link, adjust the expiration of the link as needed and click **Generate Invite Link**.
+5. Copy and send the URL to the user you wish to onboard.
 
 ## Deactivate or delete a user
 
@@ -107,13 +84,6 @@ Deleting is not reversible.
 Along with the account, Pelican removes group memberships.  There is no "undelete" functionality.
 
 To delete, go to **Settings** → **Users** and use the **Delete** control on the user's row.
-
-### CLI
-
-```bash copy
-pelican-server server user set-status <user-id> --status inactive
-pelican-server server user delete <user-id>
-```
 
 ## Create a group
 
@@ -133,12 +103,6 @@ Once the group exists, use it to grant access to a collection: see [Grant read o
 4. Leave **Add me as a member of this group** checked if you want to be a member as well as the owner. Creating a group makes you its owner but does not make you a member.
 5. Click **CREATE**.
 
-### CLI
-
-```bash copy
-pelican-server server group create --name cms-analysis --description "CMS analysis team"
-```
-
 ## Add and remove group members
 
 *Requires group ownership/administrator privilege or server user administration privilege.*
@@ -152,14 +116,6 @@ Each group has an owner (individual user account); optionally, there may be an "
 For administrators, the **ADD MEMBER** drop-down shows all users at the server.  Otherwise, it only shows users in groups the owner is a member of.
 
 Removing a member does not relinquish ownership; the owner remains the owner even after their membership is deleted.
-
-### CLI
-
-```bash copy
-pelican-server server group add-member <group-id> --user-id <user-id>
-pelican-server server group remove-member <group-id> --user-id <user-id>
-pelican-server server group list-members <group-id>
-```
 
 ## Invite people to a group with a link
 
@@ -178,14 +134,6 @@ The recipient must sign in to their user account and, if your server has an Acce
 
 Listed links show a short ID rather than the token; the ID is safe to quote in a ticket or an audit log.
 
-### CLI
-
-```bash copy
-pelican-server server group invite create <group-id> --single-use --expires-in 24h
-pelican-server server group invite list <group-id>
-pelican-server server group invite revoke <group-id> <link-id>
-```
-
 ## Transfer group ownership or delegate a group administrator
 
 *Requires group ownership or server administration privilege; see [Group administration](/managing-data-access/permissions-reference#group-administration).*
@@ -198,13 +146,6 @@ An administrator cannot transfer ownership and cannot delete the group.
 1. Open the group's detail page and find the **Ownership** section.
 2. Click the edit icon beside **Owner**, pick the new owner, and save.
 3. Click the edit icon beside **Administrator**, choose **None**, **User**, or **Group**, pick the target, and save.
-
-### CLI
-
-```bash copy
-pelican-server server group set-ownership <group-id> --owner-id <user-id>
-pelican-server server group set-ownership <group-id> --admin-id <id> --admin-type group
-```
 
 ## Make a group usable in authorization templates and admin lists
 
@@ -228,14 +169,6 @@ Scopes provide specific permissions to a user or group beyond data access.  Scop
 1. For a user: **Settings** → **Users**, edit the user, and scroll to **Scopes**. For a group: open the group's detail page and find its scopes panel. Both panels are rendered for system administrators only.
 2. Pick an entry from **Pick a scope to grant** — the picker offers only scopes the management API will accept — and click **GRANT**.
 3. To revoke, click the × on the scope's chip.
-
-### CLI
-
-```bash copy
-pelican-server server user scope list <user-id>
-pelican-server server user scope grant <user-id> --scope server.user_admin
-pelican-server server group scope revoke <group-id> <scope>
-```
 
 ## Manage your own account
 


### PR DESCRIPTION
Created with a Claude, went through and fixed up by hand. 

Uses Diataxis and plain language in a documentation-writing skill.

I am happy with the results. I thought it was pretty clear to use and I learned a lot about how this all works reading through things.

Update extension to `.skill` before using:
[documentation-writing.txt](https://github.com/user-attachments/files/31663131/documentation-writing.txt)
