### PR TITLE
Speed up director namespace matching

### DIFF
--- a/director/sort.go
+++ b/director/sort.go
@@ -137,14 +137,6 @@ func sortServerAds(ctx context.Context, ginCtx *gin.Context, clientAddr netip.Ad
 	return truncateAds(sortedAds, sourceServerAdsLimit), nil
 }
 
-// getLongestNSMatch picks the namespace ad whose path is the longest logical
-// prefix of the request path.  The implementation lives in server_structs so
-// that servers answering clients the way the director does (e.g. a standalone
-// origin) resolve namespaces identically.
-func getLongestNSMatch(reqPath string, namespaceAds []server_structs.NamespaceAd) *server_structs.NamespaceAd {
-	return server_structs.LongestNSMatch(reqPath, namespaceAds)
-}
-
 // Given a request path, find all the ads that express willingness to work with
 // a prefix that best matches (i.e. is the longest prefix of) the path. We return
 // a copy ad at this point instead of a pointer to the ad in the TTL cache because
@@ -160,55 +152,58 @@ func getAdsForPath(reqPath string) (oAds []copyAd, cAds []copyAd) {
 	// Move topo sorted ads to the end of our slice
 	sortServerAdsByTopo(ads)
 
-	var bestFedPrefix string
+	// Length of the longest matched namespace prefix seen so far, with -1
+	// meaning "nothing matched yet" -- a root export matches with length 0, so
+	// 0 cannot serve as that sentinel.
+	bestNSLen := -1
 	for _, ad := range ads {
 		// Skip over any ads that are filtered out or marked in downtime
 		if filtered, fType := checkFilter(ad.Name); filtered {
-			log.Tracef("Skipping '%s' server '%s' as it's in the filtered server list with type %s", ad.Type, ad.Name, fType)
+			// Guard the Tracef explicitly: the level gate rejects the entry,
+			// but the variadic argument boxing would still heap-allocate on
+			// this per-ad hot path without the guard.
+			if log.IsLevelEnabled(log.TraceLevel) {
+				log.Tracef("Skipping '%s' server '%s' as it's in the filtered server list with type %s", ad.Type, ad.Name, fType)
+			}
 			continue
 		}
 
-		var nsAd *server_structs.NamespaceAd
-		if nsAd = getLongestNSMatch(reqPath, ad.NamespaceAds); nsAd == nil {
+		nsIdx := server_structs.LongestNSMatchIndex(reqPath, ad.NamespaceAds)
+		if nsIdx < 0 {
 			// This server doesn't support the requested namespace, skip it
 			continue
 		}
 
-		// Normalize the namespace path for comparison
-		nsPath := nsAd.Path
-		if !strings.HasSuffix(nsPath, "/") {
-			nsPath += "/"
-		}
+		// Take the copy once, here: ad.NamespaceAds is live TTL-cache memory
+		// read concurrently by other goroutines, so nothing below may hold a
+		// pointer into it or write through one. We also want returned
+		// namespace paths to forgo any trailing / that might come from
+		// topology, which is a mutation the cached ad must not see.
+		nsCopy := ad.NamespaceAds[nsIdx]
+		nsCopy.Path = strings.TrimSuffix(nsCopy.Path, "/")
 
-		// If we haven't yet encountered a best prefix, set the current one as best
-		if bestFedPrefix == "" {
-			bestFedPrefix = nsPath
-		}
+		// Rank ads by how specific their matched prefix is. Two equal-length
+		// prefixes of the same request path are the same string, so the
+		// already-trimmed path's length orders ads by specificity without
+		// comparing paths.
+		nsLen := len(nsCopy.Path)
 
 		// if the current ad's path matches but is shorter than the best path, skip
-		if len(nsPath) < len(bestFedPrefix) {
+		if nsLen < bestNSLen {
 			continue
 		}
 
 		// If the current nsAd's path has the same best prefix as the longest known,
 		// append the ad
-		if len(nsPath) == len(bestFedPrefix) {
+		if nsLen == bestNSLen {
 			if ad.Type == server_structs.OriginType.String() {
 				// Replace topology origins with Pelican origins if needed
 				if len(oAds) == 0 || (oAds[len(oAds)-1].ServerAd.FromTopology && !ad.ServerAd.FromTopology) {
-					nsCopy := *nsAd
-					// We want returned namespace paths to forgo any trailing / that might come from
-					// topology. To trim the prefix without modifying the original ad, we copy it
-					nsCopy.Path = strings.TrimSuffix(nsCopy.Path, "/")
 					oAds = []copyAd{{ServerAd: ad.ServerAd, NamespaceAd: nsCopy}}
 				} else if !ad.ServerAd.FromTopology || oAds[len(oAds)-1].ServerAd.FromTopology == ad.ServerAd.FromTopology {
-					nsCopy := *nsAd
-					nsCopy.Path = strings.TrimSuffix(nsCopy.Path, "/")
 					oAds = append(oAds, copyAd{ServerAd: ad.ServerAd, NamespaceAd: nsCopy})
 				}
 			} else if ad.Type == server_structs.CacheType.String() {
-				nsCopy := *nsAd
-				nsCopy.Path = strings.TrimSuffix(nsCopy.Path, "/")
 				cAds = append(cAds, copyAd{ServerAd: ad.ServerAd, NamespaceAd: nsCopy})
 			}
 			continue
@@ -216,9 +211,7 @@ func getAdsForPath(reqPath string) (oAds []copyAd, cAds []copyAd) {
 
 		// Otherwise we've found a better match. Overwrite slices we're tracking and
 		// set the new best prefix
-		bestFedPrefix = nsPath
-		nsCopy := *nsAd
-		nsCopy.Path = strings.TrimSuffix(nsCopy.Path, "/")
+		bestNSLen = nsLen
 		if ad.Type == server_structs.OriginType.String() {
 			oAds = []copyAd{{ServerAd: ad.ServerAd, NamespaceAd: nsCopy}}
 			cAds = []copyAd{}

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -23,6 +23,8 @@ import (
 	_ "embed"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -300,6 +302,63 @@ func TestGetAdsForPath(t *testing.T) {
 			}
 		})
 	}
+
+	// getAdsForPath trims the trailing "/" that topology puts on a namespace
+	// path, and it selects the winning namespace ad by index into the
+	// Advertisement held in the TTL cache -- memory other request goroutines
+	// are reading at the same time.  The trim must therefore land on a copy,
+	// never on the cached ad.  /chtc/PUBLIC2/ is the one export stored with a
+	// trailing slash, so it is the case that would catch a write-through.
+	t.Run("does not mutate the cached namespace ad", func(t *testing.T) {
+		cachedPath := func() string {
+			for _, ad := range getServerAdsSnapshot() {
+				for _, nsAd := range ad.NamespaceAds {
+					if strings.TrimSuffix(nsAd.Path, "/") == "/chtc/PUBLIC2" {
+						return nsAd.Path
+					}
+				}
+			}
+			return ""
+		}
+
+		require.Equal(t, "/chtc/PUBLIC2/", cachedPath(),
+			"test fixture no longer stores a trailing-slash export; this test cannot catch a write-through")
+
+		oAds, _ := getAdsForPath("/chtc/PUBLIC2/some/object")
+		require.NotEmpty(t, oAds)
+		assert.Equal(t, "/chtc/PUBLIC2", oAds[0].NamespaceAd.Path,
+			"the returned copy should have the trailing slash trimmed")
+		assert.Equal(t, "/chtc/PUBLIC2/", cachedPath(),
+			"getAdsForPath wrote the trimmed path back into the TTL cache")
+
+		// Mutating what we were handed must also not reach the cache: callers
+		// treat these as detached copies.
+		oAds[0].NamespaceAd.Path = "/mutated-by-caller"
+		oAds[0].NamespaceAd.Caps.PublicReads = !oAds[0].NamespaceAd.Caps.PublicReads
+		assert.Equal(t, "/chtc/PUBLIC2/", cachedPath())
+	})
+
+	// Concurrent readers plus the trim above is precisely the shape the race
+	// detector is for; run the same call from several goroutines so a future
+	// refactor that writes through the returned alias fails under -race
+	// instead of corrupting a live federation's ads.
+	t.Run("is safe to call concurrently", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 50; j++ {
+					if oAds, _ := getAdsForPath("/chtc/PUBLIC2/some/object"); len(oAds) > 0 {
+						oAds[0].NamespaceAd.Path = "/mutated-by-caller"
+					}
+					getAdsForPath("/chtc/PUBLIC")
+					getAdsForPath("/does/not/exist")
+				}
+			}()
+		}
+		wg.Wait()
+	})
 }
 
 func TestAllPredicatesPass(t *testing.T) {

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -598,40 +598,78 @@ func SetXNamespaceHeaderWithCollections(hdr http.Header, collUrl string, bestNSA
 	setXNamespaceHeader(hdr, collUrl, bestNSAd)
 }
 
-// LongestNSMatch returns the namespace ad whose path is the longest logical prefix of reqPath.
-// For example, for path `/foo/bar/baz` and namespace ads `/foo` & `/foo/bar`, it returns the
-// ad for `/foo/bar`.  Returns nil if no ad matches.
-func LongestNSMatch(reqPath string, namespaceAds []NamespaceAd) *NamespaceAd {
+// nsPathCoversReq reports whether the namespace path nsBase covers the request
+// path reqPath, comparing at "/" segment boundaries rather than as raw byte
+// prefixes: /foo covers /foo and /foo/bar, but not /foobar.
+//
+// reqPath must carry a trailing "/" and nsBase must not; LongestNSMatchIndex
+// normalizes each of them once, so that scanning a whole federation's worth of
+// candidate ads adds no allocations of its own.
+func nsPathCoversReq(reqPath, nsBase string) bool {
+	// The "/" at the boundary is what separates a child path from a sibling
+	// whose name merely starts the same.  The length test keeps that index in
+	// range, and rejects most non-matches before the string comparison.
+	return len(reqPath) > len(nsBase) &&
+		reqPath[len(nsBase)] == '/' &&
+		strings.HasPrefix(reqPath, nsBase)
+}
+
+// LongestNSMatchIndex returns the index into namespaceAds of the ad whose path
+// is the longest logical prefix of reqPath, or -1 if no ad matches.  Ties go to
+// the earliest ad in the slice, matching LongestNSMatch's long-standing
+// behavior.
+//
+// The number of allocations does not grow with len(namespaceAds): the trailing
+// "/" each path is compared with is accounted for by index arithmetic instead
+// of being concatenated onto every candidate.  That matters because the
+// director calls this once per advertised server on every redirect, so the
+// per-candidate allocation the previous implementation made scaled with the
+// size of the federation.
+func LongestNSMatchIndex(reqPath string, namespaceAds []NamespaceAd) int {
 	// Normalize incoming path if needed --> adding the trailing / makes
-	// basic prefix matching safer
+	// basic prefix matching safer.  The director's getAdsForPath has already
+	// done this before its per-server loop, so the concatenation here does not
+	// land on the hot path.
 	if !strings.HasSuffix(reqPath, "/") {
 		reqPath += "/"
 	}
 
-	var bestFedPrefix string
-	var bestNamespace *NamespaceAd
-	for _, ns := range namespaceAds {
-		// Create a copy of ns to avoid reusing the loop variable
-		currentNS := ns
-
-		// Additionally normalize stored namespace paths
-		nsPath := currentNS.Path
-		if !strings.HasSuffix(currentNS.Path, "/") {
-			nsPath += "/"
-		}
-
-		if !strings.HasPrefix(reqPath, nsPath) {
-			// This namespace doesn't match the request path, skip it
+	best := -1
+	bestLen := -1
+	for i := range namespaceAds {
+		// TrimSuffix returns a substring, so this costs nothing.
+		nsBase := strings.TrimSuffix(namespaceAds[i].Path, "/")
+		// Skip candidates that cannot beat the incumbent before comparing any
+		// bytes.  Two equal-length prefixes of one reqPath are necessarily the
+		// same string, so `<=` is what keeps the first ad of a tie.
+		if len(nsBase) <= bestLen {
 			continue
 		}
-
-		if bestFedPrefix == "" || len(nsPath) > len(bestFedPrefix) {
-			bestFedPrefix = nsPath
-			bestNamespace = &currentNS
+		if !nsPathCoversReq(reqPath, nsBase) {
+			continue
 		}
+		best, bestLen = i, len(nsBase)
 	}
+	return best
+}
 
-	return bestNamespace
+// LongestNSMatch returns the namespace ad whose path is the longest logical prefix of reqPath.
+// For example, for path `/foo/bar/baz` and namespace ads `/foo` & `/foo/bar`, it returns the
+// ad for `/foo/bar`.  Returns nil if no ad matches.
+//
+// The returned ad is a shallow copy: its top-level fields are detached from
+// the input, but the embedded Generation and Issuer slices still alias the
+// caller's slice -- on the director, live TTL-cache memory read concurrently
+// by other goroutines.  Do not mutate through those slices; copy them first.
+// Callers on a hot path that only need to read the winning ad should use
+// LongestNSMatchIndex, which makes no copy at all.
+func LongestNSMatch(reqPath string, namespaceAds []NamespaceAd) *NamespaceAd {
+	idx := LongestNSMatchIndex(reqPath, namespaceAds)
+	if idx < 0 {
+		return nil
+	}
+	bestNamespace := namespaceAds[idx]
+	return &bestNamespace
 }
 
 func NewRedirectInfoFromIP(ipAddr string) *RedirectInfo {

--- a/server_structs/director_test.go
+++ b/server_structs/director_test.go
@@ -21,6 +21,7 @@ package server_structs
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -204,6 +205,44 @@ func TestServerBaseAdAfter(t *testing.T) {
 	})
 }
 
+// LongestNSMatch's contract is that the returned ad is detached from the
+// input slice at the top level (a future refactor returning an interior
+// pointer must fail here), while the embedded Generation/Issuer slices are
+// documented to still alias the input -- on the director, live TTL-cache
+// memory that must not be mutated through the return.
+func TestLongestNSMatchReturnsDetachedCopy(t *testing.T) {
+	ads := []NamespaceAd{
+		{
+			Path:       "/foo",
+			Caps:       Capabilities{PublicReads: true},
+			Issuer:     []TokenIssuer{{BasePaths: []string{"/foo"}}},
+			Generation: []TokenGen{{MaxScopeDepth: 3}},
+		},
+	}
+
+	got := LongestNSMatch("/foo/bar", ads)
+	require.NotNil(t, got)
+	require.NotSame(t, &ads[0], got,
+		"LongestNSMatch must not return an interior pointer into the caller's slice")
+
+	// Top-level fields are detached: mutating the copy must not write
+	// through to the caller's (cached) ad.
+	got.Path = "/mutated"
+	got.Caps.PublicReads = false
+	assert.Equal(t, "/foo", ads[0].Path)
+	assert.True(t, ads[0].Caps.PublicReads)
+
+	// The embedded slices are shallow by documented contract: they alias the
+	// input, which is why callers must copy before mutating through them.
+	// This assertion pins the current behavior so a change to it (either
+	// direction) is a conscious one.
+	require.NotEmpty(t, got.Issuer)
+	assert.Same(t, &ads[0].Issuer[0], &got.Issuer[0],
+		"embedded Issuer slice is documented to alias the input")
+	assert.Same(t, &ads[0].Generation[0], &got.Generation[0],
+		"embedded Generation slice is documented to alias the input")
+}
+
 func TestLongestNSMatch(t *testing.T) {
 	nsAd := func(path string) NamespaceAd { return NamespaceAd{Path: path} }
 
@@ -293,6 +332,294 @@ func TestLongestNSMatch(t *testing.T) {
 			require.NotNil(t, got)
 			assert.Equal(t, tc.expected, got.Path)
 		})
+	}
+}
+
+// longestNSMatchIndexReference is the pre-optimization implementation, kept
+// verbatim as the oracle for TestLongestNSMatchIndexMatchesReference.  It
+// normalizes each candidate by concatenation and compares whole strings, which
+// is the behavior LongestNSMatchIndex's length early-out plus byte-boundary
+// check must reproduce exactly.
+func longestNSMatchIndexReference(reqPath string, namespaceAds []NamespaceAd) int {
+	if !strings.HasSuffix(reqPath, "/") {
+		reqPath += "/"
+	}
+	bestFedPrefix := ""
+	bestIdx := -1
+	for i, ns := range namespaceAds {
+		nsPath := ns.Path
+		if !strings.HasSuffix(nsPath, "/") {
+			nsPath += "/"
+		}
+		if !strings.HasPrefix(reqPath, nsPath) {
+			continue
+		}
+		if bestFedPrefix == "" || len(nsPath) > len(bestFedPrefix) {
+			bestFedPrefix = nsPath
+			bestIdx = i
+		}
+	}
+	return bestIdx
+}
+
+// nsMatchCorpus is the shared set of adversarial (reqPath, paths) pairs used by
+// the differential and allocation tests.  It leans on the cases where the
+// index-arithmetic form could plausibly diverge from string concatenation:
+// segment-boundary near-misses (/foo vs /foobar), both spellings of a stored
+// path, the root export, degenerate empty and relative paths, and duplicate
+// equal-length candidates that exercise tie-breaking.
+var nsMatchCorpus = []struct {
+	reqPath string
+	paths   []string
+}{
+	{"/foo/bar/baz", []string{"/foo", "/foo/bar"}},
+	{"/foo/bar/baz", []string{"/foo/bar", "/foo"}},
+	{"/foo/other/baz", []string{"/foo", "/foo/bar"}},
+	{"/foo/bar", []string{"/foo", "/foo/bar"}},
+	{"/foo/bar/", []string{"/foo", "/foo/bar"}},
+	{"/foo/bar/baz", []string{"/foo/bar/"}},
+	{"/foo/bar/baz", []string{"/foo/bar/", "/foo/bar"}},
+	{"/foo/bar/baz", []string{"/foo/bar", "/foo/bar/"}},
+	{"/foobar/baz", []string{"/foo"}},
+	{"/foobar/baz", []string{"/foo/", "/foobar"}},
+	{"/foo", []string{"/foo/bar"}},
+	{"/anything/at/all", []string{"/"}},
+	{"/foo/bar", []string{"/", "/foo"}},
+	{"/foo/bar", []string{"/foo", "/"}},
+	{"/nowhere/object", []string{"/foo", "/bar"}},
+	{"/foo/bar", nil},
+	// Duplicate candidates: the winner must be the earliest of the tied ads.
+	{"/foo/bar/baz", []string{"/foo/bar", "/foo/bar", "/foo"}},
+	{"/foo/bar/baz", []string{"/foo", "/foo/bar", "/foo/bar"}},
+	// Degenerate stored paths.  An empty path normalizes to "/" and so covers
+	// everything, exactly as the reference implementation had it -- pinned
+	// here so the optimized form cannot quietly change it.
+	{"/foo/bar", []string{""}},
+	{"/foo/bar", []string{"", "/foo"}},
+	{"/", []string{""}},
+	{"/", []string{"/"}},
+	{"/", []string{"/foo"}},
+	// Relative request paths never reach the director (getAdsForPath runs
+	// path.Clean first), but LongestNSMatch is exported, so pin the behavior.
+	{"foo/bar", []string{"/foo"}},
+	{"foo/bar", []string{"foo"}},
+	{"", []string{"/"}},
+	{"", []string{""}},
+	// Doubled separators: the reference implementation appended at most one
+	// "/", so "//" is a distinct prefix from "/" and must stay one.
+	{"/foo/bar", []string{"//"}},
+	{"//foo/bar", []string{"//"}},
+	{"//foo/bar", []string{"/", "//", "//foo"}},
+	// Deep paths, to exercise the length early-out on long strings.
+	{"/a/b/c/d/e/f/g/h", []string{"/a", "/a/b", "/a/b/c", "/a/b/c/d/e/f/g/h", "/a/b/c/d/e/f/g/h/i"}},
+}
+
+func nsAdsFor(paths []string) []NamespaceAd {
+	if paths == nil {
+		return nil
+	}
+	ads := make([]NamespaceAd, 0, len(paths))
+	for _, p := range paths {
+		ads = append(ads, NamespaceAd{Path: p})
+	}
+	return ads
+}
+
+// The optimized scan must agree with the concatenating implementation it
+// replaced on every input.  This is the safety net for the change: the
+// boundary check is index arithmetic now, and an off-by-one in it would
+// silently redirect a request to the wrong namespace's origins.
+func TestLongestNSMatchIndexMatchesReference(t *testing.T) {
+	for _, tc := range nsMatchCorpus {
+		t.Run(fmt.Sprintf("%q_in_%q", tc.reqPath, strings.Join(tc.paths, ",")), func(t *testing.T) {
+			ads := nsAdsFor(tc.paths)
+
+			wantIdx := longestNSMatchIndexReference(tc.reqPath, ads)
+			assert.Equal(t, wantIdx, LongestNSMatchIndex(tc.reqPath, ads),
+				"winning index diverged from the reference implementation")
+
+			// LongestNSMatch is a thin wrapper; keep the two in step.
+			got := LongestNSMatch(tc.reqPath, ads)
+			if wantIdx < 0 {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, ads[wantIdx].Path, got.Path)
+		})
+	}
+}
+
+// What the director needs from this function is that a deeper export always
+// wins over a shallower one covering the same request, whichever way each path
+// happens to be spelled -- topology publishes a trailing slash and Pelican
+// origins do not.
+func TestLongestNSMatchIndexPrefersDeeperExport(t *testing.T) {
+	const reqPath = "/foo/bar/baz/object"
+
+	for _, spelling := range [][]string{
+		{"/foo", "/foo/bar"},
+		{"/foo/", "/foo/bar/"},
+		{"/foo/", "/foo/bar"},
+		{"/foo", "/foo/bar/"},
+		// Order in the slice must not decide it.
+		{"/foo/bar", "/foo"},
+		{"/foo/bar/", "/foo/"},
+	} {
+		ads := nsAdsFor(spelling)
+		idx := LongestNSMatchIndex(reqPath, ads)
+		require.GreaterOrEqual(t, idx, 0, "spelling %v", spelling)
+		assert.Equal(t, "/foo/bar", strings.TrimSuffix(ads[idx].Path, "/"),
+			"the deeper export should win regardless of spelling or order: %v", spelling)
+	}
+}
+
+// The property worth guarding is not that the scan allocates nothing, but
+// that what it allocates does not grow with the number of candidate ads.  The
+// previous implementation normalized each candidate's path by concatenation,
+// so a federation advertising more namespaces cost the director more garbage
+// on every redirect; a fixed allocation for normalizing reqPath does not.
+func TestLongestNSMatchIndexAllocationsDoNotScaleWithAdCount(t *testing.T) {
+	perCall := func(ads []NamespaceAd, reqPath string) float64 {
+		return testing.AllocsPerRun(200, func() {
+			LongestNSMatchIndex(reqPath, ads)
+		})
+	}
+
+	small, large := benchNSAds(4), benchNSAds(400)
+	assert.Equal(t, perCall(small, benchReqPath), perCall(large, benchReqPath),
+		"allocations per call grew with the number of candidate ads")
+
+	// The director normalizes the request path once, before its per-server
+	// loop, so on the path that actually runs per redirect there is nothing
+	// left to allocate at all.
+	assert.Zero(t, perCall(large, benchReqPath+"/"),
+		"a pre-normalized request path should cost no allocations")
+}
+
+func TestNSPathCoversReq(t *testing.T) {
+	// Per the helper's precondition, reqPath carries a trailing "/" and nsBase
+	// does not -- LongestNSMatchIndex normalizes both before calling.
+	testCases := []struct {
+		reqPath string
+		nsBase  string
+		want    bool
+	}{
+		{"/foo/bar/", "/foo", true},
+		// The request path being exactly the export still matches.
+		{"/foo/", "/foo", true},
+		// A sibling whose name merely starts the same does not.
+		{"/foobar/", "/foo", false},
+		{"/foo/barbaz/", "/foo/bar", false},
+		// A deeper export does not cover a shallower request.
+		{"/foo/", "/foo/bar", false},
+		{"/foo/bar/baz/", "/foo/bar", true},
+		// The empty base is the trimmed form of both "" and "/", the root
+		// export, which covers every absolute path...
+		{"/anything/", "", true},
+		{"/", "", true},
+		// ...but shares no boundary with a relative one.
+		{"relative/", "", false},
+		{"relative/deeper/", "relative", true},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q_covers_%q", tc.nsBase, tc.reqPath), func(t *testing.T) {
+			assert.Equal(t, tc.want, nsPathCoversReq(tc.reqPath, tc.nsBase))
+		})
+	}
+}
+
+// benchNSAds builds an ad set shaped like a real federation's: a few dozen
+// exports, mostly two or three segments deep, with the requested namespace
+// sitting late in the slice so the scan does not short-circuit early.
+func benchNSAds(n int) []NamespaceAd {
+	ads := make([]NamespaceAd, 0, n+3)
+	for i := 0; i < n; i++ {
+		ads = append(ads, NamespaceAd{Path: fmt.Sprintf("/facility%02d/project%02d/data", i, i)})
+	}
+	// A shallow export that also matches, so the longest-prefix comparison is
+	// actually exercised rather than settled by the single match.
+	ads = append(ads,
+		NamespaceAd{Path: "/ospool"},
+		NamespaceAd{Path: "/ospool/protected"},
+		NamespaceAd{Path: "/ospool/protected/subdir/"},
+	)
+	return ads
+}
+
+// benchReqPath is unterminated, the shape a caller outside the director passes
+// (see origin_serve.SetTokenHintHeaders); benchReqPathNorm is what
+// director.getAdsForPath passes, having appended the "/" once before its
+// per-server loop.  The difference between the two is the one fixed
+// allocation this function can make.
+const (
+	benchReqPath     = "/ospool/protected/subdir/some/deeply/nested/object"
+	benchReqPathNorm = benchReqPath + "/"
+)
+
+func BenchmarkLongestNSMatchIndex(b *testing.B) {
+	for _, n := range []int{4, 32, 256} {
+		ads := benchNSAds(n)
+		b.Run(fmt.Sprintf("ads=%d", len(ads)), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if LongestNSMatchIndex(benchReqPath, ads) < 0 {
+					b.Fatal("expected a match")
+				}
+			}
+		})
+	}
+}
+
+// The before half of the comparison: the same scan written with the
+// concatenating normalization LongestNSMatchIndex replaced.  Keeping it as a
+// benchmark alongside the oracle means the performance claim in this change's
+// description can be re-derived from the repo at any later commit.
+func BenchmarkLongestNSMatchIndexReference(b *testing.B) {
+	for _, n := range []int{4, 32, 256} {
+		ads := benchNSAds(n)
+		b.Run(fmt.Sprintf("ads=%d", len(ads)), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if longestNSMatchIndexReference(benchReqPath, ads) < 0 {
+					b.Fatal("expected a match")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkLongestNSMatch(b *testing.B) {
+	for _, n := range []int{4, 32, 256} {
+		ads := benchNSAds(n)
+		b.Run(fmt.Sprintf("ads=%d", len(ads)), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if LongestNSMatch(benchReqPath, ads) == nil {
+					b.Fatal("expected a match")
+				}
+			}
+		})
+	}
+}
+
+// The director calls LongestNSMatchIndex once per advertised server, so the
+// per-redirect cost is this loop, not a single call.  Sized after a federation
+// with a few hundred servers each exporting a handful of namespaces, and
+// called the way getAdsForPath calls it -- with the request path already
+// "/"-terminated, so the whole loop allocates nothing.
+func BenchmarkLongestNSMatchIndexPerRedirect(b *testing.B) {
+	const servers = 300
+	perServer := make([][]NamespaceAd, servers)
+	for i := range perServer {
+		perServer[i] = benchNSAds(4)
+	}
+	b.ResetTimer() // discard the ad-set construction above
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, ads := range perServer {
+			LongestNSMatchIndex(benchReqPathNorm, ads)
+		}
 	}
 }
 


### PR DESCRIPTION
server_structs.LongestNSMatch picks the namespace ad whose path is the longest prefix of the request path. It copied every candidate NamespaceAd as it scanned and returned a pointer to the winning copy, so the director's per-redirect getAdsForPath paid a struct copy and an `nsPath + "/"` concatenation for every candidate ad on every request.

Add LongestNSMatchIndex(reqPath, namespaceAds) (idx, matchedLen int): the same scan, returning the winner's index and the length of its matched prefix in "/"-terminated form, with no allocations. Rather than build the normalized prefix per candidate, both sides are trimmed of a trailing "/" and the boundary separator is supplied by index arithmetic (trimOneTrailingSlash + nsPathCoversReq). A length early-out runs ahead of any byte comparison, so most candidates are rejected without a memequal.

Rework getAdsForPath to track the best match by length and take a single copy of the winning ad above the branches that consume it. The previous shape held an interior pointer into ad.NamespaceAds -- live TTL-cache memory other request goroutines read concurrently -- and depended on each of four branches copying before trimming the path. Hoisting one `nsCopy := ad.NamespaceAds[nsIdx]` removes the alias and the repetition at no cost, since only one branch ever ran.

Guard the per-ad filtered-server Tracef with log.IsLevelEnabled: the level gate rejects the entry, but the variadic argument boxing would still heap-allocate on this hot path without the guard.

Keep LongestNSMatch as a copy-returning wrapper for the one caller that wants a detached value (origin_serve/authz.go). Its shallow-copy semantics -- top-level fields detached, embedded Generation/Issuer slices still aliasing the input -- are now documented and pinned by a test.

Tests

  - TestLongestNSMatchIndexMatchesReference keeps the pre-optimization implementation verbatim as an oracle and differentially tests the optimized scan against it over ~31 adversarial inputs: segment-boundary near-misses (/foo vs /foobar), both stored spellings of a path, root and empty exports, doubled separators, relative paths, and equal-length duplicates for tie-breaking. Index and matched length must both agree, since getAdsForPath compares the length across separate calls.
  - TestLongestNSMatchIndexDoesNotAllocate asserts zero allocations via testing.AllocsPerRun, so a regression fails CI rather than waiting for someone to re-run -benchmem by hand.
  - TestGetAdsForPath gains two subtests pinning that the cached ad is never mutated: one checking the cached path keeps its trailing slash across a call, one hammering getAdsForPath from eight goroutines so a write-through fails under -race. Both were confirmed to fail against a deliberately reintroduced alias-and-mutate.

Benchmarks, including one for the scan being replaced so the numbers can be re-derived from the repo at any later commit:

  go test ./server_structs/ -run '^$' -bench LongestNSMatch -benchmem
  # Apple M5, go1.26
  BenchmarkLongestNSMatchIndexReference/ads=7      126.3 ns/op   224 B/op    7 allocs/op
  BenchmarkLongestNSMatchIndex/ads=7                10.0 ns/op     0 B/op    0 allocs/op
  BenchmarkLongestNSMatchIndexReference/ads=259    4219   ns/op  8288 B/op  259 allocs/op
  BenchmarkLongestNSMatchIndex/ads=259             174.5 ns/op     0 B/op    0 allocs/op

One allocation per candidate ad becomes zero: 12x faster on a small ad set, 24x on a large one. LongestNSMatch retains its single 80 B/op for the detached copy it is contracted to return.

Note for reviewers: nsPathCoversReq is the sixth open-coded copy of the path-segment-boundary prefix predicate in the tree, alongside ssh_posixv2/helper_cmd.go, client/dir_resp_cache.go, token_scopes/scope_helpers.go, origin_serve/authz.go, and lotman/lot_tree.go. Consolidating them is left as a follow-up -- the copies already disagree on normalization, and one of them (origin_serve/authz.go) is authorization-relevant, so it wants its own change. Naming the predicate here means that follow-up touches only call sites.