### PR TITLE
Don't prompt for a credential password when stdin is not a terminal

### DIFF
--- a/config/encrypted.go
+++ b/config/encrypted.go
@@ -220,7 +220,11 @@ func ConvertX25519Key(ed25519_sk []byte) [32]byte {
 }
 
 func GetPassword(newFile bool) ([]byte, error) {
-	if fileInfo, _ := os.Stdin.Stat(); (fileInfo.Mode() & os.ModeCharDevice) == 0 {
+	// Ask the terminal itself rather than inferring from the file mode.  /dev/null is a
+	// character device, so a ModeCharDevice test passes for any non-interactive run whose
+	// stdin is /dev/null -- systemd, cron, a container entrypoint, CI -- and we would go
+	// on to print a password prompt nobody can answer and fail the read afterwards.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return nil, errors.New("Cannot read password; not connected to a terminal")
 	}
 	if newFile {

--- a/config/encrypted_test.go
+++ b/config/encrypted_test.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -172,4 +173,30 @@ func TestDecryptString(t *testing.T) {
 		assert.Equal(t, firstKeyID, keyIdUsedInEncryption)
 		assert.Equal(t, secret, decrypted)
 	})
+}
+
+// TestGetPasswordRejectsNonTerminalStdin guards the regression that made every
+// non-interactive run print a password prompt nobody could answer: /dev/null is a
+// character device, so testing os.Stdin's file mode for ModeCharDevice reported it as a
+// terminal.  Ask the terminal itself instead.
+func TestGetPasswordRejectsNonTerminalStdin(t *testing.T) {
+	devNull, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = devNull.Close() })
+
+	stderrRead, stderrWrite, err := os.Pipe()
+	require.NoError(t, err)
+
+	oldStdin, oldStderr := os.Stdin, os.Stderr
+	os.Stdin, os.Stderr = devNull, stderrWrite
+	_, passErr := GetPassword(true)
+	os.Stdin, os.Stderr = oldStdin, oldStderr
+	require.NoError(t, stderrWrite.Close())
+
+	prompt, err := io.ReadAll(stderrRead)
+	require.NoError(t, err)
+
+	require.Error(t, passErr)
+	assert.Contains(t, passErr.Error(), "not connected to a terminal")
+	assert.Empty(t, string(prompt), "must not prompt for a password when stdin is not a terminal")
 }

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -288,6 +288,8 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Issuer_AuthenticationSource.GetName(), "OIDC")
 	// Issuer.AuthorizationCodeLifetime
 	v.SetDefault(param.Issuer_AuthorizationCodeLifetime.GetName(), "10m")
+	// Issuer.DeviceCodePollingInterval
+	v.SetDefault(param.Issuer_DeviceCodePollingInterval.GetName(), "5s")
 	// Issuer.DynamicClientStaleTimeout
 	v.SetDefault(param.Issuer_DynamicClientStaleTimeout.GetName(), "336h")
 	// Issuer.DynamicClientUnusedTimeout

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4684,6 +4684,23 @@ components: ["origin", "registry"]
 ################################
 #   Issuer's Configurations    #
 ################################
