### PR TITLE
Initialize cache server database before the web engine starts serving

### DIFF
--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pelicanplatform/pelican/cache"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
-	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/launcher_utils"
 	"github.com/pelicanplatform/pelican/local_cache"
 	"github.com/pelicanplatform/pelican/lotman"
@@ -87,10 +86,6 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 // cacheServeWithPersistentCache launches the cache using the persistent cache implementation
 func cacheServeWithPersistentCache(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, modules server_structs.ServerType) (server_structs.XRootDServer, error) {
 	log.Info("Using new persistent cache implementation")
-
-	if err := database.InitServerDatabase(server_structs.CacheType); err != nil {
-		return nil, err
-	}
 
 	// The persistent cache has no XRootD process to launch the monitoring
 	// shoveler (which the XRootD-based cache does via xrootd config), so start
@@ -236,10 +231,6 @@ func cacheServeWithXRootD(ctx context.Context, engine *gin.Engine, egrp *errgrou
 	}
 
 	if err := cache.CheckCacheSentinelLocation(); err != nil {
-		return nil, err
-	}
-
-	if err := database.InitServerDatabase(server_structs.CacheType); err != nil {
 		return nil, err
 	}
 

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -250,6 +250,17 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 		log.Info("Transfer module enabled")
 	}
 
+	// The cache is the only module launched after the web engine is up (it
+	// must wait for the director to be working), while its database must be
+	// initialized here, before the engine starts serving: web handlers
+	// dereference database.ServerDatabase and a request arriving in the
+	// window between engine start and CacheServe would panic (issue #3709).
+	if modules.IsEnabled(server_structs.CacheType) {
+		if err = database.InitServerDatabase(server_structs.CacheType); err != nil {
+			return
+		}
+	}
+
 	// Start periodic database backup routine
 	database.LaunchPeriodicBackup(ctx, egrp)
 

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -1250,9 +1250,11 @@ func whoamiHandler(ctx *gin.Context) {
 		// audience+issuer were verified upstream so the row's
 		// authority is not a security check — just a label lookup.
 		var userRecord *database.User
-		if rec, dbErr := database.GetUserByID(database.ServerDatabase, userId); dbErr == nil {
-			userRecord = rec
-			res.DisplayName = rec.DisplayName
+		if database.ServerDatabase != nil {
+			if rec, dbErr := database.GetUserByID(database.ServerDatabase, userId); dbErr == nil {
+				userRecord = rec
+				res.DisplayName = rec.DisplayName
+			}
 		}
 
 		// Check AUP compliance. resolveAUP centralizes the operator-file


### PR DESCRIPTION
On a cache, `LaunchModules` starts the web engine and then waits for the director to be up before calling `CacheServe`, which was where `database.InitServerDatabase` ran. Every other module (registry, director, origin, transfer) initializes the database before the engine starts; the cache was the only one that didn't. Any authenticated web request landing in that window dereferenced a nil `database.ServerDatabase` and panicked (recovered by gin as a 500). The reported reproducer is an upgrade restart: the operator's browser still holds a valid login cookie and the frontend polls /api/v1.0/auth/whoami as soon as the engine is up, hitting the User-row enrichment added to whoamiHandler in 7.27 ([commit](https://github.com/PelicanPlatform/pelican/commit/846d0c81f1f6fc54eca01a865de00a5b0c7d0adf)).

Move the cache's database initialization into `LaunchModules`, before the engine starts, and after the transfer module's, preserving the existing last-init-wins ordering for multi-module (fed-in-a-box) processes). Also, drop the two now-redundant calls in `CacheServe`: `InitServerDatabase` opens and tracks a new handle on every call, so leaving them would double-open the DB.

Also guard whoamiHandler's enrichment lookup against a nil `ServerDatabase`, matching the existing convention in `userRecordIsActive` and `EffectiveScopesForIdentity`: the response degrades to no DisplayName/AUP verdict instead of panicking.

Closes #3709 