### PR TITLE
Bump xrdcl-pelican version to 1.8.2 in images and OSX

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -67,7 +67,7 @@ ninja
 ninja install
 popd
 
-git clone --branch v1.8.1 https://github.com/PelicanPlatform/xrdcl-pelican.git
+git clone --branch v1.8.2 https://github.com/PelicanPlatform/xrdcl-pelican.git
 pushd xrdcl-pelican
 mkdir build
 cd build

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -82,7 +82,7 @@ ARG LOTMAN_RELEASE=
 # Until the two places are programmatically synchronized, please double-check by hand
 # when doing version changes.
 ARG XRDCL_PELICAN_SRC_BUILD=false
-ARG XRDCL_PELICAN_VER=1.8.1
+ARG XRDCL_PELICAN_VER=1.8.2
 ARG XRDCL_PELICAN_RELEASE=
 # ARG XRDCL_PELICAN_RELEASE="1.osg${OSG_SERIES}.${BASE_OS}"
 ARG XROOTD_LOTMAN_SRC_BUILD=false


### PR DESCRIPTION
Fixes #3711 