+name: Issuer.DeviceCodePollingInterval
+description: |+
+  How often a client may poll the token endpoint while waiting for a user to approve an
+  OAuth2 device-code request.
+
+  This value is both advertised to the client in the `interval` field of the device
+  authorization response and enforced server-side: polling more often than this is answered
+  with `slow_down`.  RFC 8628 specifies 5 seconds, which is the default; it is exposed only
+  so tests can drive the flow faster than a human would.
+
+  Because the `interval` field is expressed in whole seconds, values below one second are
+  advertised as one second, though the server-side rate limit still uses the exact value.
+type: duration
+default: 5s
+hidden: true
+components: ["origin", "registry"]
+---
 name: Issuer.DynamicClientStaleTimeout
 description: |+
   Maximum duration of inactivity before a dynamically registered client

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -189,6 +189,11 @@ func NewFedTest(t testing.TB, originConfig string, originSetup ...func(storageDi
 	// In tests, skip the drain-wait period before XRootD restarts
 	// so tests don't time out waiting for PIDs to change.
 	require.NoError(t, param.Xrootd_ShutdownTimeout.Set(0))
+	// RFC 8628's 5s device-code polling interval is paced for a human reading a code off
+	// a screen; a test approves instantly, so the client would spend most of the flow
+	// asleep.  One second is the floor the protocol can express (the "interval" field is
+	// whole seconds).
+	require.NoError(t, param.Issuer_DeviceCodePollingInterval.Set(time.Second))
 	require.NoError(t, param.Server_EnableUI.Set(false))
 	require.NoError(t, param.Server_WebPort.Set(0))
 	require.NoError(t, param.Server_DbLocation.Set(filepath.Join(t.TempDir(), "server.sqlite")))

--- a/oauth2/issuer/device_code.go
+++ b/oauth2/issuer/device_code.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/ory/fosite"
+
+	"github.com/pelicanplatform/pelican/param"
 )
 
 // DeviceCodeHandler implements the OAuth 2.0 Device Authorization Grant (RFC 8628).
@@ -51,6 +53,27 @@ type DeviceAuthorizationResponse struct {
 	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
 	ExpiresIn               int    `json:"expires_in"`
 	Interval                int    `json:"interval,omitempty"`
+}
+
+// pollingInterval is the minimum spacing the issuer requires between device-code polls.
+// It is advertised to clients and enforced server-side; see Issuer.DeviceCodePollingInterval.
+func pollingInterval() time.Duration {
+	if interval := param.Issuer_DeviceCodePollingInterval.GetDuration(); interval > 0 {
+		return interval
+	}
+	return 5 * time.Second
+}
+
+// advertisedPollingIntervalSeconds renders the polling interval for the device authorization
+// response, whose "interval" field is whole seconds.  Sub-second intervals round up to one so
+// the field never reads as 0, which clients treat as "unset" and replace with their own
+// default; the server-side rate limit still honors the exact configured value.
+func advertisedPollingIntervalSeconds() int {
+	seconds := int(pollingInterval() / time.Second)
+	if seconds < 1 {
+		return 1
+	}
+	return seconds
 }
 
 // HandleDeviceAuthorizationRequest creates a new device code session.
@@ -92,7 +115,7 @@ func (h *DeviceCodeHandler) HandleDeviceAuthorizationRequest(ctx context.Context
 		VerificationURI:         verificationURI,
 		VerificationURIComplete: fmt.Sprintf("%s?user_code=%s", verificationURI, userCode),
 		ExpiresIn:               int(expiresIn.Seconds()),
-		Interval:                5,
+		Interval:                advertisedPollingIntervalSeconds(),
 	}, nil
 }
 

--- a/oauth2/issuer/storage.go
+++ b/oauth2/issuer/storage.go
@@ -721,14 +721,13 @@ func (s *OIDCStorage) GetDeviceCodeSession(ctx context.Context, deviceCode strin
 		return nil, ErrExpiredToken
 	}
 
-	// RFC 8628 §3.5: enforce minimum polling interval (5 seconds).
-	// A single conditional UPDATE atomically checks and advances
-	// last_polled_at, eliminating the TOCTOU race of a separate
+	// RFC 8628 §3.5: enforce the minimum polling interval (5 seconds by default; see
+	// Issuer.DeviceCodePollingInterval).  A single conditional UPDATE atomically checks
+	// and advances last_polled_at, eliminating the TOCTOU race of a separate
 	// SELECT-then-UPDATE.  If RowsAffected == 0 the previous poll
 	// was too recent → slow_down.
-	const pollingInterval = 5 * time.Second
 	now := time.Now()
