### PR TITLE
Fix the crash loop for embedded issuer with all-public namespaces

### DIFF
--- a/e2e_fed_tests/origin_all_public_issuer_e2e_test.go
+++ b/e2e_fed_tests/origin_all_public_issuer_e2e_test.go
@@ -1,4 +1,4 @@
-//go:build server && !windows
+//go:build !windows
 
 /***************************************************************
  *
@@ -22,7 +22,6 @@ package fed_tests
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 
@@ -52,28 +51,11 @@ Origin:
 // TestAllPublicOriginStartsWithEmbeddedIssuer verifies that an origin with the
 // embedded issuer enabled but only public-read exports starts cleanly
 // (issue #3719).
-//
-// The embedded issuer creates a provider per auth-requiring export, so an
-// all-public origin registers none and serves no issuer discovery endpoint.
-// The launcher's issuer startup health check used to fall back to the
-// namespace-less OA4MP discovery path in that case, which the embedded issuer
-// never serves; the probe 404'd until Server.StartupTimeout and the whole
-// launch failed, crash-looping the origin. The launcher now skips the issuer
-// health check when no export requires authentication.
-//
-// Note: on main the same configuration instead health-checks the server's
-// local issuer, which is registered whenever the embedded issuer is enabled
-// (commit 4ac260c2e). That feature is not on v7.27.x, so this test also pins
-// that no issuer provider exists on an all-public origin — if the local
-// issuer is ever backported, the second assertion flips and the launcher
-// skip should be replaced with the health check from 4ac260c2e.
 func TestAllPublicOriginStartsWithEmbeddedIssuer(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()
 	t.Cleanup(func() { server_utils.ResetTestState() })
 
-	// Without the launcher fix the fed never finishes starting: the issuer
-	// health check probes a URL nothing serves and LaunchModules errors out.
 	originConfig := fmt.Sprintf(allPublicEmbeddedIssuerConfig, t.TempDir())
 	ft := fed_test_utils.NewFedTest(t, originConfig)
 	require.NotNil(t, ft, "an all-public embedded-issuer origin must start cleanly")
@@ -81,19 +63,8 @@ func TestAllPublicOriginStartsWithEmbeddedIssuer(t *testing.T) {
 	serverURL := param.Server_ExternalWebUrl.GetString()
 	httpClient := &http.Client{Transport: config.GetTransport()}
 
-	// The server is up and healthy — the same endpoint the launcher gates on.
 	resp, err := httpClient.Get(serverURL + "/api/v1.0/health")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode, "the origin's health endpoint must respond after startup")
-
-	// No issuer provider is registered for the public export: its discovery
-	// document is not served. This is why the launcher must skip the issuer
-	// health check rather than probe anything.
-	discResp, err := httpClient.Get(serverURL + "/api/v1.0/issuer/ns/public-data/.well-known/openid-configuration")
-	require.NoError(t, err)
-	defer discResp.Body.Close()
-	body, _ := io.ReadAll(discResp.Body)
-	require.Equal(t, http.StatusNotFound, discResp.StatusCode,
-		"an all-public origin must register no issuer provider (body: %s)", string(body))
 }

--- a/e2e_fed_tests/origin_all_public_issuer_e2e_test.go
+++ b/e2e_fed_tests/origin_all_public_issuer_e2e_test.go
@@ -1,0 +1,99 @@
+//go:build server && !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package fed_tests
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// allPublicEmbeddedIssuerConfig is an origin with the embedded issuer enabled
+// but ONLY a public-read export: no export requires authentication, so the
+// embedded issuer registers no OIDC providers.
+const allPublicEmbeddedIssuerConfig = `
+Origin:
+  StorageType: posixv2
+  EnableIssuer: true
+  IssuerMode: embedded
+  Exports:
+    - FederationPrefix: /public-data
+      StoragePrefix: %s
+      Capabilities: ["PublicReads"]
+`
+
+// TestAllPublicOriginStartsWithEmbeddedIssuer verifies that an origin with the
+// embedded issuer enabled but only public-read exports starts cleanly
+// (issue #3719).
+//
+// The embedded issuer creates a provider per auth-requiring export, so an
+// all-public origin registers none and serves no issuer discovery endpoint.
+// The launcher's issuer startup health check used to fall back to the
+// namespace-less OA4MP discovery path in that case, which the embedded issuer
+// never serves; the probe 404'd until Server.StartupTimeout and the whole
+// launch failed, crash-looping the origin. The launcher now skips the issuer
+// health check when no export requires authentication.
+//
+// Note: on main the same configuration instead health-checks the server's
+// local issuer, which is registered whenever the embedded issuer is enabled
+// (commit 4ac260c2e). That feature is not on v7.27.x, so this test also pins
+// that no issuer provider exists on an all-public origin — if the local
+// issuer is ever backported, the second assertion flips and the launcher
+// skip should be replaced with the health check from 4ac260c2e.
+func TestAllPublicOriginStartsWithEmbeddedIssuer(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(func() { server_utils.ResetTestState() })
+
+	// Without the launcher fix the fed never finishes starting: the issuer
+	// health check probes a URL nothing serves and LaunchModules errors out.
+	originConfig := fmt.Sprintf(allPublicEmbeddedIssuerConfig, t.TempDir())
+	ft := fed_test_utils.NewFedTest(t, originConfig)
+	require.NotNil(t, ft, "an all-public embedded-issuer origin must start cleanly")
+
+	serverURL := param.Server_ExternalWebUrl.GetString()
+	httpClient := &http.Client{Transport: config.GetTransport()}
+
+	// The server is up and healthy — the same endpoint the launcher gates on.
+	resp, err := httpClient.Get(serverURL + "/api/v1.0/health")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "the origin's health endpoint must respond after startup")
+
+	// No issuer provider is registered for the public export: its discovery
+	// document is not served. This is why the launcher must skip the issuer
+	// health check rather than probe anything.
+	discResp, err := httpClient.Get(serverURL + "/api/v1.0/issuer/ns/public-data/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer discResp.Body.Close()
+	body, _ := io.ReadAll(discResp.Body)
+	require.Equal(t, http.StatusNotFound, discResp.StatusCode,
+		"an all-public origin must register no issuer provider (body: %s)", string(body))
+}

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -258,6 +258,7 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 	if param.Origin_EnableIssuer.GetBool() {
 		issuerMode := param.Origin_IssuerMode.GetString()
 		var issuerHealthCheckUrl string
+		skipIssuerHealthCheck := false
 		if issuerMode == "embedded" || issuerMode == "" {
 			// For the embedded issuer, use the first auth-requiring export's namespace.
 			originExports, exErr := server_utils.GetOriginExports()
@@ -269,15 +270,26 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 						break
 					}
 				}
+				// No export requires authentication, so the embedded issuer
+				// registered no providers and serves no discovery endpoint;
+				// the namespace-less fallback below is only served in OA4MP
+				// mode. Probing either would fail startup (issue #3719), so
+				// skip the check.
+				if issuerHealthCheckUrl == "" {
+					skipIssuerHealthCheck = true
+					log.Info("All origin exports are public; skipping the embedded issuer startup health check as no issuer provider is registered")
+				}
 			}
 		}
-		if issuerHealthCheckUrl == "" {
-			// Fallback for OA4MP mode or if no auth-requiring export found
-			issuerHealthCheckUrl = param.Server_ExternalWebUrl.GetString() + "/api/v1.0/issuer/.well-known/openid-configuration"
-		}
-		if err = server_utils.WaitUntilWorking(ctx, "GET", issuerHealthCheckUrl, "Issuer", http.StatusOK, true); err != nil {
-			log.Errorln("Failed to startup issuer component: ", err)
-			return
+		if !skipIssuerHealthCheck {
+			if issuerHealthCheckUrl == "" {
+				// Fallback for OA4MP mode or if the export lookup failed
+				issuerHealthCheckUrl = param.Server_ExternalWebUrl.GetString() + "/api/v1.0/issuer/.well-known/openid-configuration"
+			}
+			if err = server_utils.WaitUntilWorking(ctx, "GET", issuerHealthCheckUrl, "Issuer", http.StatusOK, true); err != nil {
+				log.Errorln("Failed to startup issuer component: ", err)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Skip issuer health check on an all-public embedded-issuer origin

This PR only needs to merge into v7.27.x, see the reason below.

An origin with the embedded issuer enabled but only public-read exports crash-looped at startup on v7.27.0 (issue #3719). The issuer startup health check probes the first auth-requiring export's namespace discovery document; when no export requires authentication it fell back to the namespace-less OA4MP path
(/api/v1.0/issuer/.well-known/openid-configuration), which the embedded issuer never serves. WaitUntilWorking then 404'd until Server.StartupTimeout and LaunchModules returned an error.

Main fixes this by health-checking the server's local issuer (4ac260c2e), but that relies on the local issuer being registered whenever the embedded issuer is enabled, which is not on v7.27.x. As a stopgap for the release branch, skip the issuer health check entirely when the embedded issuer is in use and no export requires authentication: there is no registered provider to probe. OA4MP mode and the export-lookup-failure path keep the existing fallback.

Adds TestAllPublicOriginStartsWithEmbeddedIssuer, which brings up an all-public embedded-issuer origin through the real launcher and asserts it starts and serves no issuer provider. Verified the test fails without the fix (reproducing the startup timeout from the issue) and passes with it.

Closes #3719