-	cutoff := now.Add(-pollingInterval)
+	cutoff := now.Add(-pollingInterval())
 	pollResult := s.db.WithContext(ctx).Model(&OIDCDeviceCode{}).
 		Where("device_code = ? AND namespace = ? AND (last_polled_at IS NULL OR last_polled_at <= ?)", deviceCode, s.Namespace, cutoff).
 		Update("last_polled_at", now)

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -226,6 +226,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Issuer.AuthenticationSource": false,
 	"Issuer.AuthorizationCodeLifetime": false,
 	"Issuer.AuthorizationTemplates": false,
+	"Issuer.DeviceCodePollingInterval": false,
 	"Issuer.DynamicClientStaleTimeout": false,
 	"Issuer.DynamicClientUnusedTimeout": false,
 	"Issuer.GroupFile": false,
@@ -1244,6 +1245,7 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Federation.TopologyReloadInterval": func(c *Config) time.Duration { return c.Federation.TopologyReloadInterval },
 	"Issuer.AccessTokenLifetime": func(c *Config) time.Duration { return c.Issuer.AccessTokenLifetime },
 	"Issuer.AuthorizationCodeLifetime": func(c *Config) time.Duration { return c.Issuer.AuthorizationCodeLifetime },
+	"Issuer.DeviceCodePollingInterval": func(c *Config) time.Duration { return c.Issuer.DeviceCodePollingInterval },
 	"Issuer.DynamicClientStaleTimeout": func(c *Config) time.Duration { return c.Issuer.DynamicClientStaleTimeout },
 	"Issuer.DynamicClientUnusedTimeout": func(c *Config) time.Duration { return c.Issuer.DynamicClientUnusedTimeout },
 	"Issuer.IDTokenLifetime": func(c *Config) time.Duration { return c.Issuer.IDTokenLifetime },
@@ -1534,6 +1536,7 @@ var allParameterNames = []string{
 	"Issuer.AuthenticationSource",
 	"Issuer.AuthorizationCodeLifetime",
 	"Issuer.AuthorizationTemplates",
+	"Issuer.DeviceCodePollingInterval",
 	"Issuer.DynamicClientStaleTimeout",
 	"Issuer.DynamicClientUnusedTimeout",
 	"Issuer.GroupFile",
@@ -2376,6 +2379,7 @@ var (
 	Federation_TopologyReloadInterval = DurationParam{"Federation.TopologyReloadInterval"}
 	Issuer_AccessTokenLifetime = DurationParam{"Issuer.AccessTokenLifetime"}
 	Issuer_AuthorizationCodeLifetime = DurationParam{"Issuer.AuthorizationCodeLifetime"}
+	Issuer_DeviceCodePollingInterval = DurationParam{"Issuer.DeviceCodePollingInterval"}
 	Issuer_DynamicClientStaleTimeout = DurationParam{"Issuer.DynamicClientStaleTimeout"}
 	Issuer_DynamicClientUnusedTimeout = DurationParam{"Issuer.DynamicClientUnusedTimeout"}
 	Issuer_IDTokenLifetime = DurationParam{"Issuer.IDTokenLifetime"}
@@ -2914,6 +2918,7 @@ func init() {
 		"Federation.TopologyReloadInterval": Federation_TopologyReloadInterval,
 		"Issuer.AccessTokenLifetime": Issuer_AccessTokenLifetime,
 		"Issuer.AuthorizationCodeLifetime": Issuer_AuthorizationCodeLifetime,
+		"Issuer.DeviceCodePollingInterval": Issuer_DeviceCodePollingInterval,
 		"Issuer.DynamicClientStaleTimeout": Issuer_DynamicClientStaleTimeout,
 		"Issuer.DynamicClientUnusedTimeout": Issuer_DynamicClientUnusedTimeout,
 		"Issuer.IDTokenLifetime": Issuer_IDTokenLifetime,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -168,6 +168,7 @@ type Config struct {
 		AuthenticationSource string `mapstructure:"authenticationsource" yaml:"AuthenticationSource"`
 		AuthorizationCodeLifetime time.Duration `mapstructure:"authorizationcodelifetime" yaml:"AuthorizationCodeLifetime"`
 		AuthorizationTemplates any `mapstructure:"authorizationtemplates" yaml:"AuthorizationTemplates"`
+		DeviceCodePollingInterval time.Duration `mapstructure:"devicecodepollinginterval" yaml:"DeviceCodePollingInterval"`
 		DynamicClientStaleTimeout time.Duration `mapstructure:"dynamicclientstaletimeout" yaml:"DynamicClientStaleTimeout"`
 		DynamicClientUnusedTimeout time.Duration `mapstructure:"dynamicclientunusedtimeout" yaml:"DynamicClientUnusedTimeout"`
 		GroupFile string `mapstructure:"groupfile" yaml:"GroupFile"`
@@ -757,6 +758,7 @@ type configWithType struct {
 		AuthenticationSource struct { Type string; Value string }
 		AuthorizationCodeLifetime struct { Type string; Value time.Duration }
 		AuthorizationTemplates struct { Type string; Value any }
+		DeviceCodePollingInterval struct { Type string; Value time.Duration }
 		DynamicClientStaleTimeout struct { Type string; Value time.Duration }
 		DynamicClientUnusedTimeout struct { Type string; Value time.Duration }
 		GroupFile struct { Type string; Value string }


### PR DESCRIPTION
## The bug

`config.GetPassword` decided whether it had a terminal by testing `os.Stdin`'s file mode:

```go
if fileInfo, _ := os.Stdin.Stat(); (fileInfo.Mode() & os.ModeCharDevice) == 0 {
    return nil, errors.New("Cannot read password; not connected to a terminal")
}
```

**`/dev/null` is a character device.** Every non-interactive run whose stdin is `/dev/null` — systemd, cron, a container entrypoint, CI — sails past that check.
Pelican then prints

```
Please create a new password to protect your local credentials:
```

to stderr and attempts a raw-terminal read that can only fail, leaving the operator with a prompt they cannot answer and credentials that were silently never saved.
`PELICAN_SKIP_TERMINAL_CHECK` does not help: it guards only the device-URL display in `oauth2/oauth2.go`, and it tests stdout.

The fix is to ask the terminal rather than infer from the file mode — `term.IsTerminal`, from a package `config/encrypted.go` already imports for the read itself.

`TestGetPasswordRejectsNonTerminalStdin` pins it: it points `os.Stdin` at `/dev/null`, captures stderr, and requires both the error *and* that nothing was printed. It fails against the old check on the "must not prompt" assertion.

## How it surfaced

While profiling `TestClientAcquireTokenE2E`, which at ~195s is the most expensive single test in CI.
Capturing the CLI subprocess's stderr showed that prompt **ten times** in one run, and explained why the test performs the device-code flow *twice* with identical scopes: the dynamically-registered OAuth client and the acquired token are never persisted, so the second acquisition starts over with a fresh client registration.

That part is environmental — a real user with a terminal saves credentials and does the flow once — but the prompt-that-cannot-be-answered is not.

## Device-code polling interval

The same profiling showed the test spending most of the flow asleep. RFC 8628's 5-second polling interval is paced for a human reading a code off a screen; a test approves instantly, and the client polls repeatedly while the request is pending, so the interval multiplies.

The interval was hardcoded in two places that have to agree — advertised to the client in `device_code.go`, enforced server-side in `storage.go`. Both now read the hidden `Issuer.DeviceCodePollingInterval`, still defaulting to 5s, and the federation test harness sets it to one second: the floor the protocol can express, since the `interval` field is whole seconds. Sub-second values are advertised as 1s while the server-side rate limit honors the exact value.

`TestClientAcquireTokenE2E` goes from ~18s to ~4.5s locally (steady state; the first run in a package also pays for the CLI build).

## Testing

- `TestGetPasswordRejectsNonTerminalStdin` — new, and verified to fail against the old check.
- `config`, `oauth2`, `oauth2/issuer` unit suites pass.
- The device-code e2e family (`DeviceCode|AcquireToken|LocalIssuer|CollectionAcl`) passes.
- Builds clean under `client,server` and `GOOS=windows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
